### PR TITLE
feat(skills): Pull whole skill directories from GitHub

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,2 @@
+test-output*/
+node_modules/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,17 @@ main.go                       # Entry point, sets version
 ### Tools vs Skills
 
 - **Tools** are functions the agent can invoke. Defined under `spec.tools`. Each one becomes code in the target language with a JSON schema.
-- **Skills** are markdown documents (YAML frontmatter + body) injected into the system prompt at startup. Defined under `spec.skills`. Each is generated under `skills/<id>/SKILL.md` (one directory per skill); bare skills may ship bundled scripts/resources alongside `SKILL.md` and the whole directory is protected by `.adl-ignore`. Skills are either pulled from `registry.inference-gateway.com/skills/<id>[/<version>].md` (override with `ADL_SKILLS_REGISTRY`) or scaffolded blank with `bare: true`. Registry skills currently produce only `SKILL.md` (no bundled assets over the wire). `adl generate --offline` skips registry fetches.
+- **Skills** are markdown documents (YAML frontmatter + body) injected into the system prompt at startup. Defined under `spec.skills`. Each is generated under `skills/<id>/SKILL.md` (one directory per skill, Anthropic-style layout — bundled scripts/resources may live alongside `SKILL.md`). Resolution paths:
+  - **`bare: true`** → scaffolded from inline `name`/`description`/`tags`; the whole `skills/<id>/` directory is listed in `.adl-ignore` so user-authored assets survive regeneration.
+  - **`source:` set** → must be a `github.com` `/tree/<ref>/<path>` URL or one of the shorthand forms below; the full directory is fetched (SKILL.md + bundled assets) via the GitHub trees API + `raw.githubusercontent.com`. Implemented in `internal/registry/installer.go`.
+  - **Otherwise** → fetch `registry.inference-gateway.com/skills/<id>[/<version>].md` (override with `ADL_SKILLS_REGISTRY`). Registry-by-id ships SKILL.md only.
+
+  `source:` shorthand (an optional `@<tag>` pins a branch/tag/SHA, default `main`):
+  - `<skill>[@<tag>]` → `inference-gateway/skills` repo
+  - `<owner>/<repo>/<skill>[@<tag>]` → arbitrary repo (assumes a `skills/<id>/` subdir, matching Anthropic's convention)
+  - Full `https://github.com/...` URL → passed through
+
+  Non-`github.com` URLs are rejected so the source path always produces a complete bundle. `adl generate --offline` skips network fetches; every non-bare skill must be cached at `~/.adl/skills-cache/<id>@<ref>/`.
 
 ### Service Injection
 

--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ The complete ADL schema includes:
 - **services**: Service services with interfaces, factories, and type definitions
 - **agent**: AI provider configuration (OpenAI, Anthropic, DeepSeek, Ollama, Google, Mistral, Groq)
 - **tools**: Function-call definitions with JSON schemas, validation, and service injection support
-- **skills**: Markdown playbooks (id + optional `bare`, version, source) pulled from the skills registry or scaffolded locally, advertised on the agent card, and prepended to the system prompt at runtime
+- **skills**: Markdown playbooks (id + optional `bare`, version, source) pulled from the skills registry, fetched as a full directory from a GitHub repo (shorthand or URL), or scaffolded locally; advertised on the agent card and prepended to the system prompt at runtime
 - **server**: HTTP server configuration with authentication support
 - **language**: Programming language-specific settings (Go, Rust, TypeScript) and configurable acronyms
 - **scm**: Source control management configuration (GitHub, GitLab)
@@ -479,7 +479,9 @@ spec:
             type: integer
             description: "Result limit"
             maximum: 1000
-        required: [query, table]
+        required:
+          - query
+          - table
     - name: send_notification
       description: "Send multi-channel notifications"
       inject:
@@ -496,11 +498,23 @@ spec:
             description: "Message content"
           priority:
             type: string
-            enum: ["low", "medium", "high", "critical"]
+            enum:
+              - low
+              - medium
+              - high
+              - critical
           channel:
             type: string
-            enum: ["email", "slack", "teams", "webhook"]
-        required: [recipient, message, priority, channel]
+            enum:
+              - email
+              - slack
+              - teams
+              - webhook
+        required:
+          - recipient
+          - message
+          - priority
+          - channel
   server:
     port: 8443
     debug: false
@@ -561,15 +575,57 @@ spec:
       name: company-policy
       description: "Internal compliance rules to follow"
       tags: [policy, compliance]
-    - id: custom-external
-      source: https://example.com/skills/custom-external.md  # per-skill override
+    - id: pdf                    # pull a full skill directory from GitHub
+      source: anthropics/skills/pdf
+    - id: skill-creator
+      source: skill-creator@v1.0 # pin to a tag/branch/sha
 ```
 
-Resolution rules:
+### Resolution rules
 
-- `bare: true` → the CLI scaffolds `skills/<id>/SKILL.md` with frontmatter from the manifest and a TODO body that you author by hand. The whole `skills/<id>/` directory is listed in `.adl-ignore`, so any bundled scripts, templates, or resources you drop alongside `SKILL.md` are preserved on regeneration.
-- `source: <url>` → fetch from that URL (becomes `skills/<id>/SKILL.md`).
-- Otherwise → fetch `https://registry.inference-gateway.com/skills/<id>[/<version>].md` (becomes `skills/<id>/SKILL.md`). Override the registry with `ADL_SKILLS_REGISTRY`. Use `adl generate --offline` to skip network access (requires every non-bare skill to be cached at `~/.adl/skills-cache/`). Registry skills currently produce only the `SKILL.md` file — bundled-asset support over the wire is a future enhancement.
+- **`bare: true`** → the CLI scaffolds `skills/<id>/SKILL.md` with frontmatter from the manifest and a TODO body that you author by hand. The whole `skills/<id>/` directory is listed in `.adl-ignore`, so any bundled scripts, templates, or resources you drop alongside `SKILL.md` are preserved on regeneration.
+- **`source:` set** → the source must resolve to a public GitHub directory (a `/tree/<ref>/<path>` URL, or one of the shorthand forms below). The CLI pulls the *entire* directory — `SKILL.md`, reference docs, bundled scripts, anything else — and writes it to `skills/<id>/`. Non-`github.com` URLs are rejected so the same code path always produces a complete skill bundle, not a stray markdown file.
+- **Otherwise** → fetch `https://registry.inference-gateway.com/skills/<id>[/<version>].md` (becomes `skills/<id>/SKILL.md`). Override the registry with `ADL_SKILLS_REGISTRY`. Registry-by-id currently ships `SKILL.md` only; if you need bundled assets, use `source:` to point at a GitHub directory.
+
+Use `adl generate --offline` to skip network access — every non-bare skill must already be cached at `~/.adl/skills-cache/<id>@<ref>/` (where `<ref>` is the pinned tag/branch, or `latest` for an unpinned registry fetch).
+
+### `source:` shorthand grammar
+
+Every form below resolves to a GitHub `tree/<ref>/<path>` URL. An optional `@<tag>` suffix pins a branch, tag, or commit SHA; omit it to use the default `main` branch.
+
+| Shorthand                        | Expands to                                                                   |
+| -------------------------------- | ---------------------------------------------------------------------------- |
+| `<skill>`                        | `https://github.com/inference-gateway/skills/tree/main/skills/<skill>`       |
+| `<skill>@<tag>`                  | `https://github.com/inference-gateway/skills/tree/<tag>/skills/<skill>`      |
+| `<owner>/<repo>/<skill>`         | `https://github.com/<owner>/<repo>/tree/main/skills/<skill>`                 |
+| `<owner>/<repo>/<skill>@<tag>`   | `https://github.com/<owner>/<repo>/tree/<tag>/skills/<skill>`                |
+| Full `https://github.com/...` URL | passed through unchanged                                                    |
+
+Concrete examples:
+
+```yaml
+# Default inference-gateway/skills, latest main:
+- id: skill-creator
+  source: skill-creator
+
+# Default inference-gateway/skills, pinned to a tag:
+- id: skill-creator
+  source: skill-creator@v1.0
+
+# Different repo (Anthropic's official skill library):
+- id: pdf
+  source: anthropics/skills/pdf
+
+# Different repo, pinned to a commit SHA:
+- id: pdf
+  source: anthropics/skills/pdf@abc1234
+
+# Full URL for anything that doesn't fit the shorthand:
+- id: custom
+  source: https://github.com/my-org/my-repo/tree/release/path/to/skill
+```
+
+The 3-segment form assumes a `skills/<id>/` subdirectory inside the repo (the convention used by both `inference-gateway/skills` and `anthropics/skills`). If your repo lays skills out differently, pass the full URL.
 
 At runtime, the generated agent walks first-level subdirectories under `skills/` (overridable with `A2A_SKILLS_DIR`), reads each `<id>/SKILL.md`, strips frontmatter, and concatenates the bodies onto the configured `systemPrompt`. Both Go and Rust runtimes ship with this loader baked into `main.go` / `main.rs`.
 

--- a/README.md
+++ b/README.md
@@ -584,7 +584,7 @@ spec:
 ### Resolution rules
 
 - **`bare: true`** → the CLI scaffolds `skills/<id>/SKILL.md` with frontmatter from the manifest and a TODO body that you author by hand. The whole `skills/<id>/` directory is listed in `.adl-ignore`, so any bundled scripts, templates, or resources you drop alongside `SKILL.md` are preserved on regeneration.
-- **`source:` set** → the source must resolve to a public GitHub directory (a `/tree/<ref>/<path>` URL, or one of the shorthand forms below). The CLI pulls the *entire* directory — `SKILL.md`, reference docs, bundled scripts, anything else — and writes it to `skills/<id>/`. Non-`github.com` URLs are rejected so the same code path always produces a complete skill bundle, not a stray markdown file.
+- **`source:` set** → the source must resolve to a public GitHub directory (a `/tree/<ref>/<path>` URL, or one of the shorthand forms below). The CLI pulls the _entire_ directory — `SKILL.md`, reference docs, bundled scripts, anything else — and writes it to `skills/<id>/`. Non-`github.com` URLs are rejected so the same code path always produces a complete skill bundle, not a stray markdown file.
 - **Otherwise** → fetch `https://registry.inference-gateway.com/skills/<id>[/<version>].md` (becomes `skills/<id>/SKILL.md`). Override the registry with `ADL_SKILLS_REGISTRY`. Registry-by-id currently ships `SKILL.md` only; if you need bundled assets, use `source:` to point at a GitHub directory.
 
 Use `adl generate --offline` to skip network access — every non-bare skill must already be cached at `~/.adl/skills-cache/<id>@<ref>/` (where `<ref>` is the pinned tag/branch, or `latest` for an unpinned registry fetch).

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -412,20 +413,19 @@ func (g *Generator) generateProject(templateEngine *templates.Engine, adl *schem
 			if !ok {
 				return fmt.Errorf("skill %s not found in resolved skills", skillID)
 			}
-			if resolved.Bare {
-				skillContext := map[string]interface{}{
-					"ID":          resolved.ID,
-					"Name":        resolved.Name,
-					"Description": resolved.Description,
-					"Tags":        resolved.Tags,
-					"Version":     resolved.Version,
-				}
-				content, err = templateEngine.ExecuteToolTemplateWithContext(templateKey, skillContext, ctx)
-				if err != nil {
-					return fmt.Errorf("failed to scaffold bare skill %s: %w", resolved.ID, err)
-				}
-			} else {
-				content = string(resolved.Body)
+			if !resolved.Bare {
+				return fmt.Errorf("non-bare skill %s should not flow through the skills/skill.md template", resolved.ID)
+			}
+			skillContext := map[string]interface{}{
+				"ID":          resolved.ID,
+				"Name":        resolved.Name,
+				"Description": resolved.Description,
+				"Tags":        resolved.Tags,
+				"Version":     resolved.Version,
+			}
+			content, err = templateEngine.ExecuteToolTemplateWithContext(templateKey, skillContext, ctx)
+			if err != nil {
+				return fmt.Errorf("failed to scaffold bare skill %s: %w", resolved.ID, err)
 			}
 		} else if templateKey == "service.go" {
 			return fmt.Errorf("service template reached fallback case - this should not happen")
@@ -474,6 +474,10 @@ func (g *Generator) generateProject(templateEngine *templates.Engine, adl *schem
 		}
 	}
 
+	if err := g.writeResolvedSkillFiles(resolvedSkills, outputDir, ignoreChecker); err != nil {
+		return err
+	}
+
 	if err := g.generateADLIgnoreFile(outputDir, templateEngine.GetTemplate(), adl); err != nil {
 		return fmt.Errorf("failed to generate .adl-ignore file: %w", err)
 	}
@@ -490,6 +494,34 @@ func (g *Generator) generateProject(templateEngine *templates.Engine, adl *schem
 		}
 	}
 
+	return nil
+}
+
+// writeResolvedSkillFiles writes the file map of every non-bare resolved
+// skill to skills/<id>/<rel-path>. Bare skills are scaffolded earlier by
+// the template engine and don't appear here. Files matched by .adl-ignore
+// are skipped so users can lock down a vendored skill if they need to.
+func (g *Generator) writeResolvedSkillFiles(skills []*registry.ResolvedSkill, outputDir string, ignoreChecker *IgnoreChecker) error {
+	for _, rs := range skills {
+		if rs.Bare {
+			continue
+		}
+		for rel, data := range rs.Files {
+			cleaned := filepath.ToSlash(filepath.Clean(rel))
+			if strings.HasPrefix(cleaned, "../") || strings.HasPrefix(cleaned, "/") {
+				return fmt.Errorf("skill %s: refusing to write file with suspicious path %q", rs.ID, rel)
+			}
+			relPath := path.Join("skills", rs.ID, cleaned)
+			if ignoreChecker.ShouldIgnore(relPath) {
+				fmt.Printf("🚫 Ignoring file (matches .adl-ignore): %s\n", relPath)
+				continue
+			}
+			filePath := filepath.Join(outputDir, filepath.FromSlash(relPath))
+			if err := g.writeFile(filePath, string(data)); err != nil {
+				return fmt.Errorf("failed to write %s: %w", relPath, err)
+			}
+		}
+	}
 	return nil
 }
 

