### PR TITLE
fix(Skills): Skip "DO NOT EDIT" headers for skill files

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -298,7 +298,11 @@ func (g *Generator) generateProject(templateEngine *templates.Engine, adl *schem
 			fileType = "taskfile"
 		}
 
-		if fileType != "" {
+		// Skip adding "DO NOT EDIT" headers to skill files - they are user-editable scaffolding
+		isSkillFile := (templateKey == "skill.go" || templateKey == "skill.rs" || templateKey == "skill.ts") || 
+			(strings.Contains(fileName, "/skills/") && (ext == ".go" || ext == ".rs" || ext == ".ts"))
+
+		if fileType != "" && !isSkillFile {
 			header := templates.GetGeneratedFileHeader(fileType, ctx.Metadata.CLIVersion, ctx.Metadata.GeneratedAt)
 			content = header + content
 		}


### PR DESCRIPTION
Fixes #69

Skill files are scaffolding code meant to be modified by users to implement business logic. They should not have "DO NOT EDIT" headers that mislead users.

**Changes:**
- Skip adding headers to skill files (detected by template key and path patterns)
- Preserve existing .adl-ignore functionality
- All tests passing

🤖 Generated with [Claude Code](https://claude.ai/code)