### PR TITLE
fix(artifacts): Show warning instead of fatal error when artifacts server not enabled

### DIFF
--- a/internal/templates/languages/go/main.go.tmpl
+++ b/internal/templates/languages/go/main.go.tmpl
@@ -134,7 +134,9 @@ func main() {
 		NewArtifactsServerBuilder(&cfg.A2A.ArtifactsConfig, l).
 		Build()
 	if err != nil {
-		l.Fatal("failed to create artifacts server", zap.Error(err))
+		l.Warn("artifacts server could not be created - check ARTIFACTS_ENABLE environment variable", zap.Error(err))
+		l.Info("continuing without artifacts server support")
+		artifactsServer = nil
 	}
 {{- end }}
 
@@ -146,12 +148,14 @@ func main() {
 	}()
 
 {{ if and .ADL.Spec.Artifacts .ADL.Spec.Artifacts.Enabled }}
-	go func() {
-		l.Info("starting A2A artifacts server", zap.String("port", cfg.A2A.ArtifactsConfig.ServerConfig.Port))
-		if err := artifactsServer.Start(ctx); err != nil {
-			l.Fatal("artifacts server failed to start", zap.Error(err))
-		}
-	}()
+	if artifactsServer != nil {
+		go func() {
+			l.Info("starting A2A artifacts server", zap.String("port", cfg.A2A.ArtifactsConfig.ServerConfig.Port))
+			if err := artifactsServer.Start(ctx); err != nil {
+				l.Fatal("artifacts server failed to start", zap.Error(err))
+			}
+		}()
+	}
 {{- end }}
 
 	l.Info("{{ .ADL.Metadata.Name }} agent running successfully", 
@@ -165,7 +169,9 @@ func main() {
 	l.Info("shutdown signal received, gracefully stopping server...")
 	a2aServer.Stop(ctx)
 {{- if and .ADL.Spec.Artifacts .ADL.Spec.Artifacts.Enabled }}
-	artifactsServer.Stop(ctx)
+	if artifactsServer != nil {
+		artifactsServer.Stop(ctx)
+	}
 {{- end }}
 	l.Info("{{ .ADL.Metadata.Name }} agent stopped")
 }


### PR DESCRIPTION
Fixes ##81

## Summary

Changes the artifacts server initialization to show a warning instead of a fatal error when the server cannot be created due to `ARTIFACTS_ENABLE` not being set to true.

## Changes

- Changed fatal error to warning when artifacts server creation fails
- Added nil checks before starting/stopping artifacts server
- Allow main A2A server to continue running normally

## Testing

- All existing tests pass
- Linting passes
- Generated artifacts example works correctly

## Acceptance Criteria

- [x] A warning instead of a fatal error is shown when the artifact server is not enabled
- [x] Everything works as usual

Generated with [Claude Code](https://claude.ai/code)