--- a/internal/registry/cache.go
+++ b/internal/registry/cache.go
@@ -4,9 +4,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
-// Cache is a simple disk-backed cache for fetched skill markdown blobs.
+// Cache is a disk-backed cache for fetched skill directories. Each
+// cached skill lives under <dir>/<id>@<ref>/ and may contain any number
+// of files (SKILL.md plus optional scripts/resources).
 type Cache struct {
 	dir string
 }
@@ -27,39 +30,80 @@ func NewCache(dir string) (*Cache, error) {
 // Dir returns the cache root directory.
 func (c *Cache) Dir() string { return c.dir }
 
-// Path returns the on-disk path that would be used for a skill id+version.
-// version may be empty to denote the registry default.
-func (c *Cache) Path(id, version string) string {
-	v := version
-	if v == "" {
-		v = "latest"
+// SkillDir returns the on-disk directory for a skill at (id, ref). An
+// empty ref resolves to "latest".
+func (c *Cache) SkillDir(id, ref string) string {
+	r := ref
+	if r == "" {
+		r = "latest"
 	}
-	return filepath.Join(c.dir, fmt.Sprintf("%s@%s.md", id, v))
+	return filepath.Join(c.dir, fmt.Sprintf("%s@%s", id, r))
 }
 
-// Get returns the cached bytes for (id, version) if present.
+// Get returns the cached file map for (id, ref) if the directory exists.
 // The boolean is false when the entry is absent.
-func (c *Cache) Get(id, version string) ([]byte, bool, error) {
-	path := c.Path(id, version)
-	data, err := os.ReadFile(path)
+func (c *Cache) Get(id, ref string) (map[string][]byte, bool, error) {
+	dir := c.SkillDir(id, ref)
+	info, err := os.Stat(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, false, nil
 		}
-		return nil, false, fmt.Errorf("failed to read skill cache entry %s: %w", path, err)
+		return nil, false, fmt.Errorf("failed to stat skill cache entry %s: %w", dir, err)
 	}
-	return data, true, nil
+	if !info.IsDir() {
+		return nil, false, fmt.Errorf("cache entry %s is not a directory", dir)
+	}
+
+	files := make(map[string][]byte)
+	if err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(dir, path)
+		if relErr != nil {
+			return relErr
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		files[filepath.ToSlash(rel)] = data
+		return nil
+	}); err != nil {
+		return nil, false, fmt.Errorf("failed to read skill cache entry %s: %w", dir, err)
+	}
+	if len(files) == 0 {
+		return nil, false, nil
+	}
+	return files, true, nil
 }
 
-// Put writes the bytes for (id, version) into the cache, creating the
-// cache directory as needed.
-func (c *Cache) Put(id, version string, data []byte) error {
-	if err := os.MkdirAll(c.dir, 0o755); err != nil {
+// Put writes the file map into the cache directory for (id, ref). The
+// directory is wiped first so stale entries from a previous version
+// can't bleed through.
+func (c *Cache) Put(id, ref string, files map[string][]byte) error {
+	dir := c.SkillDir(id, ref)
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("failed to clear skill cache directory %s: %w", dir, err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("failed to create skill cache directory: %w", err)
 	}
-	path := c.Path(id, version)
-	if err := os.WriteFile(path, data, 0o644); err != nil {
-		return fmt.Errorf("failed to write skill cache entry %s: %w", path, err)
+	for rel, data := range files {
+		if strings.HasPrefix(rel, "/") || strings.Contains(rel, "..") {
+			return fmt.Errorf("refusing to cache file with suspicious relative path: %q", rel)
+		}
+		outPath := filepath.Join(dir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+			return fmt.Errorf("failed to create dir for %s: %w", rel, err)
+		}
+		if err := os.WriteFile(outPath, data, 0o644); err != nil {
+			return fmt.Errorf("failed to write skill cache entry %s: %w", outPath, err)
+		}
 	}
 	return nil
 }

--- a/internal/registry/cache_test.go
+++ b/internal/registry/cache_test.go
@@ -16,8 +16,11 @@ func TestCache_GetPut(t *testing.T) {
 		t.Fatalf("expected empty cache miss, got ok=%v err=%v data=%v", ok, err, got)
 	}
 
-	payload := []byte("---\nname: x\ndescription: y\n---\nbody\n")
-	if err := cache.Put("my-skill", "1.0.0", payload); err != nil {
+	files := map[string][]byte{
+		"SKILL.md":          []byte("---\nname: x\ndescription: y\n---\nbody\n"),
+		"scripts/helper.sh": []byte("#!/bin/sh\necho hi\n"),
+	}
+	if err := cache.Put("my-skill", "1.0.0", files); err != nil {
 		t.Fatalf("Put: %v", err)
 	}
 
@@ -25,16 +28,57 @@ func TestCache_GetPut(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("expected cache hit, got ok=%v err=%v", ok, err)
 	}
-	if string(got) != string(payload) {
-		t.Errorf("payload mismatch: got %q want %q", got, payload)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 files, got %d", len(got))
+	}
+	if string(got["SKILL.md"]) != string(files["SKILL.md"]) {
+		t.Errorf("SKILL.md mismatch: got %q", got["SKILL.md"])
+	}
+	if string(got["scripts/helper.sh"]) != string(files["scripts/helper.sh"]) {
+		t.Errorf("scripts/helper.sh mismatch: got %q", got["scripts/helper.sh"])
 	}
 
-	wantPath := filepath.Join(dir, "my-skill@1.0.0.md")
-	if cache.Path("my-skill", "1.0.0") != wantPath {
-		t.Errorf("Path = %q, want %q", cache.Path("my-skill", "1.0.0"), wantPath)
+	wantDir := filepath.Join(dir, "my-skill@1.0.0")
+	if cache.SkillDir("my-skill", "1.0.0") != wantDir {
+		t.Errorf("SkillDir = %q, want %q", cache.SkillDir("my-skill", "1.0.0"), wantDir)
+	}
+	if cache.SkillDir("foo", "") != filepath.Join(dir, "foo@latest") {
+		t.Errorf("SkillDir for empty version should use 'latest', got %q", cache.SkillDir("foo", ""))
+	}
+}
+
+func TestCache_PutClearsStaleFiles(t *testing.T) {
+	dir := t.TempDir()
+	cache, err := NewCache(dir)
+	if err != nil {
+		t.Fatalf("NewCache: %v", err)
 	}
 
-	if cache.Path("foo", "") != filepath.Join(dir, "foo@latest.md") {
-		t.Errorf("Path for empty version should use 'latest', got %q", cache.Path("foo", ""))
+	if err := cache.Put("a", "main", map[string][]byte{
+		"SKILL.md":         []byte("---\nname: a\ndescription: v1\n---\n"),
+		"scripts/v1.sh":    []byte("v1"),
+		"resources/old.md": []byte("old"),
+	}); err != nil {
+		t.Fatalf("first Put: %v", err)
+	}
+	if err := cache.Put("a", "main", map[string][]byte{
+		"SKILL.md":      []byte("---\nname: a\ndescription: v2\n---\n"),
+		"scripts/v2.sh": []byte("v2"),
+	}); err != nil {
+		t.Fatalf("second Put: %v", err)
+	}
+
+	got, ok, err := cache.Get("a", "main")
+	if err != nil || !ok {
+		t.Fatalf("Get after second Put: ok=%v err=%v", ok, err)
+	}
+	if _, exists := got["scripts/v1.sh"]; exists {
+		t.Error("expected stale scripts/v1.sh to be cleared, but it is still present")
+	}
+	if _, exists := got["resources/old.md"]; exists {
+		t.Error("expected stale resources/old.md to be cleared, but it is still present")
+	}
+	if string(got["scripts/v2.sh"]) != "v2" {
+		t.Errorf("expected fresh scripts/v2.sh, got %q", got["scripts/v2.sh"])
 	}
 }

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -10,14 +10,18 @@ import (
 	"time"
 )
 
-// DefaultBaseURL is the canonical skill registry endpoint used when neither
-// ADL_SKILLS_REGISTRY nor a per-skill `source:` overrides it.
+// DefaultBaseURL is the canonical skill registry endpoint used when no
+// per-skill `source:` overrides it.
 const DefaultBaseURL = "https://registry.inference-gateway.com/skills/"
 
 // EnvBaseURL is the env var that overrides DefaultBaseURL.
 const EnvBaseURL = "ADL_SKILLS_REGISTRY"
 
-// Client fetches skill markdown from the registry.
+// Client fetches SKILL.md from the default registry by id.
+//
+// `source:` overrides do NOT flow through this client; they go through
+// the GitHub Installer instead so they can pull a whole skill directory
+// (scripts, resources, …).
 type Client struct {
 	BaseURL    string
 	HTTPClient *http.Client
@@ -39,7 +43,7 @@ func NewClient(baseURL string) *Client {
 	}
 }
 
-// FetchByID retrieves a skill's markdown by id (and optional version)
+// FetchByID retrieves a skill's SKILL.md by id (and optional version)
 // from the configured BaseURL. Version "" resolves to the registry's
 // default version of that skill.
 func (c *Client) FetchByID(ctx context.Context, id, version string) ([]byte, error) {
@@ -58,19 +62,6 @@ func (c *Client) FetchByID(ctx context.Context, id, version string) ([]byte, err
 		return nil, err
 	}
 
-	return c.fetch(ctx, target)
-}
-
-// FetchURL retrieves a skill's markdown from an absolute URL, used by
-// per-skill `source:` overrides.
-func (c *Client) FetchURL(ctx context.Context, raw string) ([]byte, error) {
-	if raw == "" {
-		return nil, fmt.Errorf("skill source URL is required")
-	}
-	return c.fetch(ctx, raw)
-}
-
-func (c *Client) fetch(ctx context.Context, target string) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build request for %s: %w", target, err)

--- a/internal/registry/client_test.go
+++ b/internal/registry/client_test.go
@@ -58,26 +58,6 @@ func TestClient_FetchByID(t *testing.T) {
 	}
 }
 
-func TestClient_FetchURL(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/external/skill.md" {
-			_, _ = w.Write([]byte("---\nname: ext\ndescription: e\n---\nbody\n"))
-			return
-		}
-		http.NotFound(w, r)
-	}))
-	defer srv.Close()
-
-	client := NewClient("")
-	body, err := client.FetchURL(context.Background(), srv.URL+"/external/skill.md")
-	if err != nil {
-		t.Fatalf("FetchURL: %v", err)
-	}
-	if !strings.Contains(string(body), "name: ext") {
-		t.Errorf("unexpected body: %q", body)
-	}
-}
-
 func TestNewClient_DefaultBaseURL(t *testing.T) {
 	c := NewClient("")
 	if c.BaseURL != DefaultBaseURL {

--- a/internal/registry/installer.go
+++ b/internal/registry/installer.go
@@ -1,0 +1,245 @@
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+	"time"
+)
+
+const (
+	githubAPIBase     = "https://api.github.com"
+	githubRawBase     = "https://raw.githubusercontent.com"
+	installerTimeout  = 30 * time.Second
+	installerUA       = "inference-gateway-adl-cli"
+	treePartsExpected = 5
+
+	defaultSkillsOrg    = "inference-gateway"
+	defaultSkillsRepo   = "skills"
+	defaultSkillsRef    = "main"
+	defaultSkillsSubdir = "skills"
+)
+
+// ExpandShorthand turns shorthand install targets into full GitHub
+// tree URLs. Accepted forms (an optional `@<tag>` suffix pins a branch
+// or tag; without it, the default ref "main" is used):
+//
+//   - "<skill>[@<tag>]"
+//     → https://github.com/inference-gateway/skills/tree/<tag>/skills/<skill>
+//   - "<owner>/<repo>/<skill>[@<tag>]"
+//     → https://github.com/<owner>/<repo>/tree/<tag>/skills/<skill>
+//   - any http(s):// URL → returned unchanged
+//
+// Anything else (two slash-separated segments, four-plus segments,
+// empty segments, etc.) is returned unchanged so ParseGitHubTreeURL
+// produces a clear error.
+func ExpandShorthand(input string) string {
+	if strings.HasPrefix(input, "http://") || strings.HasPrefix(input, "https://") {
+		return input
+	}
+	trimmed := strings.Trim(input, "/")
+	if trimmed == "" {
+		return input
+	}
+
+	ref := defaultSkillsRef
+	if at := strings.LastIndex(trimmed, "@"); at >= 0 {
+		tag := trimmed[at+1:]
+		body := trimmed[:at]
+		if tag == "" || body == "" {
+			return input
+		}
+		trimmed = body
+		ref = tag
+	}
+
+	parts := strings.Split(trimmed, "/")
+	if slices.Contains(parts, "") {
+		return input
+	}
+	switch len(parts) {
+	case 1:
+		return fmt.Sprintf("https://github.com/%s/%s/tree/%s/%s/%s",
+			defaultSkillsOrg, defaultSkillsRepo, ref, defaultSkillsSubdir, parts[0])
+	case 3:
+		return fmt.Sprintf("https://github.com/%s/%s/tree/%s/%s/%s",
+			parts[0], parts[1], ref, defaultSkillsSubdir, parts[2])
+	default:
+		return input
+	}
+}
+
+// GitHubLocation identifies a directory inside a public GitHub repository,
+// parsed out of a /tree/<ref>/<path> URL.
+type GitHubLocation struct {
+	Owner string
+	Repo  string
+	Ref   string
+	Path  string
+}
+
+// ParseGitHubTreeURL accepts URLs of the form
+//
+//	https://github.com/<owner>/<repo>/tree/<ref>/<path-to-skill>
+//
+// Refs containing a literal "/" (e.g. "feature/foo" branches) are not
+// supported; pass the URL of a tag or single-segment branch instead.
+func ParseGitHubTreeURL(rawURL string) (*GitHubLocation, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %w", err)
+	}
+	if u.Scheme != "https" && u.Scheme != "http" {
+		return nil, fmt.Errorf("URL must use http(s): got %q", u.Scheme)
+	}
+	if u.Host != "github.com" {
+		return nil, fmt.Errorf("only github.com URLs are supported, got %q", u.Host)
+	}
+
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) >= 3 && parts[2] == "blob" {
+		return nil, fmt.Errorf("URL points to a file (/blob/) — pass the directory URL (/tree/) instead: %s", rawURL)
+	}
+	if len(parts) < treePartsExpected || parts[2] != "tree" {
+		return nil, fmt.Errorf("URL must be of the form https://github.com/<owner>/<repo>/tree/<ref>/<path>: got %s", rawURL)
+	}
+
+	return &GitHubLocation{
+		Owner: parts[0],
+		Repo:  parts[1],
+		Ref:   parts[3],
+		Path:  strings.Join(parts[4:], "/"),
+	}, nil
+}
+
+type treeEntry struct {
+	Path string `json:"path"`
+	Type string `json:"type"`
+}
+
+type treeResponse struct {
+	Tree      []treeEntry `json:"tree"`
+	Truncated bool        `json:"truncated"`
+}
+
+// Installer downloads a skill folder from a public GitHub repo and
+// returns its contents as a relative-path → bytes map. Tests substitute
+// APIBase / RawBase to point at httptest.Server.
+type Installer struct {
+	Client  *http.Client
+	APIBase string
+	RawBase string
+}
+
+// NewInstaller returns an Installer pointed at github.com with a 30s HTTP
+// timeout.
+func NewInstaller() *Installer {
+	return &Installer{
+		Client:  &http.Client{Timeout: installerTimeout},
+		APIBase: githubAPIBase,
+		RawBase: githubRawBase,
+	}
+}
+
+// Fetch downloads every blob under loc.Path at loc.Ref and returns a
+// map keyed by the blob's path *relative to loc.Path*. The map is
+// guaranteed to contain at least one entry; callers are responsible for
+// verifying that "SKILL.md" is present.
+func (i *Installer) Fetch(ctx context.Context, loc *GitHubLocation) (map[string][]byte, error) {
+	tree, err := i.fetchTree(ctx, loc)
+	if err != nil {
+		return nil, err
+	}
+
+	prefix := loc.Path + "/"
+	var blobs []treeEntry
+	for _, e := range tree.Tree {
+		if e.Type != "blob" {
+			continue
+		}
+		if !strings.HasPrefix(e.Path, prefix) {
+			continue
+		}
+		blobs = append(blobs, e)
+	}
+	if len(blobs) == 0 {
+		return nil, fmt.Errorf("no files found under %s/%s/%s @ %s — check the URL", loc.Owner, loc.Repo, loc.Path, loc.Ref)
+	}
+
+	files := make(map[string][]byte, len(blobs))
+	for _, b := range blobs {
+		rel := strings.TrimPrefix(b.Path, prefix)
+		data, err := i.downloadBlob(ctx, loc, b.Path)
+		if err != nil {
+			return nil, err
+		}
+		files[rel] = data
+	}
+	return files, nil
+}
+
+func (i *Installer) fetchTree(ctx context.Context, loc *GitHubLocation) (*treeResponse, error) {
+	apiURL := fmt.Sprintf("%s/repos/%s/%s/git/trees/%s?recursive=1", i.APIBase, loc.Owner, loc.Repo, loc.Ref)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create tree request: %w", err)
+	}
+	req.Header.Set("User-Agent", installerUA)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := i.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch tree: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusNotFound:
+		return nil, fmt.Errorf("repository or ref not found: %s/%s @ %s", loc.Owner, loc.Repo, loc.Ref)
+	case http.StatusForbidden:
+		return nil, fmt.Errorf("GitHub API rate limit exceeded (60 req/hour for unauthenticated requests); try again later")
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("GitHub API returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var tree treeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tree); err != nil {
+		return nil, fmt.Errorf("failed to parse tree response: %w", err)
+	}
+	if tree.Truncated {
+		return nil, fmt.Errorf("repository tree was truncated by GitHub (repo too large) — cannot reliably install")
+	}
+	return &tree, nil
+}
+
+func (i *Installer) downloadBlob(ctx context.Context, loc *GitHubLocation, repoPath string) ([]byte, error) {
+	rawURL := fmt.Sprintf("%s/%s/%s/%s/%s", i.RawBase, loc.Owner, loc.Repo, loc.Ref, repoPath)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request for %s: %w", repoPath, err)
+	}
+	req.Header.Set("User-Agent", installerUA)
+
+	resp, err := i.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download %s: %w", repoPath, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to download %s: status %d", repoPath, resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s: %w", repoPath, err)
+	}
+	return data, nil
+}

