### PR TITLE
feat(config): Add support for config subsection injection in skills

### DIFF
--- a/internal/templates/languages/go/main.go.tmpl
+++ b/internal/templates/languages/go/main.go.tmpl
@@ -94,7 +94,7 @@ func main() {
 	{{- range .ADL.Spec.Skills }}
 
 	// Register {{ .Name }} skill
-	{{ .Name | toCamelCase }}Skill := skills.New{{ .Name | toPascalCase }}Skill({{ range $index, $svc := .Inject }}{{ if $index }}, {{ end }}{{ if eq $svc "logger" }}l{{ else }}{{ $svc | toCamelCase }}Svc{{ end }}{{ end }})
+	{{ .Name | toCamelCase }}Skill := skills.New{{ .Name | toPascalCase }}Skill({{ range $index, $svc := .Inject }}{{ if $index }}, {{ end }}{{ if eq $svc "logger" }}l{{ else if eq $svc "config" }}&cfg{{ else if hasPrefix "config." $svc }}&cfg.{{ $svc | trimPrefix "config." | toPascalCase }}{{ else }}{{ $svc | toCamelCase }}Svc{{ end }}{{ end }})
 	toolBox.AddTool({{ .Name | toCamelCase }}Skill)
 	l.Info("registered skill: {{ .Name }} ({{ .Description }})")
 	{{- end }}

--- a/internal/templates/languages/go/skill.go.tmpl
+++ b/internal/templates/languages/go/skill.go.tmpl
@@ -8,6 +8,10 @@ import (
 {{- range $depID := .Inject }}
 {{- if eq $depID "logger" }}
 	zap "go.uber.org/zap"
+{{- else if eq $depID "config" }}
+	config "{{ $.GoModule }}/config"
+{{- else if hasPrefix "config." $depID }}
+	config "{{ $.GoModule }}/config"
 {{- else }}
 	{{ $depID | toCamelCase }} "{{ $.GoModule }}/internal/{{ $depID | toSnakeCase }}"
 {{- end }}
@@ -19,6 +23,10 @@ type {{ .Name | toPascalCase }}Skill struct {
 {{- range $depID := .Inject }}
 {{- if eq $depID "logger" }}
 	{{ $depID | toCamelCase }} *zap.Logger
+{{- else if eq $depID "config" }}
+	{{ $depID | toCamelCase }} *config.Config
+{{- else if hasPrefix "config." $depID }}
+	{{ $depID | trimPrefix "config." | toCamelCase }} *config.{{ $depID | trimPrefix "config." | toPascalCase }}Config
 {{- else }}
 {{- $svc := index $.ServiceMap $depID }}
 	{{ $depID | toCamelCase }} {{ $depID | toCamelCase }}.{{ $svc.Interface }}
@@ -27,10 +35,14 @@ type {{ .Name | toPascalCase }}Skill struct {
 }
 
 // New{{ .Name | toPascalCase }}Skill creates a new {{ .Name }} skill
-func New{{ .Name | toPascalCase }}Skill({{ range $index, $depID := .Inject }}{{ if $index }}, {{ end }}{{- if eq $depID "logger" }}{{ $depID | toCamelCase }} *zap.Logger{{- else }}{{- $svc := index $.ServiceMap $depID }}{{ $depID | toCamelCase }} {{ $depID | toCamelCase }}.{{ $svc.Interface }}{{- end }}{{ end }}) server.Tool {
+func New{{ .Name | toPascalCase }}Skill({{ range $index, $depID := .Inject }}{{ if $index }}, {{ end }}{{- if eq $depID "logger" }}{{ $depID | toCamelCase }} *zap.Logger{{- else if eq $depID "config" }}{{ $depID | toCamelCase }} *config.Config{{- else if hasPrefix "config." $depID }}{{ $depID | trimPrefix "config." | toCamelCase }} *config.{{ $depID | trimPrefix "config." | toPascalCase }}Config{{- else }}{{- $svc := index $.ServiceMap $depID }}{{ $depID | toCamelCase }} {{ $depID | toCamelCase }}.{{ $svc.Interface }}{{- end }}{{ end }}) server.Tool {
 	skill := &{{ .Name | toPascalCase }}Skill{
 {{- range $depID := .Inject }}
+{{- if hasPrefix "config." $depID }}
+		{{ $depID | trimPrefix "config." | toCamelCase }}: {{ $depID | trimPrefix "config." | toCamelCase }},
+{{- else }}
 		{{ $depID | toCamelCase }}: {{ $depID | toCamelCase }},
+{{- end }}
 {{- end }}
 	}
 	return server.NewBasicTool(


### PR DESCRIPTION
## Summary

- Add support for injecting specific configuration subsections into skills using dotted notation (e.g., `config.email`, `config.database`)
- Enable type-safe, scoped access to configuration following principle of least privilege
- Add schema validation to ensure injected config sections are defined in `spec.config`
- Update Go templates to generate correct constructor parameters and imports for config subsections
- Add comprehensive documentation with examples and benefits

## Changes

**Schema & Validation** (`internal/schema/validator.go`)
- Add `config` as a built-in injectable service alongside `logger`
- Validate that config subsections (e.g., `config.email`) reference existing sections in `spec.config`
- Update JSON schema pattern to allow dotted notation in inject arrays

**Template Updates**
- **`skill.go.tmpl`**: Generate struct fields and constructor parameters for config subsections with proper types (e.g., `*config.EmailConfig`)
- **`main.go.tmpl`**: Pass config subsections to skill constructors (e.g., `&cfg.Email`)

**Documentation** (`README.md`)
- Add new "Config Subsection Injection" section with complete examples
- Document injection patterns for `logger`, `config`, `config.subsection`, and services
- List benefits: scoped access, type safety, clear dependencies, easier testing, better separation

## Example Usage

```yaml
spec:
  config:
    email:
      apiKey: ""
      fromAddress: "noreply@example.com"
  skills:
    - name: send_notification
      inject:
        - logger
        - config.email  # Inject only email config subsection
```

## Test plan

- [ ] Validate ADL files with config subsection injection
- [ ] Generate projects and verify correct code generation
- [ ] Test that skills receive proper config subsection types
- [ ] Verify validation catches invalid config section references
- [ ] Build generated projects successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)