### PR TITLE
refactor: Rename A2A agent card to follow the A2A latest spec agent card path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Generated A2A (Agent-to-Agent) servers implement the [A2A Protocol](https://gith
 
 ### Core Components
 - **Main Entry Point**: `main.go` - Configures and starts the A2A server with agent provider configuration and graceful shutdown handling
-- **Agent Configuration**: `.well-known/agent.json` - Serves agent metadata at runtime
+- **Agent Configuration**: `.well-known/agent-card.json` - Serves agent metadata at runtime
 - **Skills Implementation**: Generated skill files with TODO placeholders for business logic
 - **Environment Configuration**: Extensive env vars with `A2A_` prefix for runtime configuration
 
@@ -145,7 +145,7 @@ Standard development environment required:
 
 - Enable debug mode: `A2A_DEBUG=true`
 - Check health: `GET /health`
-- View agent metadata: `GET /.well-known/agent.json`
+- View agent metadata: `GET /.well-known/agent-card.json`
 - Monitor streaming updates: Set `A2A_STREAMING_STATUS_UPDATE_INTERVAL`
 - Use A2A Debugger container for interactive testing
 - Check logs for skill execution details

--- a/README.md
+++ b/README.md
@@ -680,7 +680,7 @@ my-go-agent/
 ├── Dockerfile                 # Container configuration
 ├── .adl-ignore                # Files to protect from regeneration
 ├── .well-known/
-│   └── agent.json             # Agent capabilities (auto-generated)
+│   └── agent-card.json        # Agent capabilities (auto-generated)
 ├── .github/                   # GitHub-specific configurations
 │   ├── workflows/             # Generated when using --ci flag
 │   │   ├── ci.yml             # GitHub Actions CI workflow
@@ -720,7 +720,7 @@ my-rust-agent/
 ├── Dockerfile                 # Rust-optimized container
 ├── .adl-ignore                # Protection configuration
 ├── .well-known/
-│   └── agent.json             # Agent capabilities
+│   └── agent-card.json        # Agent capabilities
 ├── .github/workflows/         # CI configuration (with --ci)
 │   ├── ci.yml                 # Rust-specific CI workflow
 │   └── cd.yml                 # GitHub Actions CD workflow (with --cd flag)
@@ -737,7 +737,7 @@ my-rust-agent/
 
 All projects include these essential files regardless of language:
 
-- **`.well-known/agent.json`** - A2A agent discovery and capabilities manifest
+- **`.well-known/agent-card.json`** - A2A agent discovery and capabilities manifest
 - **`Taskfile.yml`** - Unified task runner configuration for build, test, lint, run
 - **`Dockerfile`** - Language-optimized container configuration  
 - **`k8s/deployment.yaml`** - Kubernetes deployment manifest
@@ -1151,7 +1151,7 @@ Each language has its own file mapping that determines what gets generated:
 
 **Universal Files:**
 - `Taskfile.yml` → Development task runner
-- `.well-known/agent.json` → A2A capabilities manifest
+- `.well-known/agent-card.json` → A2A capabilities manifest
 - `k8s/deployment.yaml` → Kubernetes deployment
 - CI workflows and sandbox configurations
 

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -349,11 +349,11 @@ func (g *Generator) generateProject(templateEngine *templates.Engine, adl *schem
 					serviceMap := make(map[string]interface{})
 					for svcName, svc := range adl.Spec.Services {
 						serviceMap[svcName] = map[string]interface{}{
-							"ID":   svcName,
-							"Name": titleCase(svcName),
-							"Type": svc.Type,
-							"Interface": svc.Interface,
-							"Factory": svc.Factory,
+							"ID":          svcName,
+							"Name":        titleCase(svcName),
+							"Type":        svc.Type,
+							"Interface":   svc.Interface,
+							"Factory":     svc.Factory,
 							"Description": svc.Description,
 						}
 					}
@@ -409,9 +409,6 @@ func (g *Generator) generateProject(templateEngine *templates.Engine, adl *schem
 			return fmt.Errorf("failed to write %s: %w", fileName, err)
 		}
 	}
-
-	// The agent.json is now generated via the template in the files map above
-	// No need for separate generateAgentJSON function
 
 	if err := g.generateADLIgnoreFile(outputDir, templateEngine.GetTemplate(), adl); err != nil {
 		return fmt.Errorf("failed to generate .adl-ignore file: %w", err)

--- a/internal/templates/common/ai/agents.md.tmpl
+++ b/internal/templates/common/ai/agents.md.tmpl
@@ -99,7 +99,7 @@ No skills defined - this agent provides basic A2A communication without speciali
 
 The agent exposes the following HTTP endpoints:
 
-- `GET /.well-known/agent.json` - Agent metadata and capabilities
+- `GET /.well-known/agent-card.json` - Agent metadata and capabilities
 - `POST /skills/{skill_name}` - Execute a specific skill{{ if .ADL.Spec.Capabilities.Streaming }}
 - `GET /skills/{skill_name}/stream` - Stream skill execution results{{ end }}{{ if .ADL.Spec.Capabilities.PushNotifications }}
 - `GET /events` - Server-sent events for notifications{{ end }}{{ if .ADL.Spec.Capabilities.StateTransitionHistory }}
@@ -171,7 +171,7 @@ The agent implements the A2A protocol and can be communicated with via HTTP requ
 
 ```bash
 # Get agent information
-curl http://localhost:{{ .ADL.Spec.Server.Port }}/.well-known/agent.json
+curl http://localhost:{{ .ADL.Spec.Server.Port }}/.well-known/agent-card.json
 
 {{ if .ADL.Spec.Skills }}
 {{ range .ADL.Spec.Skills }}
@@ -238,7 +238,7 @@ docker run -p {{ .ADL.Spec.Server.Port }}:{{ .ADL.Spec.Server.Port }} {{ .ADL.Me
 │   └── {{ .Name }}.go   # {{ .Description }}
 {{ end }}
 ├── .well-known/         # Agent configuration
-│   └── agent.json       # Agent metadata
+│   └── agent-card.json  # Agent metadata
 ├── go.mod               # Go module definition
 └── README.md            # Project documentation
 ```
@@ -253,7 +253,7 @@ docker run -p {{ .ADL.Spec.Server.Port }}:{{ .ADL.Spec.Server.Port }} {{ .ADL.Me
 {{ end }}
 │       └── mod.rs       # Skills module
 ├── .well-known/         # Agent configuration  
-│   └── agent.json       # Agent metadata
+│   └── agent-card.json  # Agent metadata
 ├── Cargo.toml           # Rust package definition
 └── README.md            # Project documentation
 ```
@@ -267,7 +267,7 @@ docker run -p {{ .ADL.Spec.Server.Port }}:{{ .ADL.Spec.Server.Port }} {{ .ADL.Me
 │       └── {{ .Name }}.ts # {{ .Description }}
 {{ end }}
 ├── .well-known/         # Agent configuration
-│   └── agent.json       # Agent metadata
+│   └── agent-card.json  # Agent metadata
 ├── package.json         # Node.js package definition
 ├── tsconfig.json        # TypeScript configuration
 └── README.md            # Project documentation

--- a/internal/templates/common/ai/claude.md.tmpl
+++ b/internal/templates/common/ai/claude.md.tmpl
@@ -23,7 +23,7 @@ The codebase is generated using ADL CLI {{ .Metadata.CLIVersion }} and follows a
   - A2A server with streaming and background task handlers
   - Graceful shutdown handling
 
-- **Agent Configuration**: `.well-known/agent.json` - Serves agent metadata at runtime
+- **Agent Configuration**: `.well-known/agent-card.json` - Serves agent metadata at runtime
 - **Environment Configuration**: Extensive env vars with `A2A_` prefix (see README for full list)
 
 ## Development Commands
@@ -157,7 +157,7 @@ Standard development environment required. Install:
 
 - Enable debug mode: `A2A_DEBUG=true`{{ if .ADL.Spec.Server.Debug }} (currently enabled in agent.yaml){{ end }}
 - Check health: `GET /health`
-- View agent metadata: `GET /.well-known/agent.json`
+- View agent metadata: `GET /.well-known/agent-card.json`
 {{- if .ADL.Spec.Capabilities.Streaming }}
 - Monitor streaming updates: Set `A2A_STREAMING_STATUS_UPDATE_INTERVAL`
 {{- end }}

--- a/internal/templates/common/config/gitattributes.tmpl
+++ b/internal/templates/common/config/gitattributes.tmpl
@@ -34,7 +34,7 @@ k8s/*.yaml linguist-generated=true
 k8s/*.yml linguist-generated=true
 
 # Agent capabilities
-.well-known/agent.json linguist-generated=true
+.well-known/agent-card.json linguist-generated=true
 
 # Documentation (partially generated)
 README.md linguist-documentation=true

--- a/internal/templates/common/config/releaserc.yaml.tmpl
+++ b/internal/templates/common/config/releaserc.yaml.tmpl
@@ -95,7 +95,7 @@ plugins:
         - main.go
         - README.md
         - Taskfile.yml
-        - .well-known/agent.json
+        - .well-known/agent-card.json
       message: "chore(release): 🔖 ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
 
   - - '@semantic-release/github'

--- a/internal/templates/common/docs/README.md.tmpl
+++ b/internal/templates/common/docs/README.md.tmpl
@@ -62,7 +62,7 @@ docker run -p {{ .ADL.Spec.Server.Port | default 8080 }}:{{ .ADL.Spec.Server.Por
 
 ## Endpoints
 
-- `GET /.well-known/agent.json` - Agent metadata and capabilities
+- `GET /.well-known/agent-card.json` - Agent metadata and capabilities
 - `GET /health` - Health check endpoint
 - `POST /a2a` - A2A protocol endpoint
 
@@ -102,7 +102,7 @@ The following custom configuration variables are available:
 | **Server** | `A2A_SERVER_WRITE_TIMEOUT` | HTTP server write timeout | `120s` |
 | **Server** | `A2A_SERVER_IDLE_TIMEOUT` | HTTP server idle timeout | `120s` |
 | **Server** | `A2A_SERVER_DISABLE_HEALTHCHECK_LOG` | Disable logging for health check requests | `true` |
-| **Agent Metadata** | `A2A_AGENT_CARD_FILE_PATH` | Path to agent card JSON file | `.well-known/agent.json` |
+| **Agent Metadata** | `A2A_AGENT_CARD_FILE_PATH` | Path to agent card JSON file | `.well-known/agent-card.json` |
 | **LLM Client** | `A2A_AGENT_CLIENT_PROVIDER` | LLM provider (`openai`, `anthropic`, `azure`, `ollama`, `deepseek`) | {{- if .ADL.Spec.Agent }}`{{ .ADL.Spec.Agent.Provider }}`{{- else }}`openai`{{- end }} |
 | **LLM Client** | `A2A_AGENT_CLIENT_MODEL` | Model to use | {{- if .ADL.Spec.Agent }}`{{ .ADL.Spec.Agent.Model }}`{{- else }}`gpt-4o-mini`{{- end }} |
 | **LLM Client** | `A2A_AGENT_CLIENT_API_KEY` | API key for LLM provider | - |

--- a/internal/templates/languages/go/main.go.tmpl
+++ b/internal/templates/languages/go/main.go.tmpl
@@ -116,7 +116,7 @@ func main() {
 
 	a2aServer, err := server.NewA2AServerBuilder(cfg.A2A, l).
 		WithAgent(agent).
-		WithAgentCardFromFile(".well-known/agent.json", map[string]any{
+		WithAgentCardFromFile(".well-known/agent-card.json", map[string]any{
 			"name":        AgentName,
 			"version":     Version,
 			"description": AgentDescription,

--- a/internal/templates/languages/rust/main.rs.tmpl
+++ b/internal/templates/languages/rust/main.rs.tmpl
@@ -134,7 +134,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let server = A2AServerBuilder::new()
         .with_config(config)
         .with_agent(agent)
-        .with_agent_card_from_file(".well-known/agent.json", None)
+        .with_agent_card_from_file(".well-known/agent-card.json", None)
         .with_gateway_url(gateway_url)
         .build()
         .await?;

--- a/internal/templates/registry.go
+++ b/internal/templates/registry.go
@@ -138,16 +138,16 @@ func (r *Registry) GetFiles(adl *schema.ADL) map[string]string {
 // getGoFiles returns the file mapping for Go projects
 func (r *Registry) getGoFiles(adl *schema.ADL) map[string]string {
 	files := map[string]string{
-		"main.go":                "main.go",
-		"go.mod":                 "go.mod",
-		"config/config.go":       "config.go",
-		".well-known/agent.json": "config/agent.json",
-		"Taskfile.yml":           "taskfile/taskfile.yml",
-		"Dockerfile":             "docker/dockerfile.go",
-		".gitignore":             "config/gitignore",
-		".gitattributes":         "config/gitattributes",
-		".editorconfig":          "config/editorconfig",
-		"README.md":              "docs/README.md",
+		"main.go":                     "main.go",
+		"go.mod":                      "go.mod",
+		"config/config.go":            "config.go",
+		".well-known/agent-card.json": "config/agent.json",
+		"Taskfile.yml":                "taskfile/taskfile.yml",
+		"Dockerfile":                  "docker/dockerfile.go",
+		".gitignore":                  "config/gitignore",
+		".gitattributes":              "config/gitattributes",
+		".editorconfig":               "config/editorconfig",
+		"README.md":                   "docs/README.md",
 	}
 
 	if adl.Spec.Deployment != nil && adl.Spec.Deployment.Type != "" {
@@ -181,15 +181,15 @@ func (r *Registry) getGoFiles(adl *schema.ADL) map[string]string {
 // getRustFiles returns the file mapping for Rust projects
 func (r *Registry) getRustFiles(adl *schema.ADL) map[string]string {
 	files := map[string]string{
-		"src/main.rs":            "main.rs",
-		"Cargo.toml":             "Cargo.toml",
-		".well-known/agent.json": "config/agent.json",
-		"Taskfile.yml":           "taskfile/taskfile.yml",
-		"Dockerfile":             "docker/dockerfile.rust",
-		".gitignore":             "config/gitignore",
-		".gitattributes":         "config/gitattributes",
-		".editorconfig":          "config/editorconfig",
-		"README.md":              "docs/README.md",
+		"src/main.rs":                 "main.rs",
+		"Cargo.toml":                  "Cargo.toml",
+		".well-known/agent-card.json": "config/agent.json",
+		"Taskfile.yml":                "taskfile/taskfile.yml",
+		"Dockerfile":                  "docker/dockerfile.rust",
+		".gitignore":                  "config/gitignore",
+		".gitattributes":              "config/gitattributes",
+		".editorconfig":               "config/editorconfig",
+		"README.md":                   "docs/README.md",
 	}
 
 	if adl.Spec.Deployment != nil && adl.Spec.Deployment.Type != "" {
@@ -220,16 +220,16 @@ func (r *Registry) getRustFiles(adl *schema.ADL) map[string]string {
 // getTypeScriptFiles returns the file mapping for TypeScript projects
 func (r *Registry) getTypeScriptFiles(adl *schema.ADL) map[string]string {
 	files := map[string]string{
-		"src/index.ts":           "index.ts",
-		"package.json":           "package.json",
-		"tsconfig.json":          "tsconfig.json",
-		".well-known/agent.json": "config/agent.json",
-		"Taskfile.yml":           "taskfile/taskfile.yml",
-		"Dockerfile":             "docker/dockerfile.ts",
-		".gitignore":             "config/gitignore",
-		".gitattributes":         "config/gitattributes",
-		".editorconfig":          "config/editorconfig",
-		"README.md":              "docs/README.md",
+		"src/index.ts":                "index.ts",
+		"package.json":                "package.json",
+		"tsconfig.json":               "tsconfig.json",
+		".well-known/agent-card.json": "config/agent.json",
+		"Taskfile.yml":                "taskfile/taskfile.yml",
+		"Dockerfile":                  "docker/dockerfile.ts",
+		".gitignore":                  "config/gitignore",
+		".gitattributes":              "config/gitattributes",
+		".editorconfig":               "config/editorconfig",
+		"README.md":                   "docs/README.md",
 	}
 
 	if adl.Spec.Deployment != nil && adl.Spec.Deployment.Type != "" {


### PR DESCRIPTION
## Summary

This is related to: https://github.com/inference-gateway/adk/pull/74