### PR TITLE
refactor: Use GitHub repository name variable in CD workflow

### DIFF
--- a/internal/templates/common/cd/cd.yaml.tmpl
+++ b/internal/templates/common/cd/cd.yaml.tmpl
@@ -26,7 +26,7 @@ jobs:
           private-key: ${{`{{ secrets.BOT_GH_APP_PRIVATE_KEY }}`}}
           owner: ${{`{{ github.repository_owner }}`}}
           repositories: |
-            {{ .ADL.Metadata.Name }}
+            ${{`{{ github.event.repository.name }}`}}
 
       - name: Get GitHub App User ID
         id: get-user-id
@@ -224,7 +224,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{`{{ github.repository_owner }}`}}/{{ .ADL.Metadata.Name }}
+          images: ghcr.io/${{`{{ github.repository_owner }}`}}/${{`{{ github.event.repository.name }}`}}
           tags: |
             type=ref,event=branch
             type=ref,event=pr


### PR DESCRIPTION
Replace hardcoded ADL metadata name with GitHub repository name variable

Fixes #53

Generated with [Claude Code](https://claude.ai/code)