--- a/internal/registry/installer_test.go
+++ b/internal/registry/installer_test.go
@@ -1,0 +1,144 @@
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestExpandShorthand(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"single segment defaults to inference-gateway/skills@main", "skill-creator", "https://github.com/inference-gateway/skills/tree/main/skills/skill-creator"},
+		{"single segment with @tag", "skill-creator@v1.0", "https://github.com/inference-gateway/skills/tree/v1.0/skills/skill-creator"},
+		{"three segments pin owner/repo/skill", "anthropics/skills/pdf", "https://github.com/anthropics/skills/tree/main/skills/pdf"},
+		{"three segments with @tag", "anthropics/skills/pdf@main", "https://github.com/anthropics/skills/tree/main/skills/pdf"},
+		{"three segments with @sha", "anthropics/skills/pdf@abc123", "https://github.com/anthropics/skills/tree/abc123/skills/pdf"},
+		{"https URL unchanged", "https://github.com/anthropics/skills/tree/main/skills/pdf", "https://github.com/anthropics/skills/tree/main/skills/pdf"},
+		{"http URL unchanged", "http://example.com/x", "http://example.com/x"},
+		{"empty unchanged", "", ""},
+		{"two segments unchanged (no implicit repo=skills)", "anthropics/pdf", "anthropics/pdf"},
+		{"four segments unchanged", "a/b/c/d", "a/b/c/d"},
+		{"leading/trailing slashes trimmed", "/skill/", "https://github.com/inference-gateway/skills/tree/main/skills/skill"},
+		{"empty middle segment unchanged", "a//b/c", "a//b/c"},
+		{"empty tag unchanged", "skill@", "skill@"},
+		{"empty body before @ unchanged", "@v1", "@v1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExpandShorthand(tt.input); got != tt.want {
+				t.Errorf("ExpandShorthand(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseGitHubTreeURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    *GitHubLocation
+		wantErr string
+	}{
+		{
+			name:  "happy path",
+			input: "https://github.com/inference-gateway/skills/tree/main/skills/skill-creator",
+			want:  &GitHubLocation{Owner: "inference-gateway", Repo: "skills", Ref: "main", Path: "skills/skill-creator"},
+		},
+		{
+			name:    "blob URL rejected",
+			input:   "https://github.com/foo/bar/blob/main/README.md",
+			wantErr: "/blob/",
+		},
+		{
+			name:    "non-github host rejected",
+			input:   "https://gitlab.com/foo/bar/tree/main/skills/x",
+			wantErr: "github.com",
+		},
+		{
+			name:    "missing path segment rejected",
+			input:   "https://github.com/foo/bar/tree/main",
+			wantErr: "must be of the form",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseGitHubTreeURL(tt.input)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if *got != *tt.want {
+				t.Errorf("got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInstaller_Fetch(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/acme/skills/git/trees/main", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(treeResponse{
+			Tree: []treeEntry{
+				{Path: "skills/foo/SKILL.md", Type: "blob"},
+				{Path: "skills/foo/scripts/a.sh", Type: "blob"},
+				{Path: "skills/foo/scripts", Type: "tree"},
+				{Path: "skills/bar/SKILL.md", Type: "blob"},
+			},
+		})
+	})
+	mux.HandleFunc("/acme/skills/main/skills/foo/SKILL.md", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("skill body\n"))
+	})
+	mux.HandleFunc("/acme/skills/main/skills/foo/scripts/a.sh", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("#!/bin/sh\n"))
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	inst := &Installer{Client: srv.Client(), APIBase: srv.URL, RawBase: srv.URL}
+	files, err := inst.Fetch(context.Background(), &GitHubLocation{Owner: "acme", Repo: "skills", Ref: "main", Path: "skills/foo"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("expected 2 files, got %d: %v", len(files), files)
+	}
+	if string(files["SKILL.md"]) != "skill body\n" {
+		t.Errorf("SKILL.md mismatch: %q", files["SKILL.md"])
+	}
+	if string(files["scripts/a.sh"]) != "#!/bin/sh\n" {
+		t.Errorf("scripts/a.sh mismatch: %q", files["scripts/a.sh"])
+	}
+}
+
+func TestInstaller_FetchEmptyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/acme/skills/git/trees/main", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(treeResponse{
+			Tree: []treeEntry{
+				{Path: "skills/other/SKILL.md", Type: "blob"},
+			},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	inst := &Installer{Client: srv.Client(), APIBase: srv.URL, RawBase: srv.URL}
+	_, err := inst.Fetch(context.Background(), &GitHubLocation{Owner: "acme", Repo: "skills", Ref: "main", Path: "skills/missing"})
+	if err == nil || !strings.Contains(err.Error(), "no files found") {
+		t.Fatalf("expected no-files error, got %v", err)
+	}
+}

