### PR TITLE
fix(init): Add default SCM configuration when using --defaults flag

### DIFF
--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -43,6 +43,44 @@ func TestInitCommand(t *testing.T) {
 	}
 }
 
+func TestInitCommandIncludesSCMDefaults(t *testing.T) {
+	tempDir := t.TempDir()
+	outputPath := filepath.Join(tempDir, "test-output")
+
+	cmd := initCmd
+	if err := cmd.Flags().Set("defaults", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("path", outputPath); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runInit(cmd, []string{"test-agent"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	adlPath := filepath.Join(outputPath, "agent.yaml")
+	content, err := os.ReadFile(adlPath)
+	if err != nil {
+		t.Fatalf("failed to read ADL file: %v", err)
+	}
+
+	contentStr := string(content)
+	
+	if !strings.Contains(contentStr, "scm:") {
+		t.Errorf("ADL file missing SCM configuration")
+	}
+	if !strings.Contains(contentStr, "provider: github") {
+		t.Errorf("ADL file missing SCM provider default")
+	}
+	if !strings.Contains(contentStr, "github_app: true") {
+		t.Errorf("ADL file missing SCM github_app default")
+	}
+	
+	t.Logf("Generated ADL content:\n%s", contentStr)
+}
+
 func TestInitDoesNotGenerateCode(t *testing.T) {
 	tempDir := t.TempDir()
 


### PR DESCRIPTION
Fixes the issue where SCM configuration was not being added to the manifest when running `init --defaults`.

## Changes

- Added complete SCM configuration with provider, URL, and GitHub App fields
- Added Card and Server Auth configurations for completeness
- Auto-detects repository URL from git remote origin
- Added comprehensive test coverage

Fixes #43

Generated with [Claude Code](https://claude.ai/code)