### PR TITLE
refactor: Remove language field from agent.json card

### DIFF
--- a/internal/templates/minimal.go
+++ b/internal/templates/minimal.go
@@ -166,13 +166,7 @@ const cardJSONTemplate = `{
 			"schema": {{ $tool.Schema | toJson }}
 		}
 		{{- end }}
-	],
-	"language": {
-		"go": {
-			"version": "{{ .ADL.Spec.Language.Go.Version }}",
-			"module": "{{ .ADL.Spec.Language.Go.Module }}"
-		}
-	}
+	]
 }
 `
 


### PR DESCRIPTION
Removes the non-compliant "language" field from the generated .well-known/agent.json file to align with the official A2A schema specification.

The language field is not defined in Google's A2A specification and was causing compliance issues.

Resolves #5

Generated with [Claude Code](https://claude.ai/code)