--- a/internal/registry/resolver.go
+++ b/internal/registry/resolver.go
@@ -8,11 +8,16 @@ import (
 	"github.com/inference-gateway/adl-cli/internal/schema"
 )
 
-// ResolvedSkill is the result of resolving a spec.skills[] entry: either
-// fetched from a registry, read from cache, or scaffolded from a bare
-// declaration. Body holds the markdown that should be written to
-// skills/<id>.md in the generated project (empty for bare skills, which
-// are scaffolded by the template engine instead).
+// SkillFile is the canonical filename of a skill's playbook within the
+// skill directory.
+const SkillFile = "SKILL.md"
+
+// ResolvedSkill is the result of resolving a spec.skills[] entry. For
+// non-bare skills, Files contains every blob fetched from the source
+// (the registry default, or a GitHub tree URL via Installer), keyed by
+// path relative to the skill's directory. SKILL.md is always present
+// for non-bare skills. For bare skills, Files is empty — the template
+// engine scaffolds SKILL.md from the ADL metadata.
 type ResolvedSkill struct {
 	ID          string
 	Name        string
@@ -20,15 +25,17 @@ type ResolvedSkill struct {
 	Tags        []string
 	Version     string
 	Bare        bool
-	Body        []byte
+	Files       map[string][]byte
 }
 
-// Resolver coordinates registry fetches, cache lookups, and bare-skill
-// scaffolding to produce ResolvedSkill entries the generator can consume.
+// Resolver coordinates the GitHub Installer, the default registry
+// Client, the on-disk Cache, and bare-skill scaffolding to produce
+// ResolvedSkill entries the generator can consume.
 type Resolver struct {
-	Client  *Client
-	Cache   *Cache
-	Offline bool
+	Client    *Client
+	Installer *Installer
+	Cache     *Cache
+	Offline   bool
 }
 
 // NewDefaultResolver builds a Resolver using ADL_SKILLS_REGISTRY (or the
@@ -40,12 +47,13 @@ func NewDefaultResolver() (*Resolver, error) {
 		return nil, err
 	}
 	return &Resolver{
-		Client: NewClient(base),
-		Cache:  cache,
+		Client:    NewClient(base),
+		Installer: NewInstaller(),
+		Cache:     cache,
 	}, nil
 }
 
