### PR TITLE
fix(templates): Remove double escaping of GITHUB_OUTPUT in CD template

### DIFF
--- a/internal/templates/common/ci/cd.yml.tmpl
+++ b/internal/templates/common/ci/cd.yml.tmpl
@@ -136,7 +136,7 @@ jobs:
           # Check if there are no changes
           if $(echo "$DRY_OUTPUT" | grep -q "no new version is released"); then
             echo "No new release needed"
-            echo "new_release_published=false" >> ${{`$GITHUB_OUTPUT`}}
+            echo "new_release_published=false" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -148,12 +148,12 @@ jobs:
             exit 1
           fi
 
-          echo "new_release_version=$VERSION" >> ${{`$GITHUB_OUTPUT`}}
+          echo "new_release_version=$VERSION" >> $GITHUB_OUTPUT
 
           # Run actual release
           if semantic-release; then
             echo "Successfully released version $VERSION"
-            echo "new_release_published=true" >> ${{`$GITHUB_OUTPUT`}}
+            echo "new_release_published=true" >> $GITHUB_OUTPUT
           else
             echo "Release failed"
             exit 1


### PR DESCRIPTION
The CD template was incorrectly using `${{`$GITHUB_OUTPUT`}}` syntax which caused
Go's template engine to double-escape the $ character, resulting in $$GITHUB_OUTPUT
instead of the expected $GITHUB_OUTPUT.

Fixed by removing the backtick escaping and using plain $GITHUB_OUTPUT syntax
in lines 139, 151, and 156 of the template.

This resolves the CD generation issue where GITHUB_OUTPUT variables were being
double-escaped and causing workflow failures.

Fixes #36

Generated with [Claude Code](https://claude.ai/code)