### PR TITLE
refactor(templates): Fix logger injection and syntax error in Go skill template

### DIFF
--- a/internal/templates/languages/go/skill.go.tmpl
+++ b/internal/templates/languages/go/skill.go.tmpl
@@ -33,6 +33,8 @@ func New{{ .Name | toPascalCase }}Skill(logger *zap.Logger) server.Tool {
 					"{{ $k }}": []string{ {{- range $i, $e := $v }}{{ if $i }}, {{ end }}"{{ $e }}"{{ end -}} },
 					{{- else if eq $k "properties" }}
 					"{{ $k }}": {{ $v | toGoMap }},
+					{{- else if eq $k "items" }}
+					"{{ $k }}": {{ $v | toGoMap }},
 					{{- else }}
 					"{{ $k }}": {{ $v | toJson }},
 					{{- end }}
@@ -44,14 +46,18 @@ func New{{ .Name | toPascalCase }}Skill(logger *zap.Logger) server.Tool {
 			"required": []string{ {{- range $i, $field := .Schema.required }}{{ if $i }}, {{ end }}"{{ $field }}"{{ end -}} },
 			{{- end }}
 		},
-		{{ .Name | toPascalCase }}Handler,
+		skill.{{ .Name | toPascalCase }}Handler,
 	)
 }
 
 // {{ .Name | toPascalCase }}Handler handles the {{ .Name }} skill execution
-func {{ .Name | toPascalCase }}Handler(ctx context.Context, args map[string]any) (string, error) {
+func (s *{{ .Name | toPascalCase }}Skill) {{ .Name | toPascalCase }}Handler(ctx context.Context, args map[string]any) (string, error) {
 	// TODO: Implement {{ .Name }} logic
 	// {{ .Description }}
+
+	// Log the incoming request
+	s.logger.Info("Processing {{ .Name }} request",
+		zap.Any("args", args))
 	
 	// Extract parameters from args
 	{{- range $key, $value := .Schema.properties }}


### PR DESCRIPTION
Fixes #67

## Changes
- Make handler function a method on skill struct to access logger
- Add items field handling in template to use toGoMap for proper syntax
- Handler now logs incoming requests using the injected logger

## Testing
- All tests pass
- Linting and formatting applied
- Generated examples compile correctly

Generated with [Claude Code](https://claude.ai/code)