### PR TITLE
refactor(init): Make default AI provider and model vendor-neutral

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -261,24 +261,10 @@ func collectADLInfo(cmd *cobra.Command, projectName string, useDefaults bool) *a
 			Temperature  float64 `yaml:"temperature,omitempty"`
 		}{}
 
-		provider := conditionalPromptChoice(useDefaults, "AI Provider", []string{"openai", "anthropic", "azure", "ollama", "deepseek"}, "openai")
+		provider := conditionalPromptChoice(useDefaults, "AI Provider", []string{"openai", "anthropic", "azure", "ollama", "deepseek"}, "")
 		adl.Spec.Agent.Provider = provider
 
-		var defaultModel string
-		switch provider {
-		case "openai":
-			defaultModel = "gpt-4o-mini"
-		case "anthropic":
-			defaultModel = "claude-3-haiku-20240307"
-		case "azure":
-			defaultModel = "gpt-4o"
-		case "ollama":
-			defaultModel = "llama3.1"
-		case "deepseek":
-			defaultModel = "deepseek-chat"
-		}
-
-		adl.Spec.Agent.Model = conditionalPrompt(useDefaults, "Model", defaultModel)
+		adl.Spec.Agent.Model = conditionalPrompt(useDefaults, "Model", "")
 
 		systemPrompt := conditionalPrompt(useDefaults, "System prompt", "You are a helpful AI assistant.")
 		adl.Spec.Agent.SystemPrompt = systemPrompt

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestInitCommand(t *testing.T) {
@@ -75,5 +77,49 @@ func TestInitDoesNotGenerateCode(t *testing.T) {
 	mainGoPath := filepath.Join(tempDir, "main.go")
 	if _, err := os.Stat(mainGoPath); !os.IsNotExist(err) {
 		t.Errorf("init command should not generate main.go file")
+	}
+}
+
+func TestInitDefaultsVendorNeutral(t *testing.T) {
+	tempDir := t.TempDir()
+	outputPath := filepath.Join(tempDir, "test-output")
+
+	cmd := initCmd
+	if err := cmd.Flags().Set("defaults", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("path", outputPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("type", "ai-powered"); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runInit(cmd, []string{"test-agent"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	adlPath := filepath.Join(outputPath, "agent.yaml")
+	content, err := os.ReadFile(adlPath)
+	if err != nil {
+		t.Fatalf("failed to read ADL file: %v", err)
+	}
+
+	var adl adlData
+	if err := yaml.Unmarshal(content, &adl); err != nil {
+		t.Fatalf("failed to parse ADL YAML: %v", err)
+	}
+
+	if adl.Spec.Agent == nil {
+		t.Fatalf("expected agent spec to be present for ai-powered agent")
+	}
+
+	if adl.Spec.Agent.Provider != "" {
+		t.Errorf("expected provider to be empty string for vendor neutrality, got: %s", adl.Spec.Agent.Provider)
+	}
+
+	if adl.Spec.Agent.Model != "" {
+		t.Errorf("expected model to be empty string for vendor neutrality, got: %s", adl.Spec.Agent.Model)
 	}
 }


### PR DESCRIPTION
Remove "openai" as default AI provider and use empty string instead.
Remove specific model defaults and use empty string instead.
This keeps the CLI vendor-neutral and allows users to choose their
preferred AI provider and model without bias.

## Changes

- Changed AI provider default from `"openai"` to `""` (empty string)
- Changed model default to `""` (empty string) instead of provider-specific models
- Removed switch statement that set different model defaults for each provider
- Added comprehensive test coverage to verify vendor-neutral behavior

Fixes part of #43

Generated with [Claude Code](https://claude.ai/code)