### PR TITLE
feat(server): Add scheme option to specify HTTP or HTTPS

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -216,9 +216,10 @@ type adlData struct {
 			Inject      []string       `yaml:"inject,omitempty"`
 		} `yaml:"skills,omitempty"`
 		Server struct {
-			Port  int  `yaml:"port"`
-			Debug bool `yaml:"debug"`
-			Auth  *struct {
+			Port   int    `yaml:"port"`
+			Scheme string `yaml:"scheme,omitempty"`
+			Debug  bool   `yaml:"debug"`
+			Auth   *struct {
 				Enabled bool `yaml:"enabled"`
 			} `yaml:"auth,omitempty"`
 		} `yaml:"server"`
@@ -484,6 +485,7 @@ func collectADLInfo(cmd *cobra.Command, projectName string, useDefaults bool) *a
 	} else {
 		adl.Spec.Server.Port = 8080
 	}
+	adl.Spec.Server.Scheme = conditionalPrompt(useDefaults, "Server scheme (http/https)", "http")
 	adl.Spec.Server.Debug = conditionalPromptBool(useDefaults, "Enable debug mode", false)
 
 	authEnabled := conditionalPromptBool(useDefaults, "Enable server authentication", false)
@@ -531,7 +533,11 @@ func collectADLInfo(cmd *cobra.Command, projectName string, useDefaults bool) *a
 			adl.Spec.Card.DefaultOutputModes = modes
 		}
 
-		cardURL := conditionalPrompt(useDefaults, "Agent service URL", fmt.Sprintf("https://%s.example.com:%d", adl.Metadata.Name, adl.Spec.Server.Port))
+		scheme := adl.Spec.Server.Scheme
+		if scheme == "" {
+			scheme = "http"
+		}
+		cardURL := conditionalPrompt(useDefaults, "Agent service URL", fmt.Sprintf("%s://%s.example.com:%d", scheme, adl.Metadata.Name, adl.Spec.Server.Port))
 		adl.Spec.Card.URL = cardURL
 	}
 

--- a/examples/cloudrun-agent.yaml
+++ b/examples/cloudrun-agent.yaml
@@ -34,6 +34,7 @@ spec:
         required: ["name"]
   server:
     port: 8080
+    scheme: http
     debug: false
   language:
     go:

--- a/examples/cloudrun-ghcr-agent.yaml
+++ b/examples/cloudrun-ghcr-agent.yaml
@@ -31,6 +31,7 @@ spec:
         required: ["data"]
   server:
     port: 8080
+    scheme: http
     debug: false
   language:
     go:

--- a/examples/go-agent-artifacts-filesystem.yaml
+++ b/examples/go-agent-artifacts-filesystem.yaml
@@ -64,6 +64,7 @@ spec:
         required: [id]
   server:
     port: 8443
+    scheme: https
     debug: false
     auth:
       enabled: true

--- a/examples/go-agent-artifacts-minio.yaml
+++ b/examples/go-agent-artifacts-minio.yaml
@@ -77,6 +77,7 @@ spec:
         required: []
   server:
     port: 8443
+    scheme: https
     debug: false
     auth:
       enabled: true

--- a/examples/go-agent.yaml
+++ b/examples/go-agent.yaml
@@ -136,6 +136,7 @@ spec:
         required: [report_type, date_range, format]
   server:
     port: 8443
+    scheme: https
     debug: false
     auth:
       enabled: true

--- a/examples/rust-agent.yaml
+++ b/examples/rust-agent.yaml
@@ -83,6 +83,7 @@ spec:
         required: [domains]
   server:
     port: 8080
+    scheme: http
     debug: false
     auth:
       enabled: false