-// Resolve fetches or scaffolds metadata for a single skill entry.
+// Resolve fetches or scaffolds metadata + files for a single skill entry.
 func (r *Resolver) Resolve(ctx context.Context, skill schema.Skill) (*ResolvedSkill, error) {
 	if skill.ID == "" {
 		return nil, fmt.Errorf("skill id is required")
@@ -65,31 +73,17 @@ func (r *Resolver) Resolve(ctx context.Context, skill schema.Skill) (*ResolvedSk
 		}, nil
 	}
 
-	cached, ok, err := r.Cache.Get(skill.ID, skill.Version)
+	cacheRef, files, err := r.loadFiles(ctx, skill)
 	if err != nil {
 		return nil, err
 	}
+
+	skillMD, ok := files[SkillFile]
 	if !ok {
-		if r.Offline {
-			return nil, fmt.Errorf("skill %q is not cached and --offline is set", skill.ID)
-		}
-		var body []byte
-		var fetchErr error
-		if skill.Source != "" {
-			body, fetchErr = r.Client.FetchURL(ctx, skill.Source)
-		} else {
-			body, fetchErr = r.Client.FetchByID(ctx, skill.ID, skill.Version)
-		}
-		if fetchErr != nil {
-			return nil, fetchErr
-		}
-		if err := r.Cache.Put(skill.ID, skill.Version, body); err != nil {
-			return nil, err
-		}
-		cached = body
+		return nil, fmt.Errorf("skill %q: no %s found in fetched files", skill.ID, SkillFile)
 	}
 
-	doc, err := ParseSkillDocument(cached)
+	doc, err := ParseSkillDocument(skillMD)
 	if err != nil {
 		return nil, fmt.Errorf("skill %q: %w", skill.ID, err)
 	}
@@ -110,6 +104,9 @@ func (r *Resolver) Resolve(ctx context.Context, skill schema.Skill) (*ResolvedSk
 	if skill.Version != "" {
 		version = skill.Version
 	}
+	if version == "" {
+		version = cacheRef
+	}
 
 	return &ResolvedSkill{
 		ID:          skill.ID,
@@ -117,8 +114,57 @@ func (r *Resolver) Resolve(ctx context.Context, skill schema.Skill) (*ResolvedSk
 		Description: description,
 		Tags:        tags,
 		Version:     version,
-		Body:        cached,
+		Files:       files,
 	}, nil
+}
+
+// loadFiles returns the cached or freshly fetched files for a non-bare
+// skill, along with the cache ref used (either skill.Version or, for
+// source-pulled skills, the GitHub ref from the URL).
+func (r *Resolver) loadFiles(ctx context.Context, skill schema.Skill) (string, map[string][]byte, error) {
+	if skill.Source != "" {
+		expanded := ExpandShorthand(skill.Source)
+		loc, err := ParseGitHubTreeURL(expanded)
+		if err != nil {
+			return "", nil, fmt.Errorf("skill %q: %w", skill.ID, err)
+		}
+		ref := loc.Ref
+		if cached, ok, err := r.Cache.Get(skill.ID, ref); err != nil {
+			return "", nil, err
+		} else if ok {
+			return ref, cached, nil
+		}
+		if r.Offline {
+			return "", nil, fmt.Errorf("skill %q is not cached and --offline is set", skill.ID)
+		}
+		files, err := r.Installer.Fetch(ctx, loc)
+		if err != nil {
+			return "", nil, fmt.Errorf("skill %q: %w", skill.ID, err)
+		}
+		if err := r.Cache.Put(skill.ID, ref, files); err != nil {
+			return "", nil, err
+		}
+		return ref, files, nil
+	}
+
+	ref := skill.Version
+	if cached, ok, err := r.Cache.Get(skill.ID, ref); err != nil {
+		return "", nil, err
+	} else if ok {
+		return ref, cached, nil
+	}
+	if r.Offline {
+		return "", nil, fmt.Errorf("skill %q is not cached and --offline is set", skill.ID)
+	}
+	body, err := r.Client.FetchByID(ctx, skill.ID, skill.Version)
+	if err != nil {
+		return "", nil, err
+	}
+	files := map[string][]byte{SkillFile: body}
+	if err := r.Cache.Put(skill.ID, ref, files); err != nil {
+		return "", nil, err
+	}
+	return ref, files, nil
 }
 
 // ResolveAll resolves every skill in skills, returning the resolved

--- a/internal/registry/resolver_test.go
+++ b/internal/registry/resolver_test.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -18,8 +19,9 @@ func newTestResolver(t *testing.T, handler http.HandlerFunc) (*Resolver, func())
 		t.Fatalf("NewCache: %v", err)
 	}
 	return &Resolver{
-		Client: NewClient(srv.URL + "/skills/"),
-		Cache:  cache,
+		Client:    NewClient(srv.URL + "/skills/"),
+		Installer: NewInstaller(),
+		Cache:     cache,
 	}, srv.Close
 }
 
