### PR TITLE
fix: Replace non-existent .Type fields in agents.md template

### DIFF
--- a/internal/templates/common/ai/agents.md.tmpl
+++ b/internal/templates/common/ai/agents.md.tmpl
@@ -67,7 +67,7 @@ This agent provides {{ len .ADL.Spec.Skills }} skills:
 {{ range .ADL.Spec.Skills }}
 ### {{ .Name }}
 - **Description**: {{ .Description }}
-- **Type**: {{ .Type }}
+{{ if .Tags }}- **Tags**: {{ join ", " .Tags }}{{ end }}
 - **Input Schema**: Defined in agent configuration
 - **Output Schema**: Defined in agent configuration
 
@@ -86,8 +86,11 @@ No skills defined - this agent provides basic A2A communication without speciali
 {{ end }}
 
 {{ if .ADL.Spec.Server.Auth }}
+{{ if .ADL.Spec.Server.Auth.Enabled }}
 **Authentication**: ✅ Required
-- Type: {{ .ADL.Spec.Server.Auth.Type }}
+{{ else }}
+**Authentication**: ❌ Not required
+{{ end }}
 {{ else }}
 **Authentication**: ❌ Not required
 {{ end }}


### PR DESCRIPTION
Fixes #63

## Summary
- Replace .Type field (which doesn't exist in schema.Skill) with .Tags field
- Fix .ADL.Spec.Server.Auth.Type (which doesn't exist in schema.AuthConfig) to use .Enabled field properly
- Resolves template execution errors when using --ai flag

## Test plan
- [x] Run `go run . generate --file examples/go-agent.yaml --output test-output --overwrite --ai`
- [x] Verify AGENTS.md is generated successfully with correct skill tags
- [x] Verify authentication section displays correctly

Generated with [Claude Code](https://claude.ai/code)