### PR TITLE
fix: Only include skills import when skills are defined

### DIFF
--- a/internal/templates/languages/go/main.go.tmpl
+++ b/internal/templates/languages/go/main.go.tmpl
@@ -11,8 +11,10 @@ import (
 	config "github.com/inference-gateway/adk/server/config"
 	envconfig "github.com/sethvargo/go-envconfig"
 	zap "go.uber.org/zap"
+{{- if .ADL.Spec.Skills }}
 
 	skills "{{ .ADL.Spec.Language.Go.Module }}/skills"
+{{- end }}
 )
 
 // Config represents the application configuration


### PR DESCRIPTION
Fixes #46

The Go main.go template was unconditionally importing the skills package, causing go mod tidy to fail when no skills are defined in the ADL specification.

Changed the template to conditionally include the skills import only when .ADL.Spec.Skills contains entries, preventing import errors for skill-less agents.

Generated with [Claude Code](https://claude.ai/code)