@@ -45,8 +47,8 @@ func TestResolver_Bare(t *testing.T) {
 	if resolved.Name != "company-policy" || resolved.Description != "Internal rules" {
 		t.Errorf("unexpected resolved metadata: %+v", resolved)
 	}
-	if len(resolved.Body) != 0 {
-		t.Errorf("bare skill should not have Body, got %q", resolved.Body)
+	if len(resolved.Files) != 0 {
+		t.Errorf("bare skill should not have Files, got %d entries", len(resolved.Files))
 	}
 }
 
@@ -85,6 +87,9 @@ func TestResolver_FetchAndCache(t *testing.T) {
 	if len(resolved.Tags) != 1 || resolved.Tags[0] != "analytics" {
 		t.Errorf("unexpected tags: %v", resolved.Tags)
 	}
+	if _, ok := resolved.Files["SKILL.md"]; !ok {
+		t.Errorf("expected resolved.Files to contain SKILL.md, got keys: %v", keysOf(resolved.Files))
+	}
 	if calls != 1 {
 		t.Errorf("expected 1 registry call, got %d", calls)
 	}
@@ -110,27 +115,106 @@ func TestResolver_OfflineMissingCache(t *testing.T) {
 	}
 }
 
-func TestResolver_SourceOverride(t *testing.T) {
-	var seenPath string
+func TestResolver_SourceRejectsNonGitHub(t *testing.T) {
 	resolver, closer := newTestResolver(t, func(w http.ResponseWriter, r *http.Request) {
-		seenPath = r.URL.Path
-		_, _ = w.Write([]byte("---\nname: external\ndescription: from override\n---\nbody\n"))
+		t.Fatalf("should not hit registry when source is invalid")
 	})
 	defer closer()
 
-	skill := schema.Skill{
-		ID:     "external-skill",
-		Source: resolver.Client.BaseURL + "../custom/path/external.md",
+	_, err := resolver.Resolve(context.Background(), schema.Skill{
+		ID:     "external",
+		Source: "https://example.com/some/skill.md",
+	})
+	if err == nil || !strings.Contains(err.Error(), "github.com") {
+		t.Fatalf("expected github.com URL error, got %v", err)
+	}
+}
+
+func TestResolver_SourceFetchesGitHubDirectory(t *testing.T) {
+	files := map[string]string{
+		"skills/skill-creator/SKILL.md":         "---\nname: skill-creator\ndescription: from gh\n---\nbody\n",
+		"skills/skill-creator/scripts/hello.sh": "#!/bin/sh\necho hi\n",
 	}
 
-	resolved, err := resolver.Resolve(context.Background(), skill)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/acme/skills/git/trees/main", func(w http.ResponseWriter, r *http.Request) {
+		resp := treeResponse{
+			Tree: []treeEntry{
+				{Path: "skills/skill-creator", Type: "tree"},
+				{Path: "skills/skill-creator/SKILL.md", Type: "blob"},
+				{Path: "skills/skill-creator/scripts", Type: "tree"},
+				{Path: "skills/skill-creator/scripts/hello.sh", Type: "blob"},
+				{Path: "skills/other-skill/SKILL.md", Type: "blob"},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		var body string
+		var ok bool
+		for repoPath, content := range files {
+			if strings.HasSuffix(r.URL.Path, "/"+repoPath) {
+				body = content
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(body))
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	cache, err := NewCache(t.TempDir())
 	if err != nil {
-		t.Fatalf("Resolve with source override: %v", err)
+		t.Fatalf("NewCache: %v", err)
 	}
-	if resolved.Name != "external" {
-		t.Errorf("unexpected name: %q", resolved.Name)
+	resolver := &Resolver{
+		Client: NewClient(""),
+		Installer: &Installer{
+			Client:  srv.Client(),
+			APIBase: srv.URL,
+			RawBase: srv.URL,
+		},
+		Cache: cache,
 	}
-	if !strings.Contains(seenPath, "external.md") {
-		t.Errorf("expected fetch through source override path, got %s", seenPath)
+
+	resolved, err := resolver.Resolve(context.Background(), schema.Skill{
+		ID:     "skill-creator",
+		Source: "https://github.com/acme/skills/tree/main/skills/skill-creator",
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
 	}
+	if resolved.Name != "skill-creator" || resolved.Description != "from gh" {
+		t.Errorf("unexpected metadata: %+v", resolved)
+	}
+	if len(resolved.Files) != 2 {
+		t.Fatalf("expected 2 files (SKILL.md + scripts/hello.sh), got %d: %v", len(resolved.Files), keysOf(resolved.Files))
+	}
+	if _, ok := resolved.Files["SKILL.md"]; !ok {
+		t.Errorf("missing SKILL.md, got keys: %v", keysOf(resolved.Files))
+	}
+	if _, ok := resolved.Files["scripts/hello.sh"]; !ok {
+		t.Errorf("missing scripts/hello.sh, got keys: %v", keysOf(resolved.Files))
+	}
+	if resolved.Version != "main" {
+		t.Errorf("expected Version derived from ref 'main', got %q", resolved.Version)
+	}
+
+	if _, ok, err := resolver.Cache.Get("skill-creator", "main"); err != nil || !ok {
+		t.Errorf("expected cache to be populated after Resolve, got ok=%v err=%v", ok, err)
+	}
+}
+
+func keysOf(m map[string][]byte) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }

--- a/internal/templates/registry.go
+++ b/internal/templates/registry.go
@@ -165,7 +165,9 @@ func (r *Registry) getGoFiles(adl *schema.ADL) map[string]string {
 	}
 
 	for _, skill := range adl.Spec.Skills {
-		files[fmt.Sprintf("skills/%s/SKILL.md", skill.ID)] = "skills/skill.md"
+		if skill.Bare {
+			files[fmt.Sprintf("skills/%s/SKILL.md", skill.ID)] = "skills/skill.md"
+		}
 	}
 
 	files["internal/logger/logger.go"] = "logger.go"
@@ -218,7 +220,9 @@ func (r *Registry) getRustFiles(adl *schema.ADL) map[string]string {
 	}
 
 	for _, skill := range adl.Spec.Skills {
-		files[fmt.Sprintf("skills/%s/SKILL.md", skill.ID)] = "skills/skill.md"
+		if skill.Bare {
+			files[fmt.Sprintf("skills/%s/SKILL.md", skill.ID)] = "skills/skill.md"
+		}
 	}
 
 	if adl.Spec.Sandbox != nil &&
@@ -264,7 +268,9 @@ func (r *Registry) getTypeScriptFiles(adl *schema.ADL) map[string]string {
 	}
 
 	for _, skill := range adl.Spec.Skills {
-		files[fmt.Sprintf("skills/%s/SKILL.md", skill.ID)] = "skills/skill.md"
+		if skill.Bare {
+			files[fmt.Sprintf("skills/%s/SKILL.md", skill.ID)] = "skills/skill.md"
+		}
 	}
 
 	r.addSandboxFiles(adl, files)


### PR DESCRIPTION
## Summary

- `spec.skills[].source:` now pulls an entire skill directory (SKILL.md + bundled scripts/reference docs) from GitHub via the trees API + `raw.githubusercontent.com`, instead of doing a single-file HTTP GET. Non-`github.com` URLs are rejected so the path always produces a complete bundle.
- Shorthand grammar extended to `<skill>[@<tag>]` and `<owner>/<repo>/<skill>[@<tag>]` (the 2-segment `<org>/<skill>` form was dropped — it silently rewrote to `<org>/skills` which was misleading).
- Skill cache reshaped from single-file blobs (`~/.adl/skills-cache/<id>@<ver>.md`) to per-skill directories (`~/.adl/skills-cache/<id>@<ref>/`) with stale-clear on write.

## What's in the diff

- `internal/registry/installer.go` (new) — `ExpandShorthand`, `ParseGitHubTreeURL`, `Installer.Fetch` (tree listing + per-blob download). Ported from `inference-gateway/cli/internal/services/skills/install.go`.
- `internal/registry/cache.go` — per-skill directory layout, stale-clear on Put.
- `internal/registry/resolver.go` — `ResolvedSkill.Body []byte` → `ResolvedSkill.Files map[string][]byte`; routes `source:` through `Installer`, keeps registry-by-id for unsourced skills.
- `internal/registry/client.go` — `FetchURL` removed (now handled by `Installer`); `FetchByID` kept for the no-source registry path.
- `internal/generator/generator.go` — writes every resolved skill file under `skills/<id>/<rel-path>`; bare skills still scaffolded via the template engine.
- `internal/templates/registry.go` — the `skills/<id>/SKILL.md` template mapping is now bare-skill-only.
- Tests: `cache_test.go`, `client_test.go`, `resolver_test.go` updated; new `installer_test.go` with 14 shorthand cases + URL-parsing + installer fetch.
- Docs: README "Skills vs. Tools" section rewritten with the new resolution rules and a shorthand grammar table; CLAUDE.md kept in sync.

## Followup

Filed #109 for the next step: replacing the runtime body-concat-into-system-prompt with a frontmatter manifest, plus built-in `Read` and `Bash` tools ported from `inference-gateway/cli`. **Not in this PR.**
