### PR TITLE
refactor: Simplify GitHub issue templates for better flexibility

### DIFF
--- a/internal/templates/common/github/bug_report.md.tmpl
+++ b/internal/templates/common/github/bug_report.md.tmpl
@@ -1,58 +1,26 @@
 ---
-name: Bug Report
-about: Report a bug to help improve {{.ADL.Metadata.Name}}
+name: Bug report
+about: Create a bug report
 title: '[BUG] '
 labels: bug
+type: bug
 assignees: ''
 ---
 
-## Bug Description
+## Summary
 
-A clear and concise description of what the bug is.
 
-## To Reproduce
 
-Steps to reproduce the behavior:
+### Steps to Reproduce
 
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
 
-## Expected Behavior
 
-A clear and concise description of what you expected to happen.
+1. Step 1
+2. Step 2
+3. Step 3
 
-## Actual Behavior
+### Expected Behavior
 
-A clear and concise description of what actually happened.
 
-## Screenshots
 
-If applicable, add screenshots to help explain your problem.
-
-## Environment
-
-- Agent Name: {{.ADL.Metadata.Name}}
-- Agent Version: {{.ADL.Metadata.Version}}
-- OS: [e.g. iOS]
-- Browser: [e.g. chrome, safari]
-- Version: [e.g. 22]
-
-## Additional Context
-
-Add any other context about the problem here.
-
-## Severity
-
-- [ ] Critical (system crash, data loss)
-- [ ] High (major feature broken)
-- [ ] Medium (minor feature issue)
-- [ ] Low (cosmetic issue)
-
-## Logs
-
-Please paste any relevant error logs below:
-
-```
-[Paste error logs here]
+### Actual Behavior

--- a/internal/templates/common/github/feature_request.md.tmpl
+++ b/internal/templates/common/github/feature_request.md.tmpl
@@ -1,62 +1,19 @@
 ---
-name: Feature Request
-about: Suggest an idea for {{.ADL.Metadata.Name}}
+name: Feature request
+about: Suggest an idea for this project
 title: '[FEATURE] '
 labels: enhancement
+type: feature
 assignees: ''
 ---
 
-## Feature Summary
+## Summary
 
-A clear and concise description of the feature you'd like to request.
 
-## Problem Statement
 
-Is your feature request related to a problem? Please describe.
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+### Acceptance Criteria
 
-## Proposed Solution
 
-Describe the solution you'd like.
-A clear and concise description of what you want to happen.
-
-## Alternative Solutions
-
-Describe alternatives you've considered.
-A clear and concise description of any alternative solutions or features you've considered.
-
-## Use Case
-
-Describe the specific use case where this feature would be valuable.
-
-## Benefits
-
-What benefits would this feature provide to users?
-
-- Benefit 1
-- Benefit 2
-- Benefit 3
-
-## Technical Considerations
-
-Are there any technical considerations or constraints that should be taken into account?
-
-## Priority
-
-How important is this feature to you?
-
-- [ ] Critical (blocking current work)
-- [ ] High (would significantly improve workflow)
-- [ ] Medium (nice to have)
-- [ ] Low (minor convenience)
-
-## Additional Context
-
-Add any other context, mockups, or screenshots about the feature request here.
-
-## Acceptance Criteria
-
-Please describe what would need to be implemented for this feature to be considered complete:
 
 - [ ] Criterion 1
 - [ ] Criterion 2

--- a/internal/templates/common/github/refactor_request.md.tmpl
+++ b/internal/templates/common/github/refactor_request.md.tmpl
@@ -1,90 +1,20 @@
 ---
-name: Refactor Request
-about: Suggest a code improvement for {{.ADL.Metadata.Name}}
-title: '[REFACTOR] '
-labels: refactor, tech-debt
+name: Refactor request
+about: Request a refactor of existing code
+title: '[TASK] Refactor '
+labels: refactor
+type: task
 assignees: ''
 ---
 
-## Refactor Summary
+## Summary
 
-A clear and concise description of the refactor you'd like to propose.
 
-## Current Implementation
 
-Describe the current implementation that needs refactoring.
+### Acceptance Criteria
 
-### File(s) Affected
-List the files or modules that would be affected by this refactor:
 
-- `file1.go`
-- `file2.rs`
-- `directory/module`
 
-## Proposed Changes
-
-Describe the changes you'd like to see implemented.
-
-### Code Quality Issues
-What specific code quality issues does this refactor address?
-
-- [ ] Code duplication
-- [ ] Complex/hard to understand code
-- [ ] Performance issues
-- [ ] Security concerns
-- [ ] Maintainability issues
-- [ ] Outdated patterns or libraries
-- [ ] Technical debt
-
-## Benefits
-
-What benefits would this refactor provide?
-
-- **Performance**: How would this improve performance?
-- **Maintainability**: How would this make the code easier to maintain?
-- **Security**: Does this address any security concerns?
-- **Readability**: How would this make the code more readable?
-
-## Implementation Approach
-
-Describe your suggested approach for implementing this refactor.
-
-### Steps
-1. Step 1
-2. Step 2
-3. Step 3
-
-### Backwards Compatibility
-- [ ] This refactor maintains backwards compatibility
-- [ ] This refactor introduces breaking changes (please describe below)
-
-**Breaking changes description:**
-
-## Testing Requirements
-
-What testing should be done to ensure this refactor is successful?
-
-- [ ] Unit tests
-- [ ] Integration tests
-- [ ] Performance tests
-- [ ] Manual testing
-
-## Priority
-
-How critical is this refactor?
-
-- [ ] Critical (security or major performance issue)
-- [ ] High (blocking future development)
-- [ ] Medium (improves code quality)
-- [ ] Low (nice to have cleanup)
-
-## Additional Context
-
-Add any other context, code examples, or references about the refactor request here.
-
-## Related Issues
-
-Does this refactor relate to any existing issues? Please link them here.
-
-- Fixes #
-- Related to #
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3


### PR DESCRIPTION
Fixes #56

Simplified the GitHub issue templates to make them more flexible and user-friendly:

- **Bug Report**: Reduced from complex multi-section template to simple format with Summary, Steps to Reproduce, Expected/Actual Behavior
- **Feature Request**: Streamlined to focus on Summary and Acceptance Criteria
- **Refactor Request**: Simplified to basic Summary and Acceptance Criteria

Templates now follow the flexible format similar to inference gateway templates, allowing users to add whatever they need without being constrained by overly-complex predefined sections.

Generated with [Claude Code](https://claude.ai/code)