### PR TITLE
Fix(artifacts): Change invalid Go duration format from days to hours

### DIFF
--- a/examples/go-agent.yaml
+++ b/examples/go-agent.yaml
@@ -41,7 +41,7 @@ spec:
       outputPath: "/tmp/reports"
       templateDir: "/app/templates"
       maxFileSizeMB: "50"
-      retention: "30d"
+      retention: "720h"
   services:
     database:
       type: service

--- a/internal/templates/common/docs/README.md.tmpl
+++ b/internal/templates/common/docs/README.md.tmpl
@@ -135,7 +135,7 @@ The following custom configuration variables are available:
 | **Artifacts** | `ARTIFACTS_STORAGE_BUCKET_NAME` | MinIO/S3 bucket name | `artifacts` |
 | **Artifacts** | `ARTIFACTS_STORAGE_USE_SSL` | Use SSL for MinIO/S3 connections | `true` |
 | **Artifacts** | `ARTIFACTS_RETENTION_MAX_ARTIFACTS` | Max artifacts per task (0 = unlimited) | `5` |
-| **Artifacts** | `ARTIFACTS_RETENTION_MAX_AGE` | Max artifact age (0 = no age limit) | `7d` |
+| **Artifacts** | `ARTIFACTS_RETENTION_MAX_AGE` | Max artifact age (0 = no age limit) | `168h` |
 | **Artifacts** | `ARTIFACTS_RETENTION_CLEANUP_INTERVAL` | Cleanup frequency (0 = manual only) | `24h` |
 {{- end }}
 {{- if and .ADL.Spec.Server.Auth .ADL.Spec.Server.Auth.Enabled }}


### PR DESCRIPTION
Replace invalid "7d" and "30d" duration formats with valid Go time.Duration format "168h" (7 days) and "720h" (30 days) respectively. Go's time.Duration parser does not recognize "d" as a valid unit - only ns, us/µs, ms, s, m, h.

- Fix ARTIFACTS_RETENTION_MAX_AGE default in README template
- Fix retention config in go-agent example

Fixes #86

Generated with [Claude Code](https://claude.ai/code)