--- a/internal/schema/types.go
+++ b/internal/schema/types.go
@@ -86,9 +86,10 @@ type Skill struct {
 
 // Server configuration
 type Server struct {
-	Port  int         `yaml:"port" json:"port"`
-	Debug bool        `yaml:"debug" json:"debug"`
-	Auth  *AuthConfig `yaml:"auth,omitempty" json:"auth,omitempty"`
+	Port   int         `yaml:"port" json:"port"`
+	Scheme string      `yaml:"scheme,omitempty" json:"scheme,omitempty"`
+	Debug  bool        `yaml:"debug" json:"debug"`
+	Auth   *AuthConfig `yaml:"auth,omitempty" json:"auth,omitempty"`
 }
 
 // AuthConfig for server authentication

--- a/internal/templates/common/docs/README.md.tmpl
+++ b/internal/templates/common/docs/README.md.tmpl
@@ -42,6 +42,20 @@ docker build -t {{ .ADL.Metadata.Name }} .
 docker run -p {{ .ADL.Spec.Server.Port | default 8080 }}:{{ .ADL.Spec.Server.Port | default 8080 }} {{ .ADL.Metadata.Name }}
 ```
 
+## Quick Install
+
+Add this agent to your Inference Gateway CLI:
+
+```bash
+infer agents add {{ .ADL.Metadata.Name }} {{ .ADL.Spec.Server.Scheme | default "http" }}://localhost:{{ .ADL.Spec.Server.Port | default 8080 }}{{- if and .ADL.Spec.SCM (eq .ADL.Spec.SCM.Provider "github") .ADL.Spec.SCM.URL }} \
+{{- $url := .ADL.Spec.SCM.URL | trimSuffix ".git" | trimPrefix "https://github.com/" | trimPrefix "git@github.com:" }}
+  --oci ghcr.io/{{ $url }}:latest \
+{{- end }}
+  --run{{- if and .ADL.Spec.Agent .ADL.Spec.Agent.Model }} \
+  --model {{ .ADL.Spec.Agent.Provider }}/{{ .ADL.Spec.Agent.Model }}
+{{- end }}
+```
+
 ## Features
 
 - ✅ A2A protocol compliant
@@ -96,7 +110,7 @@ The following custom configuration variables are available:
 |----------|----------|-------------|---------|
 | **Server** | `A2A_PORT` | Server port | `{{ .ADL.Spec.Server.Port | default 8080 }}` |
 | **Server** | `A2A_DEBUG` | Enable debug mode | `{{ .ADL.Spec.Server.Debug | default false }}` |
-| **Server** | `A2A_AGENT_URL` | Agent URL for internal references | `http://localhost:{{ .ADL.Spec.Server.Port | default 8080 }}` |
+| **Server** | `A2A_AGENT_URL` | Agent URL for internal references | `{{ .ADL.Spec.Server.Scheme | default "http" }}://localhost:{{ .ADL.Spec.Server.Port | default 8080 }}` |
 | **Server** | `A2A_STREAMING_STATUS_UPDATE_INTERVAL` | Streaming status update frequency | `1s` |
 | **Server** | `A2A_SERVER_READ_TIMEOUT` | HTTP server read timeout | `120s` |
 | **Server** | `A2A_SERVER_WRITE_TIMEOUT` | HTTP server write timeout | `120s` |
@@ -171,15 +185,15 @@ task fmt
 Use the [A2A Debugger](https://github.com/inference-gateway/a2a-debugger) to test and debug your A2A agent during development. It provides a web interface for sending requests to your agent and inspecting responses, making it easier to troubleshoot issues and validate your implementation.
 
 ```bash
-docker run --rm -it --network host ghcr.io/inference-gateway/a2a-debugger:latest --server-url http://localhost:8080 tasks submit "What are your skills?"
+docker run --rm -it --network host ghcr.io/inference-gateway/a2a-debugger:latest --server-url {{ .ADL.Spec.Server.Scheme | default "http" }}://localhost:{{ .ADL.Spec.Server.Port | default 8080 }} tasks submit "What are your skills?"
 ```
 
 ```bash
-docker run --rm -it --network host ghcr.io/inference-gateway/a2a-debugger:latest --server-url http://localhost:8080 tasks list
+docker run --rm -it --network host ghcr.io/inference-gateway/a2a-debugger:latest --server-url {{ .ADL.Spec.Server.Scheme | default "http" }}://localhost:{{ .ADL.Spec.Server.Port | default 8080 }} tasks list
 ```
 
 ```bash
-docker run --rm -it --network host ghcr.io/inference-gateway/a2a-debugger:latest --server-url http://localhost:8080 tasks get <task ID>
+docker run --rm -it --network host ghcr.io/inference-gateway/a2a-debugger:latest --server-url {{ .ADL.Spec.Server.Scheme | default "http" }}://localhost:{{ .ADL.Spec.Server.Port | default 8080 }} tasks get <task ID>
 ```
 
 ## Deployment


### PR DESCRIPTION
## Summary

Add a new `scheme` field to the server configuration that allows users to explicitly specify whether the server should use HTTP or HTTPS. This provides better clarity and flexibility in server configuration, addressing the need to differentiate between secure and non-secure endpoints.

## Changes

- **Schema**: Add `Scheme` field to `Server` struct in `internal/schema/types.go`
- **Examples**: Update all example YAML files with appropriate `scheme` values:
  - HTTPS for production examples (port 8443)
  - HTTP for CloudRun and Rust examples (port 8080)
- **Templates**: Update README template to dynamically use scheme in URLs and agent installation commands
- **CLI**: Add interactive prompt in `init` command for scheme selection (defaults to "http")

## Test Plan

- [x] Build succeeds (`task build`)
- [x] All tests pass (`task test`)
- [x] Example validation passes (`task examples:test`)
- [x] Schema properly handles optional `scheme` field with default value
- [x] Generated README uses correct scheme in URLs

## Breaking Changes

None. The `scheme` field is optional and defaults to "http" for backward compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)