### PR TITLE
fix(templates): Improve documentation wording and formatting

### DIFF
--- a/internal/templates/common/ai/agents.md.tmpl
+++ b/internal/templates/common/ai/agents.md.tmpl
@@ -101,6 +101,7 @@ No skills defined - this agent provides basic A2A communication without speciali
 The agent exposes the following HTTP endpoints:
 
 - `GET /.well-known/agent-card.json` - Agent metadata and capabilities
+- `GET /health` - Health check endpoint
 - `POST /a2a` - JSON-RPC endpoint for all A2A operations (skill execution, streaming, etc.)
 
 ## Environment Setup

--- a/internal/templates/common/docs/README.md.tmpl
+++ b/internal/templates/common/docs/README.md.tmpl
@@ -57,7 +57,7 @@ docker run -p {{ .ADL.Spec.Server.Port | default 8080 }}:{{ .ADL.Spec.Server.Por
 - ✅ State transition history
 {{- end }}
 {{- end }}
-- ✅ Production ready
+- ✅ Enterprise-ready
 - ✅ Minimal dependencies
 
 ## Endpoints
@@ -71,7 +71,7 @@ docker run -p {{ .ADL.Spec.Server.Port | default 8080 }}:{{ .ADL.Spec.Server.Por
 | Skill | Description | Parameters |
 |-------|-------------|------------|
 {{- range .ADL.Spec.Skills }}
-| `{{ .Name }}` | {{ .Description }} | {{- if .Schema.properties }}{{- $props := list }}{{- range $key, $value := .Schema.properties }}{{- $props = append $props $key }}{{- end }}{{ $props | join ", " }}{{- else }}None{{- end }} |
+| `{{ .Name }}` | {{ .Description }} | {{- if .Schema.properties }}{{- $props := list }}{{- range $key, $value := .Schema.properties }}{{- $props = append $props $key }}{{- end }} {{ $props | join ", " }} {{- else }} None {{- end }} |
 {{- end }}
 
 ## Configuration


### PR DESCRIPTION
## Summary

This PR improves the documentation templates with better wording and formatting:

- **Changed "Production ready" to "Enterprise-ready"** in README.md.tmpl - Better positioning and consistent with industry terminology
- **Added missing health check endpoint** to AGENTS.md.tmpl - Completes the API endpoints documentation to match the ADK server implementation
- **Fixed spacing in Parameters column** - Added proper spaces before/after parameter lists in Skills table for better readability

## Changes

### README.md.tmpl
- Line 60: `Production ready` → `Enterprise-ready`
- Line 74: Added spaces around parameter list output for proper markdown table formatting

### AGENTS.md.tmpl  
- Line 104: Added `GET /health` endpoint to API documentation

## Testing

- Built ADL CLI with `task build`
- Generated test project from `examples/go-agent.yaml` to `test-output`
- Verified all template changes render correctly:
  - ✅ "Enterprise-ready" appears in features list
  - ✅ Health check endpoint listed in both README.md and AGENTS.md
  - ✅ Parameters column has proper spacing in Skills table

## Motivation

These changes ensure generated documentation is accurate, professional, and matches the actual A2A protocol implementation in the ADK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)