### PR TITLE
fix(schema): Make agent.spec.provider and agent.spec.model optional fields

### DIFF
--- a/internal/schema/validator.go
+++ b/internal/schema/validator.go
@@ -113,7 +113,6 @@ const adlSchema = `{
         },
         "agent": {
           "type": "object",
-          "required": ["provider"],
           "properties": {
             "provider": {
               "type": "string",

--- a/internal/schema/validator_test.go
+++ b/internal/schema/validator_test.go
@@ -49,6 +49,55 @@ spec:
 	}
 }
 
+func TestValidator_ValidateFile_AgentWithoutProvider(t *testing.T) {
+	validADLWithAgent := `apiVersion: adl.dev/v1
+kind: Agent
+metadata:
+  name: test-agent
+  description: "Test agent"
+  version: "1.0.0"
+spec:
+  capabilities:
+    streaming: true
+    pushNotifications: false
+    stateTransitionHistory: false
+  agent:
+    model: "gpt-3.5-turbo"
+    systemPrompt: "You are a helpful assistant"
+    maxTokens: 1000
+    temperature: 0.7
+  server:
+    port: 8080
+    debug: false
+  language:
+    go:
+      module: "github.com/example/test-agent"
+      version: "1.24"
+`
+
+	tmpFile, err := os.CreateTemp("", "test-adl-agent-*.yaml")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer func() {
+		if err := os.Remove(tmpFile.Name()); err != nil {
+			t.Logf("Failed to remove temp file: %v", err)
+		}
+	}()
+
+	if _, err := tmpFile.WriteString(validADLWithAgent); err != nil {
+		t.Fatalf("Failed to write temp file: %v", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		t.Fatalf("Failed to close temp file: %v", err)
+	}
+
+	validator := NewValidator()
+	if err := validator.ValidateFile(tmpFile.Name()); err != nil {
+		t.Errorf("Validation failed for ADL with agent section but no provider: %v", err)
+	}
+}
+
 func TestValidator_ValidateFile_Invalid(t *testing.T) {
 	invalidADL := `apiVersion: invalid
 kind: Agent


### PR DESCRIPTION
Resolves # 28

This PR fixes the validation issue where `agent.spec.provider` and `agent.spec.model` were incorrectly required when they should be optional fields.

## Changes
- Removed `"required": ["provider"]` constraint from agent object in JSON schema validation
- Added comprehensive test case for ADL files with agent section but without provider
- Fields can now be set via runtime environment variables as intended

## Testing
- All existing tests continue to pass
- New test validates the fix works correctly
- Verified with multiple scenarios: no provider, no model, empty agent section

Generated with [Claude Code](https://claude.ai/code)