### PR TITLE
fix(templates): Handle dashes in skill names for Go identifier generation

### DIFF
--- a/internal/templates/engine.go
+++ b/internal/templates/engine.go
@@ -50,7 +50,6 @@ func toPascalCase(s string) string {
 		"db":    "DB",
 	}
 
-	// Split on both underscores and dashes to handle snake_case and dash-case
 	s = strings.ReplaceAll(s, "-", "_")
 	words := strings.Split(s, "_")
 	result := make([]string, len(words))

--- a/internal/templates/engine.go
+++ b/internal/templates/engine.go
@@ -50,6 +50,8 @@ func toPascalCase(s string) string {
 		"db":    "DB",
 	}
 
+	// Split on both underscores and dashes to handle snake_case and dash-case
+	s = strings.ReplaceAll(s, "-", "_")
 	words := strings.Split(s, "_")
 	result := make([]string, len(words))
 


### PR DESCRIPTION
Fixes issue where skill IDs/names containing dashes (e.g., "search-n8n-docs") were not properly converted to valid Go identifiers, causing syntax errors in generated code.

The toPascalCase and toCamelCase functions now handle both underscores and dashes as word separators.

Before: search-n8n-docs → search-n8n-docsSkill (invalid Go syntax)
After: search-n8n-docs → searchN8nDocsSkill (valid Go syntax)

Resolves #59

Generated with [Claude Code](https://claude.ai/code)