### PR TITLE
feat(skills+tools): Skill manifest + reserved-ID built-in tools (closes #109)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,24 +73,27 @@ main.go                       # Entry point, sets version
 
 - `ADL` - Root structure with `apiVersion`, `kind`, `metadata`, `spec`
 - `Spec` - Contains `capabilities`, `agent`, `tools`, `skills`, `services`, `server`, `language`, `deployment`
-- `Tool` - Function-call entrypoint with `id`, `name`, `schema`, `inject` (for service injection). Generated as code in the target language.
-- `Skill` - Markdown playbook with `id` plus optional `version`/`source`/`bare`/`name`/`description`/`tags`. Generated as `skills/<id>/SKILL.md` (Anthropic-style directory layout — bare skills may ship bundled scripts/resources alongside), advertised on the agent card, prepended to the system prompt at runtime.
+- `Tool` - Function-call entrypoint with `id` (only `id` is required since v0.4.0). User-defined tools also set `name`, `description`, `tags`, `schema`, optional `inject`. Reserved IDs (`read`, `bash`, `write`, `edit`) take `id` alone — the generator owns metadata. See `internal/schema/builtin_config.go` for the reserved-ID set.
+- `Skill` - Markdown playbook with `id` plus optional `version`/`source`/`bare`/`name`/`description`/`tags`. Generated as `skills/<id>/SKILL.md`. **At runtime, only the frontmatter is consumed** — the body lives on disk and the model reads it on demand via the `Read` built-in.
 - `Service` - Injectable service with `interface`, `factory`, `description`
 
 ### Tools vs Skills
 
-- **Tools** are functions the agent can invoke. Defined under `spec.tools`. Each one becomes code in the target language with a JSON schema.
-- **Skills** are markdown documents (YAML frontmatter + body) injected into the system prompt at startup. Defined under `spec.skills`. Each is generated under `skills/<id>/SKILL.md` (one directory per skill, Anthropic-style layout — bundled scripts/resources may live alongside `SKILL.md`). Resolution paths:
-  - **`bare: true`** → scaffolded from inline `name`/`description`/`tags`; the whole `skills/<id>/` directory is listed in `.adl-ignore` so user-authored assets survive regeneration.
-  - **`source:` set** → must be a `github.com` `/tree/<ref>/<path>` URL or one of the shorthand forms below; the full directory is fetched (SKILL.md + bundled assets) via the GitHub trees API + `raw.githubusercontent.com`. Implemented in `internal/registry/installer.go`.
-  - **Otherwise** → fetch `registry.inference-gateway.com/skills/<id>[/<version>].md` (override with `ADL_SKILLS_REGISTRY`). Registry-by-id ships SKILL.md only.
+- **Tools** are functions the agent can invoke. Defined under `spec.tools`. Two kinds:
+  - **User tools** — full entry (`id`, `name`, `description`, `tags`, `schema`, optional `inject`). Generated as `tools/<id>.<ext>` from `tool.<ext>.tmpl`.
+  - **Reserved built-ins** — `id` only. Currently `read`, `bash`, `write`, `edit`. Generated from `builtin/<id>.<ext>.tmpl`. **All four default to `enabled: false`**; activate via `spec.config.tools.<id>.enabled: true`. The Read built-in is what loads SKILL.md bodies on demand — `spec.skills` non-empty REQUIRES `- id: read` listed AND enabled (validator enforces).
+- **Skills** are markdown documents (YAML frontmatter + body). The frontmatter (`name`/`description`) is consumed at runtime to build an `AVAILABLE SKILLS:` block appended to the system prompt; the body is fetched on demand by the model via Read. Each skill goes to `skills/<id>/SKILL.md`. Resolution paths unchanged:
+  - **`bare: true`** → scaffolded from inline `name`/`description`/`tags`; the whole `skills/<id>/` directory is listed in `.adl-ignore`.
+  - **`source:` set** → must be a `github.com` `/tree/<ref>/<path>` URL or one of the shorthand forms below; the full directory is fetched via the GitHub trees API + `raw.githubusercontent.com`. Implemented in `internal/registry/installer.go`.
+  - **Otherwise** → fetch `registry.inference-gateway.com/skills/<id>[/<version>].md`. Registry-by-id ships SKILL.md only.
 
-  `source:` shorthand (an optional `@<tag>` pins a branch/tag/SHA, default `main`):
-  - `<skill>[@<tag>]` → `inference-gateway/skills` repo
-  - `<owner>/<repo>/<skill>[@<tag>]` → arbitrary repo (assumes a `skills/<id>/` subdir, matching Anthropic's convention)
-  - Full `https://github.com/...` URL → passed through
+  `source:` shorthand (optional `@<tag>` pins branch/tag/SHA, default `main`): `<skill>[@<tag>]` → `inference-gateway/skills`; `<owner>/<repo>/<skill>[@<tag>]` → arbitrary repo; full URL passes through. Non-`github.com` URLs are rejected. `adl generate --offline` skips network; every non-bare skill must be cached at `~/.adl/skills-cache/<id>@<ref>/`.
 
-  Non-`github.com` URLs are rejected so the source path always produces a complete bundle. `adl generate --offline` skips network fetches; every non-bare skill must be cached at `~/.adl/skills-cache/<id>@<ref>/`.
+### Reserved tool config (`spec.config.tools.<id>`)
+
+Built-in config lives under the reserved `spec.config.tools` namespace (not `spec.config.<id>` — that name is reserved). The validator decodes each block into a typed struct in `internal/schema/builtin_config.go` (`ReadBuiltinConfig`, `BashBuiltinConfig`, `WriteBuiltinConfig`, `EditBuiltinConfig`) with `ErrorUnused: true`, so typos surface immediately as `spec.config.tools.bash.tymeout_seconds`. Values flow into the generated runtime as compile-time literals in `main.<ext>`'s tool-registration block — they do NOT flow through `config/config.go` (which explicitly skips the `tools` section).
+
+Bash env-var runtime overrides (read inside `tools/bash.<ext>`): `A2A_BASH_DISABLED=1` (kill switch), `A2A_BASH_WHITELIST=ls,cat,grep`. Resolution precedence: **env > compile-time literal > built-in default (disabled)**.
 
 ### Service Injection
 

--- a/README.md
+++ b/README.md
@@ -631,7 +631,7 @@ The 3-segment form assumes a `skills/<id>/` subdirectory inside the repo (the co
 
 The generated agent advertises skills to the LLM via a frontmatter-only manifest, **not** by inlining SKILL.md bodies. At startup it walks first-level subdirectories under `skills/` (overridable with `A2A_SKILLS_DIR`), parses each `<id>/SKILL.md`'s YAML frontmatter, and appends an `AVAILABLE SKILLS:` block to the system prompt:
 
-```
+```text
 AVAILABLE SKILLS:
 Skills are reusable instructions for specific tasks. When a task matches a
 skill's description, read the SKILL.md file at the listed path using the Read

--- a/README.md
+++ b/README.md
@@ -627,7 +627,76 @@ Concrete examples:
 
 The 3-segment form assumes a `skills/<id>/` subdirectory inside the repo (the convention used by both `inference-gateway/skills` and `anthropics/skills`). If your repo lays skills out differently, pass the full URL.
 
-At runtime, the generated agent walks first-level subdirectories under `skills/` (overridable with `A2A_SKILLS_DIR`), reads each `<id>/SKILL.md`, strips frontmatter, and concatenates the bodies onto the configured `systemPrompt`. Both Go and Rust runtimes ship with this loader baked into `main.go` / `main.rs`.
+### Runtime: AVAILABLE SKILLS manifest + on-demand Read
+
+The generated agent advertises skills to the LLM via a frontmatter-only manifest, **not** by inlining SKILL.md bodies. At startup it walks first-level subdirectories under `skills/` (overridable with `A2A_SKILLS_DIR`), parses each `<id>/SKILL.md`'s YAML frontmatter, and appends an `AVAILABLE SKILLS:` block to the system prompt:
+
+```
+AVAILABLE SKILLS:
+Skills are reusable instructions for specific tasks. When a task matches a
+skill's description, read the SKILL.md file at the listed path using the Read
+tool, then follow its instructions.
+
+- incident-response: Use this when the user reports a production incident...
+  Path: skills/incident-response/SKILL.md
+- pdf: Fill in PDF forms and extract structured data from PDFs.
+  Path: skills/pdf/SKILL.md
+```
+
+The model loads each SKILL.md body on demand via the `Read` built-in tool, and executes any bundled scripts via `Bash` / `Write` / `Edit`. **A skills-using agent must therefore list `- id: read` in `spec.tools` and set `spec.config.tools.read.enabled: true`** — the validator enforces this; see [Reserved built-in tools](#reserved-built-in-tools).
+
+### Reserved built-in tools
+
+`spec.tools` accepts four reserved IDs that map to framework-supplied implementations:
+
+| Reserved ID | Generated as            | Purpose                                                          |
+| ----------- | ----------------------- | ---------------------------------------------------------------- |
+| `read`      | `tools/read.go` etc.    | Read a file (`file_path`, optional `offset`/`limit`).            |
+| `bash`      | `tools/bash.go` etc.    | Execute a shell command (subject to whitelist + timeout).        |
+| `write`     | `tools/write.go` etc.   | Write content to a file (creates parent dirs).                   |
+| `edit`      | `tools/edit.go` etc.    | Replace a unique string in a file (`old_string` → `new_string`). |
+
+Opt in by listing the id alone — the generator owns `name`, `description`, and the JSON schema:
+
+```yaml
+spec:
+  tools:
+    - id: read
+    - id: bash
+    - id: query_database       # user tool: full entry still required
+      name: query_database
+      description: "..."
+      schema: { type: object, ... }
+```
+
+**All four built-ins default to `enabled: false`.** Activate them via the reserved namespace `spec.config.tools.<id>`:
+
+```yaml
+spec:
+  config:
+    tools:
+      read:
+        enabled: true
+        max_lines: 2000          # offset/limit default window
+        allowed_roots: []        # empty = project-wide
+      bash:
+        enabled: true
+        whitelist: [ls, cat, grep, jq]
+        timeout_seconds: 30
+      write:
+        enabled: false           # listed but explicitly disabled
+      edit:
+        enabled: true
+```
+
+Values are baked into the generated constructor as compile-time literals — there's no `ToolsConfig` struct in `config/config.go` because reserved-namespace sections are intentionally skipped. The validator decodes each `spec.config.tools.<id>` block into the built-in's typed shape and rejects unknown keys (typos like `tymeout_seconds` fail with `spec.config.tools.bash.tymeout_seconds`).
+
+Runtime overrides for Bash (read inside `tools/bash.go`):
+
+- `A2A_BASH_DISABLED=1` is a kill switch — overrides `enabled: true` back to false.
+- `A2A_BASH_WHITELIST=ls,cat,grep` overrides the compile-time whitelist.
+
+Resolution precedence at runtime: **env > compile-time literal > built-in default (disabled)**.
 
 ## Service Injection & Configuration Management
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,7 +5,7 @@ vars:
   VERSION: 0.29.0
   BUILD_DIR: bin
   DIST_DIR: dist
-  ADL_SCHEMA_VERSION: v0.3.0
+  ADL_SCHEMA_VERSION: v0.4.0
   ADL_SCHEMA_URL: https://raw.githubusercontent.com/inference-gateway/adl/{{.ADL_SCHEMA_VERSION}}/schema/v1/schema.json
   ADL_SCHEMA_PATH: internal/schema/schema.json
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -139,15 +139,19 @@ tasks:
     cmds:
       - rm -rf test-output
       - mkdir -p test-output
-      - ./{{.BUILD_DIR}}/{{.APP_NAME}} generate --file examples/go-agent.yaml --output test-output/go-agent --overwrite
-      - ./{{.BUILD_DIR}}/{{.APP_NAME}} generate --file examples/go-agent-artifacts-filesystem.yaml --output test-output/go-agent-artifacts-filesystem --overwrite
-      - ./{{.BUILD_DIR}}/{{.APP_NAME}} generate --file examples/go-agent-artifacts-minio.yaml --output test-output/go-agent-artifacts-minio --overwrite
-      - ./{{.BUILD_DIR}}/{{.APP_NAME}} generate --file examples/cloudrun-agent.yaml --output test-output/cloudrun-agent --overwrite
-      - ./{{.BUILD_DIR}}/{{.APP_NAME}} generate --file examples/cloudrun-ghcr-agent.yaml --output test-output/cloudrun-ghcr-agent --overwrite
-      - ./{{.BUILD_DIR}}/{{.APP_NAME}} generate --file examples/kubernetes-agent.yaml --output test-output/kubernetes-agent --overwrite
-      - ./{{.BUILD_DIR}}/{{.APP_NAME}} generate --file examples/rust-agent.yaml --output test-output/rust-agent --overwrite
-      - ./{{.BUILD_DIR}}/{{.APP_NAME}} generate --file examples/rust-agent-redis.yaml --output test-output/rust-agent-redis --overwrite
-      - ./{{.BUILD_DIR}}/{{.APP_NAME}} generate --file examples/rust-agent-ai.yaml --output test-output/rust-agent-ai --overwrite
+      - for:
+          - go-agent
+          - go-agent-artifacts-filesystem
+          - go-agent-artifacts-minio
+          - cloudrun-agent
+          - cloudrun-ghcr-agent
+          - kubernetes-agent
+          - rust-agent
+          - rust-agent-redis
+          - rust-agent-ai
+        cmd: |
+          ./{{.BUILD_DIR}}/{{.APP_NAME}} generate --file examples/{{.ITEM}}.yaml --output test-output/{{.ITEM}} --overwrite
+          cp examples/{{.ITEM}}.yaml test-output/{{.ITEM}}/agent.yaml
 
   release:
     desc: Build release binaries for multiple platforms

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -17,9 +17,9 @@ tasks:
       - go build -ldflags "-X main.Version={{.VERSION}}" -o {{.BUILD_DIR}}/{{.APP_NAME}} .
 
   install:
-    desc: Install the adl CLI to GOPATH/bin
+    desc: Install the adl CLI to GOPATH/bin as 'adl'
     cmds:
-      - go install -ldflags "-X main.Version={{.VERSION}}" .
+      - go build -ldflags "-X main.Version={{.VERSION}}" -o "$(go env GOPATH)/bin/{{.APP_NAME}}" .
 
   test:
     desc: Run tests

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -63,10 +63,13 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to resolve output directory path: %w", err)
 	}
 
-	// Validate ADL file before generation
 	validator := schema.NewValidator()
-	if err := validator.ValidateFile(adlFile); err != nil {
+	warnings, err := validator.ValidateFile(adlFile)
+	if err != nil {
 		return fmt.Errorf("ADL validation failed: %w", err)
+	}
+	for _, w := range warnings {
+		fmt.Fprintf(os.Stderr, "⚠️  %s\n", w)
 	}
 
 	gen := generator.New(generator.Config{

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -81,7 +81,12 @@ spec:
   agent:
     provider: deepseek
     model: deepseek-v4-flash
+  config:
+    tools:
+      read:
+        enabled: true
   tools:
+    - id: read
     - id: test_tool_id
       name: test_tool
       description: A test tool

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -251,7 +251,7 @@ type adlData struct {
 			Provider       string `yaml:"provider"`
 			URL            string `yaml:"url,omitempty"`
 			GithubApp      bool   `yaml:"github_app,omitempty"`
-			IssueTemplates bool   `yaml:"issue_templates,omitempty"`
+			IssueTemplates bool   `yaml:"issue_templates"`
 		} `yaml:"scm,omitempty"`
 		Sandbox *struct {
 			Flox *struct {
@@ -718,7 +718,7 @@ func collectADLInfo(cmd *cobra.Command, projectName string, useDefaults bool) *a
 			Provider       string `yaml:"provider"`
 			URL            string `yaml:"url,omitempty"`
 			GithubApp      bool   `yaml:"github_app,omitempty"`
-			IssueTemplates bool   `yaml:"issue_templates,omitempty"`
+			IssueTemplates bool   `yaml:"issue_templates"`
 		}{
 			Provider: scmProvider,
 		}
@@ -737,10 +737,10 @@ func collectADLInfo(cmd *cobra.Command, projectName string, useDefaults bool) *a
 			adl.Spec.SCM.GithubApp = conditionalPromptBool(useDefaults, "Enable GitHub App integration", true)
 
 			if useDefaults {
-				adl.Spec.SCM.IssueTemplates = true
-				fmt.Printf("Enable issue templates [y/n] [y]: y\n")
+				adl.Spec.SCM.IssueTemplates = false
+				fmt.Printf("Enable issue templates [y/n] [n]: n\n")
 			} else {
-				adl.Spec.SCM.IssueTemplates = promptBool("Enable issue templates", true)
+				adl.Spec.SCM.IssueTemplates = promptBool("Enable issue templates", false)
 			}
 		}
 	}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -79,7 +79,7 @@ func TestInitCommandIncludesSCMDefaults(t *testing.T) {
 	if !strings.Contains(contentStr, "github_app: true") {
 		t.Errorf("ADL file missing SCM github_app default")
 	}
-	if !strings.Contains(contentStr, "issue_templates: true") {
+	if !strings.Contains(contentStr, "issue_templates: false") {
 		t.Errorf("ADL file missing SCM issue_templates default")
 	}
 
@@ -128,8 +128,8 @@ func TestInitIssueTemplatesDefault(t *testing.T) {
 	}
 
 	contentStr := string(content)
-	if !strings.Contains(contentStr, "issue_templates: true") {
-		t.Errorf("ADL file should contain 'issue_templates: true'")
+	if !strings.Contains(contentStr, "issue_templates: false") {
+		t.Errorf("ADL file should contain 'issue_templates: false'")
 	}
 }
 

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -120,8 +120,8 @@ func TestInitIssueTemplatesDefault(t *testing.T) {
 	if adl.Spec.SCM.Provider != "github" {
 		t.Errorf("expected SCM provider to be 'github', got: %s", adl.Spec.SCM.Provider)
 	}
-	if !adl.Spec.SCM.IssueTemplates {
-		t.Errorf("expected IssueTemplates to be true by default")
+	if adl.Spec.SCM.IssueTemplates {
+		t.Errorf("expected IssueTemplates to be false by default")
 	}
 	if !adl.Spec.SCM.GithubApp {
 		t.Errorf("expected GithubApp to be true by default")

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -37,9 +37,14 @@ func runValidate(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Validating '%s'...\n", adlFile)
 
 	validator := schema.NewValidator()
-	if err := validator.ValidateFile(adlFile); err != nil {
+	warnings, err := validator.ValidateFile(adlFile)
+	if err != nil {
 		fmt.Printf("❌ Validation failed: %v\n", err)
 		return err
+	}
+
+	for _, w := range warnings {
+		fmt.Fprintf(os.Stderr, "⚠️  %s\n", w)
 	}
 
 	fmt.Printf("✅ '%s' is valid!\n", adlFile)

--- a/examples/cloudrun-agent.yaml
+++ b/examples/cloudrun-agent.yaml
@@ -44,7 +44,7 @@ spec:
   scm:
     provider: github
     url: "https://github.com/example/cloudrun-example"
-    issue_templates: true
+    issue_templates: false
   deployment:
     type: cloudrun
     cloudrun:

--- a/examples/go-agent-artifacts-filesystem.yaml
+++ b/examples/go-agent-artifacts-filesystem.yaml
@@ -90,7 +90,7 @@ spec:
     provider: github
     url: "https://github.com/inference-gateway/adl-cli"
     github_app: true
-    issue_templates: true
+    issue_templates: false
   sandbox:
     flox:
       enabled: true

--- a/examples/go-agent-artifacts-minio.yaml
+++ b/examples/go-agent-artifacts-minio.yaml
@@ -106,7 +106,7 @@ spec:
     provider: github
     url: "https://github.com/inference-gateway/adl-cli"
     github_app: true
-    issue_templates: true
+    issue_templates: false
   sandbox:
     flox:
       enabled: true

--- a/examples/go-agent.yaml
+++ b/examples/go-agent.yaml
@@ -32,6 +32,14 @@ spec:
     maxTokens: 8192
     temperature: 0.3
   config:
+    tools:
+      read:
+        enabled: true
+        max_lines: 2000
+      bash:
+        enabled: true
+        whitelist: [ls, cat, grep, jq, find]
+        timeout_seconds: 30
     database:
       connectionString: "postgresql://user:pass@localhost:5432/company_db"
       maxConnections: "10"
@@ -64,6 +72,8 @@ spec:
       factory: NewReportingService
       description: Business report generation service with multiple output formats
   tools:
+    - id: read
+    - id: bash
     - id: query_database
       name: query_database
       description: "Query the company database with proper authentication"

--- a/examples/go-agent.yaml
+++ b/examples/go-agent.yaml
@@ -38,7 +38,12 @@ spec:
         max_lines: 2000
       bash:
         enabled: true
-        whitelist: [ls, cat, grep, jq, find]
+        whitelist:
+          - ls
+          - cat
+          - grep
+          - jq
+          - find
         timeout_seconds: 30
     database:
       connectionString: "postgresql://user:pass@localhost:5432/company_db"

--- a/examples/go-agent.yaml
+++ b/examples/go-agent.yaml
@@ -207,7 +207,7 @@ spec:
     provider: github
     url: "https://github.com/inference-gateway/adl-cli"
     github_app: true
-    issue_templates: true
+    issue_templates: false
   sandbox:
     flox:
       enabled: true

--- a/examples/kubernetes-agent.yaml
+++ b/examples/kubernetes-agent.yaml
@@ -44,7 +44,7 @@ spec:
   scm:
     provider: github
     url: "https://github.com/example/kubernetes-example"
-    issue_templates: true
+    issue_templates: false
   deployment:
     type: kubernetes
     kubernetes:

--- a/examples/rust-agent.yaml
+++ b/examples/rust-agent.yaml
@@ -17,7 +17,23 @@ spec:
       - text
     defaultOutputModes:
       - text
+  agent:
+    provider: deepseek
+    model: deepseek-v4-flash
+    systemPrompt: |
+      You are a helpful echo assistant. When a request mentions formatting
+      (JSON, code blocks, whitespace cleanup) read the echo-formatting
+      skill at skills/echo-formatting/SKILL.md first, then apply its
+      guidance before invoking the echo tool.
+    maxTokens: 2048
+    temperature: 0.3
+  config:
+    tools:
+      read:
+        enabled: true
+        max_lines: 2000
   tools:
+    - id: read
     - id: echo
       name: echo
       description: "Echo a message back to the caller"

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.2
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/chzyer/readline v1.5.1
+	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/xeipuuv/gojsonschema v1.2.0
@@ -16,7 +17,6 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -590,23 +590,14 @@ func (g *Generator) getVersion() string {
 	return "dev"
 }
 
-// buildGenerateCommand constructs the original adl generate command from the config
+// buildGenerateCommand constructs the adl generate command embedded in the
+// generated Taskfile. Paths are always the in-project canonical values
+// (agent.yaml at the project root) so the task works after `cd` into the
+// generated project, regardless of how `adl generate` was originally invoked.
 func (g *Generator) buildGenerateCommand() string {
 	var parts []string
 
-	parts = append(parts, "adl", "generate")
-
-	if g.config.ADLFile != "" {
-		parts = append(parts, "--file", g.config.ADLFile)
-	} else {
-		parts = append(parts, "--file", "agent.yaml")
-	}
-
-	if g.config.OutputDir != "" {
-		parts = append(parts, "--output", g.config.OutputDir)
-	} else {
-		parts = append(parts, "--output", ".")
-	}
+	parts = append(parts, "adl", "generate", "--file", "agent.yaml", "--output", ".")
 
 	if g.config.Template != "" && g.config.Template != "minimal" {
 		parts = append(parts, "--template", g.config.Template)

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -209,6 +209,9 @@ func (g *Generator) validateADL(adl *schema.ADL) error {
 		if tool.ID == "" {
 			return fmt.Errorf("spec.tools[%d].id is required", i)
 		}
+		if schema.IsReservedToolID(tool.ID) {
+			continue
+		}
 		if tool.Name == "" {
 			return fmt.Errorf("spec.tools[%d].name is required", i)
 		}
@@ -280,6 +283,11 @@ func (g *Generator) generateProject(templateEngine *templates.Engine, adl *schem
 		})
 	}
 
+	builtinConfigs, err := schema.ResolveBuiltinConfigs(adl)
+	if err != nil {
+		return fmt.Errorf("failed to resolve built-in tool config: %w", err)
+	}
+
 	ctx := templates.Context{
 		ADL: adl,
 		Metadata: schema.GeneratedMetadata{
@@ -293,6 +301,7 @@ func (g *Generator) generateProject(templateEngine *templates.Engine, adl *schem
 		EnableAI:        g.config.EnableAI,
 		GenerateCommand: g.buildGenerateCommand(),
 		Skills:          skillViews,
+		BuiltinConfigs:  builtinConfigs,
 	}
 
 	ignoreChecker, err := NewIgnoreChecker(outputDir)
@@ -357,7 +366,8 @@ func (g *Generator) generateProject(templateEngine *templates.Engine, adl *schem
 					return fmt.Errorf("service %s not found in ADL spec", serviceName)
 				}
 			}
-		} else if (templateKey == "tool.go" || templateKey == "tool.rs" || templateKey == "tool.ts") && strings.Contains(fileName, "/") {
+		} else if (templateKey == "tool.go" || templateKey == "tool.rs" || templateKey == "tool.ts" ||
+			strings.HasPrefix(templateKey, "builtin/")) && strings.Contains(fileName, "/") {
 			parts := strings.Split(fileName, "/")
 			if len(parts) >= 2 {
 				toolFileName := parts[len(parts)-1]
@@ -398,6 +408,18 @@ func (g *Generator) generateProject(templateEngine *templates.Engine, adl *schem
 						}
 					}
 					toolContext["ServiceMap"] = serviceMap
+
+					if schema.IsReservedToolID(foundTool.ID) {
+						var rawCfg any
+						if toolsCfg, ok := adl.Spec.Config["tools"]; ok {
+							rawCfg = toolsCfg[foundTool.ID]
+						}
+						decoded, decodeErr := schema.DecodeBuiltinToolConfig(foundTool.ID, rawCfg)
+						if decodeErr != nil {
+							return fmt.Errorf("failed to decode built-in tool config for %s: %w", foundTool.ID, decodeErr)
+						}
+						toolContext["Config"] = decoded
+					}
 
 					content, err = templateEngine.ExecuteToolTemplateWithContext(templateKey, toolContext, ctx)
 					if err != nil {
@@ -638,6 +660,9 @@ func (g *Generator) generateADLIgnoreFile(outputDir, templateName string, adl *s
 		switch language {
 		case "go":
 			for _, tool := range adl.Spec.Tools {
+				if schema.IsReservedToolID(tool.ID) {
+					continue
+				}
 				snakeCaseName := strings.ReplaceAll(tool.ID, "-", "_")
 				filesToIgnore = append(filesToIgnore, fmt.Sprintf("tools/%s.go", snakeCaseName))
 			}
@@ -649,12 +674,18 @@ func (g *Generator) generateADLIgnoreFile(outputDir, templateName string, adl *s
 		case "rust":
 			if adl.Spec.Agent != nil {
 				for _, tool := range adl.Spec.Tools {
+					if schema.IsReservedToolID(tool.ID) {
+						continue
+					}
 					snakeCaseName := strings.ReplaceAll(tool.ID, "-", "_")
 					filesToIgnore = append(filesToIgnore, fmt.Sprintf("src/tools/%s.rs", snakeCaseName))
 				}
 			}
 		case "typescript":
 			for _, tool := range adl.Spec.Tools {
+				if schema.IsReservedToolID(tool.ID) {
+					continue
+				}
 				snakeCaseName := strings.ReplaceAll(tool.ID, "-", "_")
 				filesToIgnore = append(filesToIgnore, fmt.Sprintf("src/tools/%s.ts", snakeCaseName))
 			}

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -577,7 +577,7 @@ func TestGenerator_buildGenerateCommand(t *testing.T) {
 			expectedCmd: "adl generate --file agent.yaml --output .",
 		},
 		{
-			name: "config with all flags",
+			name: "config with all flags rewrites paths to in-project canonical values",
 			config: Config{
 				ADLFile:            "my-agent.yaml",
 				OutputDir:          "./output",
@@ -590,7 +590,7 @@ func TestGenerator_buildGenerateCommand(t *testing.T) {
 				EnableDevContainer: true,
 				EnableAI:           true,
 			},
-			expectedCmd: "adl generate --file my-agent.yaml --output ./output --template custom --overwrite --ci --cd --deployment kubernetes --flox --devcontainer --ai",
+			expectedCmd: "adl generate --file agent.yaml --output . --template custom --overwrite --ci --cd --deployment kubernetes --flox --devcontainer --ai",
 		},
 		{
 			name: "config reproducing the issue scenario",

--- a/internal/schema/builtin_config.go
+++ b/internal/schema/builtin_config.go
@@ -1,0 +1,155 @@
+package schema
+
+import (
+	"fmt"
+
+	"github.com/go-viper/mapstructure/v2"
+)
+
+// ReservedToolID is the set of tool IDs that map to built-in
+// implementations supplied by the generator. Users opt in by listing one
+// of these under spec.tools, then enable + tune via spec.config.tools.<id>.
+type ReservedToolID string
+
+const (
+	ReservedToolRead  ReservedToolID = "read"
+	ReservedToolBash  ReservedToolID = "bash"
+	ReservedToolWrite ReservedToolID = "write"
+	ReservedToolEdit  ReservedToolID = "edit"
+)
+
+// ReservedToolIDs is the lookup set used by validator/generator to detect
+// reserved IDs. Keep in sync with the constants above.
+var ReservedToolIDs = map[string]struct{}{
+	string(ReservedToolRead):  {},
+	string(ReservedToolBash):  {},
+	string(ReservedToolWrite): {},
+	string(ReservedToolEdit):  {},
+}
+
+// IsReservedToolID reports whether id maps to a built-in implementation.
+func IsReservedToolID(id string) bool {
+	_, ok := ReservedToolIDs[id]
+	return ok
+}
+
+// ReadBuiltinConfig is the typed shape of spec.config.tools.read.
+type ReadBuiltinConfig struct {
+	Enabled      bool     `mapstructure:"enabled"`
+	MaxLines     int      `mapstructure:"max_lines"`
+	AllowedRoots []string `mapstructure:"allowed_roots"`
+}
+
+// BashBuiltinConfig is the typed shape of spec.config.tools.bash.
+type BashBuiltinConfig struct {
+	Enabled        bool     `mapstructure:"enabled"`
+	Whitelist      []string `mapstructure:"whitelist"`
+	TimeoutSeconds int      `mapstructure:"timeout_seconds"`
+	WorkingDir     string   `mapstructure:"working_dir"`
+}
+
+// WriteBuiltinConfig is the typed shape of spec.config.tools.write.
+type WriteBuiltinConfig struct {
+	Enabled      bool     `mapstructure:"enabled"`
+	AllowedRoots []string `mapstructure:"allowed_roots"`
+}
+
+// EditBuiltinConfig is the typed shape of spec.config.tools.edit.
+type EditBuiltinConfig struct {
+	Enabled      bool     `mapstructure:"enabled"`
+	AllowedRoots []string `mapstructure:"allowed_roots"`
+}
+
+// ResolvedBuiltinConfigs holds the decoded config blocks for every reserved
+// tool id present in spec.tools. Entries for absent ids carry default
+// (zero) values, which means Enabled=false (the safe default).
+type ResolvedBuiltinConfigs struct {
+	Read  ReadBuiltinConfig
+	Bash  BashBuiltinConfig
+	Write WriteBuiltinConfig
+	Edit  EditBuiltinConfig
+}
+
+// ResolveBuiltinConfigs decodes spec.config.tools.<reserved-id> into
+// typed structs. Missing sections yield zero-valued (disabled) configs.
+// Returns an error only if a present section has a bad shape or unknown
+// keys. The validator should have caught these already; this function
+// re-validates so codegen can rely on the result.
+func ResolveBuiltinConfigs(adl *ADL) (ResolvedBuiltinConfigs, error) {
+	var out ResolvedBuiltinConfigs
+	if adl == nil {
+		return out, nil
+	}
+	toolsCfg, ok := adl.Spec.Config["tools"]
+	if !ok {
+		return out, nil
+	}
+
+	if raw, present := toolsCfg[string(ReservedToolRead)]; present {
+		decoded, err := DecodeBuiltinToolConfig(string(ReservedToolRead), raw)
+		if err != nil {
+			return out, err
+		}
+		out.Read = *decoded.(*ReadBuiltinConfig)
+	}
+	if raw, present := toolsCfg[string(ReservedToolBash)]; present {
+		decoded, err := DecodeBuiltinToolConfig(string(ReservedToolBash), raw)
+		if err != nil {
+			return out, err
+		}
+		out.Bash = *decoded.(*BashBuiltinConfig)
+	}
+	if raw, present := toolsCfg[string(ReservedToolWrite)]; present {
+		decoded, err := DecodeBuiltinToolConfig(string(ReservedToolWrite), raw)
+		if err != nil {
+			return out, err
+		}
+		out.Write = *decoded.(*WriteBuiltinConfig)
+	}
+	if raw, present := toolsCfg[string(ReservedToolEdit)]; present {
+		decoded, err := DecodeBuiltinToolConfig(string(ReservedToolEdit), raw)
+		if err != nil {
+			return out, err
+		}
+		out.Edit = *decoded.(*EditBuiltinConfig)
+	}
+	return out, nil
+}
+
+// DecodeBuiltinToolConfig decodes the raw value under
+// spec.config.tools.<id> into the matching typed struct, rejecting any
+// keys the built-in doesn't know about. Returns a non-nil error with a
+// path-prefixed message ("spec.config.tools.<id>.<bad-key>") so callers
+// can surface a precise location. Accepts `any` to interoperate with
+// untyped YAML decoding.
+func DecodeBuiltinToolConfig(id string, raw any) (any, error) {
+	var target any
+	switch id {
+	case string(ReservedToolRead):
+		target = &ReadBuiltinConfig{}
+	case string(ReservedToolBash):
+		target = &BashBuiltinConfig{}
+	case string(ReservedToolWrite):
+		target = &WriteBuiltinConfig{}
+	case string(ReservedToolEdit):
+		target = &EditBuiltinConfig{}
+	default:
+		return nil, fmt.Errorf("not a reserved built-in tool id: %q", id)
+	}
+
+	if _, ok := raw.(map[string]any); !ok && raw != nil {
+		return nil, fmt.Errorf("spec.config.tools.%s must be a mapping (got %T)", id, raw)
+	}
+
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		ErrorUnused: true,
+		Result:      target,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("build decoder for spec.config.tools.%s: %w", id, err)
+	}
+	if err := decoder.Decode(raw); err != nil {
+		return nil, fmt.Errorf("spec.config.tools.%s: %w", id, err)
+	}
+	return target, nil
+}

--- a/internal/schema/builtin_config.go
+++ b/internal/schema/builtin_config.go
@@ -33,6 +33,54 @@ func IsReservedToolID(id string) bool {
 	return ok
 }
 
+// BuiltinToolMeta is the documentation-facing view of a reserved built-in
+// tool — the same information the generator bakes into the per-language
+// runtime descriptor, surfaced here so templates (README, CLAUDE.md) can
+// render a uniform table without each template re-stating it.
+type BuiltinToolMeta struct {
+	ID          string
+	Name        string
+	Description string
+	Parameters  []string
+}
+
+// BuiltinToolMetas maps reserved tool IDs to their documentation metadata.
+// Keep the Name/Description/Parameters here aligned with what each
+// language's `builtin/<id>.<ext>.tmpl` advertises to the LLM.
+var BuiltinToolMetas = map[string]BuiltinToolMeta{
+	string(ReservedToolRead): {
+		ID:          string(ReservedToolRead),
+		Name:        "Read",
+		Description: "Read a file from disk. Returns its contents, optionally sliced by line offset/limit. Use this to load SKILL.md bodies on demand.",
+		Parameters:  []string{"file_path", "offset", "limit"},
+	},
+	string(ReservedToolBash): {
+		ID:          string(ReservedToolBash),
+		Name:        "Bash",
+		Description: "Execute a shell command. Subject to the configured whitelist and timeout; honors A2A_BASH_DISABLED as a runtime kill switch.",
+		Parameters:  []string{"command"},
+	},
+	string(ReservedToolWrite): {
+		ID:          string(ReservedToolWrite),
+		Name:        "Write",
+		Description: "Write content to a file, creating intermediate directories as needed. Overwrites the file if it already exists.",
+		Parameters:  []string{"file_path", "content"},
+	},
+	string(ReservedToolEdit): {
+		ID:          string(ReservedToolEdit),
+		Name:        "Edit",
+		Description: "Replace a unique string in a file with a new value. Errors if old_string is not found or appears more than once.",
+		Parameters:  []string{"file_path", "old_string", "new_string"},
+	},
+}
+
+// BuiltinToolMetaFor returns the metadata for a reserved tool ID, or an
+// empty struct if id is not a reserved built-in. Templates can call this
+// unconditionally and check `.Name` to detect presence.
+func BuiltinToolMetaFor(id string) BuiltinToolMeta {
+	return BuiltinToolMetas[id]
+}
+
 // ReadBuiltinConfig is the typed shape of spec.config.tools.read.
 type ReadBuiltinConfig struct {
 	Enabled      bool     `mapstructure:"enabled"`

--- a/internal/schema/schema.json
+++ b/internal/schema/schema.json
@@ -140,8 +140,8 @@
     },
     "Tool": {
       "type": "object",
-      "description": "Function-call entrypoint the agent can invoke. Generated as code in the target language.",
-      "required": ["id", "name", "description", "tags", "schema"],
+      "description": "Function-call entrypoint the agent can invoke. Generated as code in the target language. User-defined tools require name, description, tags, and schema; reserved built-in IDs (e.g. read, bash, write, edit) may omit them and have those fields supplied by the generator.",
+      "required": ["id"],
       "additionalProperties": false,
       "properties": {
         "id": {

--- a/internal/schema/types.go
+++ b/internal/schema/types.go
@@ -387,10 +387,12 @@ type SpecConfig map[string]map[string]any
 type SpecServices map[string]Service
 
 // Function-call entrypoint the agent can invoke. Generated as code in the target
-// language.
+// language. User-defined tools require name, description, tags, and schema;
+// reserved built-in IDs (e.g. read, bash, write, edit) may omit them and have
+// those fields supplied by the generator.
 type Tool struct {
 	// Description corresponds to the JSON schema field "description".
-	Description string `json:"description" yaml:"description" mapstructure:"description"`
+	Description string `json:"description,omitempty,omitzero" yaml:"description,omitempty" mapstructure:"description,omitempty"`
 
 	// ID corresponds to the JSON schema field "id".
 	ID string `json:"id" yaml:"id" mapstructure:"id"`
@@ -399,13 +401,13 @@ type Tool struct {
 	Inject []string `json:"inject,omitempty,omitzero" yaml:"inject,omitempty" mapstructure:"inject,omitempty"`
 
 	// Name corresponds to the JSON schema field "name".
-	Name string `json:"name" yaml:"name" mapstructure:"name"`
+	Name string `json:"name,omitempty,omitzero" yaml:"name,omitempty" mapstructure:"name,omitempty"`
 
 	// Free-form JSON Schema describing the tool's input parameters.
-	Schema ToolSchema `json:"schema" yaml:"schema" mapstructure:"schema"`
+	Schema ToolSchema `json:"schema,omitempty,omitzero" yaml:"schema,omitempty" mapstructure:"schema,omitempty"`
 
 	// Tags corresponds to the JSON schema field "tags".
-	Tags []string `json:"tags" yaml:"tags" mapstructure:"tags"`
+	Tags []string `json:"tags,omitempty,omitzero" yaml:"tags,omitempty" mapstructure:"tags,omitempty"`
 }
 
 // Free-form JSON Schema describing the tool's input parameters.

--- a/internal/schema/validator.go
+++ b/internal/schema/validator.go
@@ -35,27 +35,30 @@ func NewValidator() *Validator {
 	}
 }
 
-// ValidateFile validates an ADL file
-func (v *Validator) ValidateFile(filePath string) error {
+// ValidateFile validates an ADL file. Returns any non-fatal warnings
+// that callers should surface to the user (e.g., a skills-using agent
+// that hasn't enabled the Read built-in). A nil error means the manifest
+// is structurally valid; warnings may still be present.
+func (v *Validator) ValidateFile(filePath string) ([]string, error) {
 	data, err := os.ReadFile(filePath)
 	if err != nil {
-		return fmt.Errorf("failed to read file: %w", err)
+		return nil, fmt.Errorf("failed to read file: %w", err)
 	}
 
 	var yamlData any
 	if err := yaml.Unmarshal(data, &yamlData); err != nil {
-		return fmt.Errorf("failed to parse YAML: %w", err)
+		return nil, fmt.Errorf("failed to parse YAML: %w", err)
 	}
 
 	jsonData, err := json.Marshal(yamlData)
 	if err != nil {
-		return fmt.Errorf("failed to convert to JSON: %w", err)
+		return nil, fmt.Errorf("failed to convert to JSON: %w", err)
 	}
 
 	documentLoader := gojsonschema.NewBytesLoader(jsonData)
 	result, err := v.schema.Validate(documentLoader)
 	if err != nil {
-		return fmt.Errorf("validation error: %w", err)
+		return nil, fmt.Errorf("validation error: %w", err)
 	}
 
 	if !result.Valid() {
@@ -63,24 +66,25 @@ func (v *Validator) ValidateFile(filePath string) error {
 		for _, desc := range result.Errors() {
 			errors = append(errors, desc.String())
 		}
-		return fmt.Errorf("validation failed:\n- %s", fmt.Sprintf("\n- %s", errors))
+		return nil, fmt.Errorf("validation failed:\n- %s", fmt.Sprintf("\n- %s", errors))
 	}
 
 	// Additional validation: check that injected services are defined
 	var adl ADL
 	if err := yaml.Unmarshal(data, &adl); err != nil {
-		return fmt.Errorf("failed to parse ADL for service validation: %w", err)
+		return nil, fmt.Errorf("failed to parse ADL for service validation: %w", err)
 	}
 
 	if err := v.validateTools(&adl); err != nil {
-		return fmt.Errorf("tool validation failed: %w", err)
+		return nil, fmt.Errorf("tool validation failed: %w", err)
 	}
 
-	if err := v.validateSkills(&adl); err != nil {
-		return fmt.Errorf("skill validation failed: %w", err)
+	warnings, err := v.validateSkills(&adl)
+	if err != nil {
+		return nil, fmt.Errorf("skill validation failed: %w", err)
 	}
 
-	return nil
+	return warnings, nil
 }
 
 // reservedConfigSection is the namespace inside spec.config dedicated to
@@ -156,24 +160,27 @@ func (v *Validator) validateTools(adl *ADL) error {
 	return nil
 }
 
-// validateSkills enforces bare-skill metadata and the skills-need-read
-// contract: any skills-using agent must list `- id: read` AND enable
-// `spec.config.tools.read.enabled: true`, otherwise the agent has no way
-// to load SKILL.md bodies at runtime.
-func (v *Validator) validateSkills(adl *ADL) error {
+// validateSkills enforces bare-skill metadata and surfaces non-fatal
+// warnings about the skills-need-read contract: a skills-using agent
+// should list `- id: read` AND enable `spec.config.tools.read.enabled:
+// true`, otherwise it can't load SKILL.md bodies at runtime. Returns
+// warnings (not errors) for the read-tool case so partially configured
+// manifests still pass validation — the warning prompts the user to fix
+// it.
+func (v *Validator) validateSkills(adl *ADL) ([]string, error) {
 	for _, skill := range adl.Spec.Skills {
 		if skill.Bare {
 			if skill.Name == "" {
-				return fmt.Errorf("skill '%s' has bare: true but is missing name", skill.ID)
+				return nil, fmt.Errorf("skill '%s' has bare: true but is missing name", skill.ID)
 			}
 			if skill.Description == "" {
-				return fmt.Errorf("skill '%s' has bare: true but is missing description", skill.ID)
+				return nil, fmt.Errorf("skill '%s' has bare: true but is missing description", skill.ID)
 			}
 		}
 	}
 
 	if len(adl.Spec.Skills) == 0 || adl.Spec.Agent == nil {
-		return nil
+		return nil, nil
 	}
 
 	hasReadTool := false
@@ -184,22 +191,28 @@ func (v *Validator) validateSkills(adl *ADL) error {
 		}
 	}
 	if !hasReadTool {
-		return fmt.Errorf("spec.skills is non-empty but spec.tools is missing '- id: read'; the agent needs the Read built-in to load SKILL.md bodies on demand")
+		return []string{
+			"spec.skills is non-empty but spec.tools is missing '- id: read'; the AVAILABLE SKILLS manifest will be added to the system prompt but the agent has no Read built-in to load SKILL.md bodies. Add '- id: read' to spec.tools and set spec.config.tools.read.enabled: true.",
+		}, nil
 	}
 
 	toolsCfg := adl.Spec.Config[reservedConfigSection]
 	readRaw, ok := toolsCfg[string(ReservedToolRead)]
 	if !ok {
-		return fmt.Errorf("spec.skills is non-empty and '- id: read' is listed, but spec.config.tools.read is missing; set spec.config.tools.read.enabled: true")
+		return []string{
+			"spec.skills is non-empty and '- id: read' is listed, but spec.config.tools.read is missing; the Read built-in will register in a disabled state and fail at runtime. Set spec.config.tools.read.enabled: true.",
+		}, nil
 	}
 	decoded, err := DecodeBuiltinToolConfig(string(ReservedToolRead), readRaw)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	readCfg, ok := decoded.(*ReadBuiltinConfig)
 	if !ok || !readCfg.Enabled {
-		return fmt.Errorf("spec.skills is non-empty but spec.config.tools.read.enabled is not true; set spec.config.tools.read.enabled: true so the agent can load SKILL.md bodies")
+		return []string{
+			"spec.skills is non-empty but spec.config.tools.read.enabled is not true; the Read built-in will register in a disabled state and fail at runtime. Set spec.config.tools.read.enabled: true so the agent can load SKILL.md bodies.",
+		}, nil
 	}
 
-	return nil
+	return nil, nil
 }

--- a/internal/schema/validator.go
+++ b/internal/schema/validator.go
@@ -72,32 +72,78 @@ func (v *Validator) ValidateFile(filePath string) error {
 		return fmt.Errorf("failed to parse ADL for service validation: %w", err)
 	}
 
-	if err := v.validateServiceReferences(&adl); err != nil {
-		return fmt.Errorf("service validation failed: %w", err)
+	if err := v.validateTools(&adl); err != nil {
+		return fmt.Errorf("tool validation failed: %w", err)
+	}
+
+	if err := v.validateSkills(&adl); err != nil {
+		return fmt.Errorf("skill validation failed: %w", err)
 	}
 
 	return nil
 }
 
-// validateServiceReferences checks that all injected services are defined in the spec
-func (v *Validator) validateServiceReferences(adl *ADL) error {
-	definedServices := make(map[string]bool)
+// reservedConfigSection is the namespace inside spec.config dedicated to
+// built-in tool config (spec.config.tools.<id>). User-defined services
+// cannot inject from it.
+const reservedConfigSection = "tools"
+
+// validateTools enforces the contract for both user-defined and reserved
+// (built-in) tool IDs and the integrity of spec.config.tools.<id>.
+func (v *Validator) validateTools(adl *ADL) error {
+	definedServices := map[string]bool{"logger": true, "config": true}
 	for serviceName := range adl.Spec.Services {
 		definedServices[serviceName] = true
 	}
-
-	definedServices["logger"] = true
-	definedServices["config"] = true
 
 	definedConfigSections := make(map[string]bool)
 	for configSection := range adl.Spec.Config {
 		definedConfigSections[configSection] = true
 	}
 
+	toolsCfg := adl.Spec.Config[reservedConfigSection]
+
 	for _, tool := range adl.Spec.Tools {
+		if IsReservedToolID(tool.ID) {
+			if tool.Name != "" {
+				return fmt.Errorf("reserved tool '%s' must not set 'name' (the generator supplies it)", tool.ID)
+			}
+			if tool.Description != "" {
+				return fmt.Errorf("reserved tool '%s' must not set 'description' (the generator supplies it)", tool.ID)
+			}
+			if len(tool.Schema) > 0 {
+				return fmt.Errorf("reserved tool '%s' must not set 'schema' (the generator supplies it)", tool.ID)
+			}
+			if len(tool.Inject) > 0 {
+				return fmt.Errorf("reserved tool '%s' must not set 'inject' (built-ins do not use service injection)", tool.ID)
+			}
+			if raw, ok := toolsCfg[tool.ID]; ok {
+				if _, err := DecodeBuiltinToolConfig(tool.ID, raw); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+
+		if tool.Name == "" {
+			return fmt.Errorf("tool '%s' must set 'name' (only reserved built-in IDs may omit it)", tool.ID)
+		}
+		if tool.Description == "" {
+			return fmt.Errorf("tool '%s' must set 'description'", tool.ID)
+		}
+		if len(tool.Tags) == 0 {
+			return fmt.Errorf("tool '%s' must set 'tags' (at least one)", tool.ID)
+		}
+		if len(tool.Schema) == 0 {
+			return fmt.Errorf("tool '%s' must set 'schema'", tool.ID)
+		}
+
 		for _, injectedService := range tool.Inject {
 			if len(injectedService) > 7 && injectedService[:7] == "config." {
 				configSection := injectedService[7:]
+				if configSection == reservedConfigSection {
+					return fmt.Errorf("tool '%s' injects reserved namespace 'config.tools'; this namespace is owned by built-in tools and cannot be inject-referenced", tool.ID)
+				}
 				if !definedConfigSections[configSection] {
 					return fmt.Errorf("tool '%s' injects config section '%s' that is not defined in spec.config", tool.ID, configSection)
 				}
@@ -107,6 +153,14 @@ func (v *Validator) validateServiceReferences(adl *ADL) error {
 		}
 	}
 
+	return nil
+}
+
+// validateSkills enforces bare-skill metadata and the skills-need-read
+// contract: any skills-using agent must list `- id: read` AND enable
+// `spec.config.tools.read.enabled: true`, otherwise the agent has no way
+// to load SKILL.md bodies at runtime.
+func (v *Validator) validateSkills(adl *ADL) error {
 	for _, skill := range adl.Spec.Skills {
 		if skill.Bare {
 			if skill.Name == "" {
@@ -116,6 +170,35 @@ func (v *Validator) validateServiceReferences(adl *ADL) error {
 				return fmt.Errorf("skill '%s' has bare: true but is missing description", skill.ID)
 			}
 		}
+	}
+
+	if len(adl.Spec.Skills) == 0 || adl.Spec.Agent == nil {
+		return nil
+	}
+
+	hasReadTool := false
+	for _, tool := range adl.Spec.Tools {
+		if tool.ID == string(ReservedToolRead) {
+			hasReadTool = true
+			break
+		}
+	}
+	if !hasReadTool {
+		return fmt.Errorf("spec.skills is non-empty but spec.tools is missing '- id: read'; the agent needs the Read built-in to load SKILL.md bodies on demand")
+	}
+
+	toolsCfg := adl.Spec.Config[reservedConfigSection]
+	readRaw, ok := toolsCfg[string(ReservedToolRead)]
+	if !ok {
+		return fmt.Errorf("spec.skills is non-empty and '- id: read' is listed, but spec.config.tools.read is missing; set spec.config.tools.read.enabled: true")
+	}
+	decoded, err := DecodeBuiltinToolConfig(string(ReservedToolRead), readRaw)
+	if err != nil {
+		return err
+	}
+	readCfg, ok := decoded.(*ReadBuiltinConfig)
+	if !ok || !readCfg.Enabled {
+		return fmt.Errorf("spec.skills is non-empty but spec.config.tools.read.enabled is not true; set spec.config.tools.read.enabled: true so the agent can load SKILL.md bodies")
 	}
 
 	return nil

--- a/internal/schema/validator_test.go
+++ b/internal/schema/validator_test.go
@@ -45,7 +45,7 @@ spec:
 	}
 
 	validator := NewValidator()
-	if err := validator.ValidateFile(tmpFile.Name()); err != nil {
+	if _, err := validator.ValidateFile(tmpFile.Name()); err != nil {
 		t.Errorf("Validation failed for valid ADL: %v", err)
 	}
 }
@@ -94,7 +94,7 @@ spec:
 	}
 
 	validator := NewValidator()
-	if err := validator.ValidateFile(tmpFile.Name()); err != nil {
+	if _, err := validator.ValidateFile(tmpFile.Name()); err != nil {
 		t.Errorf("Validation failed for ADL with agent section but no provider: %v", err)
 	}
 }
@@ -173,7 +173,7 @@ spec:
 				t.Fatalf("close: %v", err)
 			}
 
-			err = NewValidator().ValidateFile(tmpFile.Name())
+			_, err = NewValidator().ValidateFile(tmpFile.Name())
 			if tc.wantErr && err == nil {
 				t.Fatalf("expected validation error, got nil")
 			}
@@ -209,7 +209,7 @@ metadata:
 	}
 
 	validator := NewValidator()
-	if err := validator.ValidateFile(tmpFile.Name()); err == nil {
+	if _, err := validator.ValidateFile(tmpFile.Name()); err == nil {
 		t.Error("Expected validation to fail for invalid ADL")
 	}
 }
@@ -220,6 +220,7 @@ func TestValidator_SkillsAndTools(t *testing.T) {
 		adl     string
 		wantErr bool
 		errSub  string
+		warnSub string
 	}{
 		{
 			name: "tool and bare skill both valid with read built-in",
@@ -266,7 +267,7 @@ spec:
 			wantErr: false,
 		},
 		{
-			name: "skills present but no read tool is rejected",
+			name: "skills present but no read tool surfaces a warning",
 			adl: `apiVersion: adl.inference-gateway.com/v1
 kind: Agent
 metadata:
@@ -293,11 +294,11 @@ spec:
       module: "github.com/example/x"
       version: "1.26.2"
 `,
-			wantErr: true,
-			errSub:  "missing '- id: read'",
+			wantErr: false,
+			warnSub: "missing '- id: read'",
 		},
 		{
-			name: "skills with read listed but not enabled is rejected",
+			name: "skills with read listed but not enabled surfaces a warning",
 			adl: `apiVersion: adl.inference-gateway.com/v1
 kind: Agent
 metadata:
@@ -326,8 +327,8 @@ spec:
       module: "github.com/example/x"
       version: "1.26.2"
 `,
-			wantErr: true,
-			errSub:  "spec.config.tools.read.enabled",
+			wantErr: false,
+			warnSub: "spec.config.tools.read.enabled",
 		},
 		{
 			name: "skills without agent are allowed even without read",
@@ -561,7 +562,7 @@ spec:
 				t.Fatalf("Failed to close: %v", err)
 			}
 
-			err = NewValidator().ValidateFile(tmpFile.Name())
+			warnings, err := NewValidator().ValidateFile(tmpFile.Name())
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected validation error, got nil")
@@ -573,6 +574,20 @@ spec:
 			}
 			if err != nil {
 				t.Fatalf("unexpected validation error: %v", err)
+			}
+			if tc.warnSub != "" {
+				matched := false
+				for _, w := range warnings {
+					if strings.Contains(w, tc.warnSub) {
+						matched = true
+						break
+					}
+				}
+				if !matched {
+					t.Fatalf("expected warning containing %q, got %v", tc.warnSub, warnings)
+				}
+			} else if len(warnings) > 0 {
+				t.Fatalf("expected no warnings, got %v", warnings)
 			}
 		})
 	}

--- a/internal/schema/validator_test.go
+++ b/internal/schema/validator_test.go
@@ -222,7 +222,7 @@ func TestValidator_SkillsAndTools(t *testing.T) {
 		errSub  string
 	}{
 		{
-			name: "tool and bare skill both valid",
+			name: "tool and bare skill both valid with read built-in",
 			adl: `apiVersion: adl.inference-gateway.com/v1
 kind: Agent
 metadata:
@@ -234,7 +234,12 @@ spec:
     streaming: true
     pushNotifications: false
     stateTransitionHistory: false
+  config:
+    tools:
+      read:
+        enabled: true
   tools:
+    - id: read
     - id: ping
       name: ping
       description: "Ping a host"
@@ -256,6 +261,219 @@ spec:
   language:
     go:
       module: "github.com/example/split"
+      version: "1.26.2"
+`,
+			wantErr: false,
+		},
+		{
+			name: "skills present but no read tool is rejected",
+			adl: `apiVersion: adl.inference-gateway.com/v1
+kind: Agent
+metadata:
+  name: no-read
+  description: "skills without read"
+  version: "0.1.0"
+spec:
+  capabilities:
+    streaming: true
+    pushNotifications: false
+    stateTransitionHistory: false
+  agent:
+    provider: deepseek
+    model: deepseek-v4-flash
+  skills:
+    - id: x
+      bare: true
+      name: x
+      description: "x"
+  server:
+    port: 8080
+  language:
+    go:
+      module: "github.com/example/x"
+      version: "1.26.2"
+`,
+			wantErr: true,
+			errSub:  "missing '- id: read'",
+		},
+		{
+			name: "skills with read listed but not enabled is rejected",
+			adl: `apiVersion: adl.inference-gateway.com/v1
+kind: Agent
+metadata:
+  name: read-disabled
+  description: "skills with disabled read"
+  version: "0.1.0"
+spec:
+  capabilities:
+    streaming: true
+    pushNotifications: false
+    stateTransitionHistory: false
+  agent:
+    provider: deepseek
+    model: deepseek-v4-flash
+  tools:
+    - id: read
+  skills:
+    - id: x
+      bare: true
+      name: x
+      description: "x"
+  server:
+    port: 8080
+  language:
+    go:
+      module: "github.com/example/x"
+      version: "1.26.2"
+`,
+			wantErr: true,
+			errSub:  "spec.config.tools.read.enabled",
+		},
+		{
+			name: "skills without agent are allowed even without read",
+			adl: `apiVersion: adl.inference-gateway.com/v1
+kind: Agent
+metadata:
+  name: no-agent-with-skills
+  description: "skills used as documentation, no agent loop"
+  version: "0.1.0"
+spec:
+  capabilities:
+    streaming: true
+    pushNotifications: false
+    stateTransitionHistory: false
+  skills:
+    - id: x
+      bare: true
+      name: x
+      description: "x"
+  server:
+    port: 8080
+  language:
+    go:
+      module: "github.com/example/x"
+      version: "1.26.2"
+`,
+			wantErr: false,
+		},
+		{
+			name: "reserved tool with user-supplied name is rejected",
+			adl: `apiVersion: adl.inference-gateway.com/v1
+kind: Agent
+metadata:
+  name: reserved-with-name
+  description: "reserved id must be id-only"
+  version: "0.1.0"
+spec:
+  capabilities:
+    streaming: true
+    pushNotifications: false
+    stateTransitionHistory: false
+  tools:
+    - id: bash
+      name: MyBash
+  server:
+    port: 8080
+  language:
+    go:
+      module: "github.com/example/x"
+      version: "1.26.2"
+`,
+			wantErr: true,
+			errSub:  "reserved tool 'bash' must not set 'name'",
+		},
+		{
+			name: "reserved tool config with unknown key is rejected",
+			adl: `apiVersion: adl.inference-gateway.com/v1
+kind: Agent
+metadata:
+  name: typo-config
+  description: "unknown config key under bash"
+  version: "0.1.0"
+spec:
+  capabilities:
+    streaming: true
+    pushNotifications: false
+    stateTransitionHistory: false
+  config:
+    tools:
+      bash:
+        enabled: true
+        tymeout_seconds: 30
+  tools:
+    - id: bash
+  server:
+    port: 8080
+  language:
+    go:
+      module: "github.com/example/x"
+      version: "1.26.2"
+`,
+			wantErr: true,
+			errSub:  "spec.config.tools.bash",
+		},
+		{
+			name: "inject config.tools is rejected",
+			adl: `apiVersion: adl.inference-gateway.com/v1
+kind: Agent
+metadata:
+  name: inject-reserved
+  description: "user tool tries to inject the reserved namespace"
+  version: "0.1.0"
+spec:
+  capabilities:
+    streaming: true
+    pushNotifications: false
+    stateTransitionHistory: false
+  tools:
+    - id: nope
+      name: nope
+      description: "Tries to grab reserved config"
+      tags: [bad]
+      inject:
+        - config.tools
+      schema:
+        type: object
+        properties:
+          x:
+            type: string
+        required: [x]
+  server:
+    port: 8080
+  language:
+    go:
+      module: "github.com/example/x"
+      version: "1.26.2"
+`,
+			wantErr: true,
+			errSub:  "reserved namespace 'config.tools'",
+		},
+		{
+			name: "reserved tool id-only entry is valid",
+			adl: `apiVersion: adl.inference-gateway.com/v1
+kind: Agent
+metadata:
+  name: minimal-bash
+  description: "minimal reserved entry"
+  version: "0.1.0"
+spec:
+  capabilities:
+    streaming: true
+    pushNotifications: false
+    stateTransitionHistory: false
+  config:
+    tools:
+      bash:
+        enabled: true
+        whitelist: [ls, cat]
+        timeout_seconds: 30
+  tools:
+    - id: bash
+  server:
+    port: 8080
+  language:
+    go:
+      module: "github.com/example/x"
       version: "1.26.2"
 `,
 			wantErr: false,

--- a/internal/templates/common/docs/README.md.tmpl
+++ b/internal/templates/common/docs/README.md.tmpl
@@ -85,7 +85,11 @@ infer agents add {{ .ADL.Metadata.Name }} {{ .ADL.Spec.Server.Scheme | default "
 | Tool | Description | Parameters |
 |------|-------------|------------|
 {{- range .ADL.Spec.Tools }}
+{{- if isBuiltinToolID .ID }}{{- $m := builtinToolMeta .ID }}
+| `{{ $m.Name }}` | {{ $m.Description }} | {{ if $m.Parameters }}{{ $m.Parameters | join ", " }}{{ else }}None{{ end }} |
+{{- else }}
 | `{{ .Name }}` | {{ .Description }} | {{- if .Schema.properties }}{{- $props := list }}{{- range $key, $value := .Schema.properties }}{{- $props = append $props $key }}{{- end }} {{ $props | join ", " }} {{- else }} None {{- end }} |
+{{- end }}
 {{- end }}
 
 {{- if .Skills }}

--- a/internal/templates/engine.go
+++ b/internal/templates/engine.go
@@ -323,6 +323,8 @@ func customFuncMap() template.FuncMap {
 	funcMap["toJson"] = toJson
 	funcMap["toGoMap"] = toGoMap
 	funcMap["findDependencyByID"] = findDependencyByID
+	funcMap["isBuiltinToolID"] = schema.IsReservedToolID
+	funcMap["builtinToolMeta"] = schema.BuiltinToolMetaFor
 	return funcMap
 }
 
@@ -351,6 +353,8 @@ func customFuncMapWithAcronyms(acronyms map[string]string) template.FuncMap {
 	funcMap["toJson"] = toJson
 	funcMap["toGoMap"] = toGoMap
 	funcMap["findDependencyByID"] = findDependencyByID
+	funcMap["isBuiltinToolID"] = schema.IsReservedToolID
+	funcMap["builtinToolMeta"] = schema.BuiltinToolMetaFor
 	return funcMap
 }
 

--- a/internal/templates/engine.go
+++ b/internal/templates/engine.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"text/template"
 	"unicode"
@@ -224,7 +225,7 @@ func NewWithRegistry(templateName string, registry *Registry) *Engine {
 }
 
 // toJson converts a value to JSON string representation
-func toJson(v interface{}) string {
+func toJson(v any) string {
 	jsonBytes, err := json.Marshal(v)
 	if err != nil {
 		return "{}"
@@ -233,60 +234,72 @@ func toJson(v interface{}) string {
 }
 
 // toGoMap converts a value to Go map literal string representation
-func toGoMap(v interface{}) string {
+func toGoMap(v any) string {
 	return convertToGoMapLiteral(v)
 }
 
-// convertToGoMapLiteral recursively converts values to Go map literal format
-func convertToGoMapLiteral(v interface{}) string {
-	switch val := v.(type) {
-	case map[string]interface{}:
-		if len(val) == 0 {
+// convertToGoMapLiteral recursively converts values to Go map literal format.
+// Uses reflection so named map/slice types (e.g. schema.ToolSchema) decoded by
+// yaml.v3 — which propagates the named type to nested maps — are handled the
+// same as plain map[string]any / []any.
+func convertToGoMapLiteral(v any) string {
+	if s, ok := v.(string); ok {
+		return fmt.Sprintf(`"%s"`, s)
+	}
+
+	rv := reflect.ValueOf(v)
+	if !rv.IsValid() {
+		return "nil"
+	}
+
+	switch rv.Kind() {
+	case reflect.Map:
+		if rv.Type().Key().Kind() != reflect.String {
+			break
+		}
+		if rv.Len() == 0 {
 			return "map[string]any{}"
 		}
 		result := "map[string]any{"
 		first := true
-		for k, v := range val {
+		iter := rv.MapRange()
+		for iter.Next() {
 			if !first {
 				result += ", "
 			}
 			first = false
-			result += fmt.Sprintf(`"%s": %s`, k, convertToGoMapLiteral(v))
+			result += fmt.Sprintf(`"%s": %s`, iter.Key().String(), convertToGoMapLiteral(iter.Value().Interface()))
 		}
 		result += "}"
 		return result
-	case []interface{}:
-		if len(val) == 0 {
+	case reflect.Slice, reflect.Array:
+		n := rv.Len()
+		if n == 0 {
 			return "[]string{}"
 		}
 
 		allStrings := true
-		for _, item := range val {
-			if _, ok := item.(string); !ok {
+		for i := 0; i < n; i++ {
+			if _, ok := rv.Index(i).Interface().(string); !ok {
 				allStrings = false
 				break
 			}
 		}
 		if allStrings {
 			result := "[]string{"
-			for i, item := range val {
+			for i := 0; i < n; i++ {
 				if i > 0 {
 					result += ", "
 				}
-				result += fmt.Sprintf(`"%s"`, item.(string))
+				result += fmt.Sprintf(`"%s"`, rv.Index(i).Interface().(string))
 			}
 			result += "}"
 			return result
 		}
-
-		jsonBytes, _ := json.Marshal(val)
-		return string(jsonBytes)
-	case string:
-		return fmt.Sprintf(`"%s"`, val)
-	default:
-		jsonBytes, _ := json.Marshal(val)
-		return string(jsonBytes)
 	}
+
+	jsonBytes, _ := json.Marshal(v)
+	return string(jsonBytes)
 }
 
 // findDependencyByID finds a dependency by name in the dependencies slice

--- a/internal/templates/engine.go
+++ b/internal/templates/engine.go
@@ -204,6 +204,7 @@ type Context struct {
 	EnableAI        bool
 	GenerateCommand string
 	Skills          []SkillView
+	BuiltinConfigs  schema.ResolvedBuiltinConfigs
 	customAcronyms  map[string]string
 }
 

--- a/internal/templates/languages/go/builtin/bash.go.tmpl
+++ b/internal/templates/languages/go/builtin/bash.go.tmpl
@@ -1,0 +1,152 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	server "github.com/inference-gateway/adk/server"
+	zap "go.uber.org/zap"
+)
+
+// BashConfig is the compile-time config for the Bash built-in. Values
+// flow in from spec.config.tools.bash at generation time. Runtime env
+// vars `A2A_BASH_DISABLED` and `A2A_BASH_WHITELIST` override the
+// compile-time values.
+type BashConfig struct {
+	Enabled        bool
+	Whitelist      []string
+	TimeoutSeconds int
+	WorkingDir     string
+}
+
+// BashTool exposes a Bash built-in. Disabled by default; flip
+// spec.config.tools.bash.enabled: true in your ADL to activate.
+// Resolution: env > compile-time literal > built-in default.
+type BashTool struct {
+	logger *zap.Logger
+	cfg    BashConfig
+}
+
+// NewBashTool builds a Bash tool with the resolved config baked in.
+// Env-var overrides are read here, once, at agent startup.
+func NewBashTool(logger *zap.Logger, cfg BashConfig) server.Tool {
+	if cfg.TimeoutSeconds <= 0 {
+		cfg.TimeoutSeconds = 30
+	}
+	if os.Getenv("A2A_BASH_DISABLED") == "1" {
+		cfg.Enabled = false
+	}
+	if v := os.Getenv("A2A_BASH_WHITELIST"); v != "" {
+		parts := strings.Split(v, ",")
+		out := make([]string, 0, len(parts))
+		for _, p := range parts {
+			if trimmed := strings.TrimSpace(p); trimmed != "" {
+				out = append(out, trimmed)
+			}
+		}
+		cfg.Whitelist = out
+	}
+	t := &BashTool{logger: logger, cfg: cfg}
+	return server.NewBasicTool(
+		"Bash",
+		"Execute a shell command. Subject to the configured whitelist and timeout; honors A2A_BASH_DISABLED as a runtime kill switch.",
+		map[string]any{
+			"type":                 "object",
+			"additionalProperties": false,
+			"properties": map[string]any{
+				"command": map[string]any{
+					"type":        "string",
+					"description": "The shell command to execute.",
+				},
+			},
+			"required": []string{"command"},
+		},
+		t.Handler,
+	)
+}
+
+// Handler executes the Bash tool.
+func (t *BashTool) Handler(ctx context.Context, args map[string]any) (string, error) {
+	if !t.cfg.Enabled {
+		return "", errors.New("Bash tool is disabled; set spec.config.tools.bash.enabled: true and ensure A2A_BASH_DISABLED is not 1")
+	}
+
+	command, _ := args["command"].(string)
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return "", errors.New("command is required")
+	}
+
+	if err := t.checkWhitelist(command); err != nil {
+		return "", err
+	}
+
+	timeout := time.Duration(t.cfg.TimeoutSeconds) * time.Second
+	cmdCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(cmdCtx, "sh", "-c", command)
+	if t.cfg.WorkingDir != "" {
+		cmd.Dir = t.cfg.WorkingDir
+	}
+
+	start := time.Now()
+	out, runErr := cmd.CombinedOutput()
+	duration := time.Since(start)
+
+	exitCode := 0
+	stderrTrunc := ""
+	if runErr != nil {
+		var exitErr *exec.ExitError
+		if errors.As(runErr, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else if errors.Is(cmdCtx.Err(), context.DeadlineExceeded) {
+			stderrTrunc = fmt.Sprintf("bash timed out after %s", timeout)
+			exitCode = -1
+		} else {
+			stderrTrunc = runErr.Error()
+			exitCode = -1
+		}
+	}
+
+	result := map[string]any{
+		"command":     command,
+		"exit_code":   exitCode,
+		"duration_ms": duration.Milliseconds(),
+		"output":      string(out),
+	}
+	if stderrTrunc != "" {
+		result["error"] = stderrTrunc
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return "", fmt.Errorf("encode Bash result: %w", err)
+	}
+	t.logger.Debug("bash executed", zap.String("command", command), zap.Int("exit", exitCode))
+	return string(payload), nil
+}
+
+// checkWhitelist enforces the configured whitelist (if any). An empty
+// whitelist allows any command (the operator is opting into Bash with
+// no command restrictions).
+func (t *BashTool) checkWhitelist(command string) error {
+	if len(t.cfg.Whitelist) == 0 {
+		return nil
+	}
+	for _, allowed := range t.cfg.Whitelist {
+		allowed = strings.TrimSpace(allowed)
+		if allowed == "" {
+			continue
+		}
+		if command == allowed || strings.HasPrefix(command, allowed+" ") {
+			return nil
+		}
+	}
+	return fmt.Errorf("command %q is not in the configured whitelist", command)
+}

--- a/internal/templates/languages/go/builtin/edit.go.tmpl
+++ b/internal/templates/languages/go/builtin/edit.go.tmpl
@@ -1,0 +1,125 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	server "github.com/inference-gateway/adk/server"
+	zap "go.uber.org/zap"
+)
+
+// EditConfig is the compile-time config for the Edit built-in. Values
+// flow in from spec.config.tools.edit at generation time.
+type EditConfig struct {
+	Enabled      bool
+	AllowedRoots []string
+}
+
+// EditTool exposes an Edit built-in. Disabled by default; flip
+// spec.config.tools.edit.enabled: true in your ADL to activate.
+type EditTool struct {
+	logger *zap.Logger
+	cfg    EditConfig
+}
+
+// NewEditTool builds an Edit tool with the resolved config baked in.
+func NewEditTool(logger *zap.Logger, cfg EditConfig) server.Tool {
+	t := &EditTool{logger: logger, cfg: cfg}
+	return server.NewBasicTool(
+		"Edit",
+		"Replace a unique string in a file with a new value. Errors if old_string is not found or appears more than once.",
+		map[string]any{
+			"type":                 "object",
+			"additionalProperties": false,
+			"properties": map[string]any{
+				"file_path": map[string]any{
+					"type":        "string",
+					"description": "Path to the file to edit.",
+				},
+				"old_string": map[string]any{
+					"type":        "string",
+					"description": "Exact string in the file to replace. Must be unique.",
+				},
+				"new_string": map[string]any{
+					"type":        "string",
+					"description": "Replacement string.",
+				},
+			},
+			"required": []string{"file_path", "old_string", "new_string"},
+		},
+		t.Handler,
+	)
+}
+
+// Handler executes the Edit tool.
+func (t *EditTool) Handler(ctx context.Context, args map[string]any) (string, error) {
+	if !t.cfg.Enabled {
+		return "", errors.New("Edit tool is disabled; set spec.config.tools.edit.enabled: true in the ADL and regenerate")
+	}
+
+	rawPath, _ := args["file_path"].(string)
+	if rawPath == "" {
+		return "", errors.New("file_path is required")
+	}
+	oldStr, ok := args["old_string"].(string)
+	if !ok || oldStr == "" {
+		return "", errors.New("old_string is required and must be non-empty")
+	}
+	newStr, ok := args["new_string"].(string)
+	if !ok {
+		return "", errors.New("new_string is required")
+	}
+
+	if err := t.validatePath(rawPath); err != nil {
+		return "", err
+	}
+
+	cleaned := filepath.Clean(rawPath)
+	data, err := os.ReadFile(cleaned)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", cleaned, err)
+	}
+	body := string(data)
+	count := strings.Count(body, oldStr)
+	if count == 0 {
+		return "", fmt.Errorf("old_string not found in %s", cleaned)
+	}
+	if count > 1 {
+		return "", fmt.Errorf("old_string appears %d times in %s; refusing to edit (must be unique)", count, cleaned)
+	}
+
+	replaced := strings.Replace(body, oldStr, newStr, 1)
+	if err := os.WriteFile(cleaned, []byte(replaced), 0o644); err != nil {
+		return "", fmt.Errorf("write %s: %w", cleaned, err)
+	}
+
+	t.logger.Debug("edit executed", zap.String("path", cleaned))
+	result := map[string]any{
+		"file_path":    cleaned,
+		"replacements": 1,
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return "", fmt.Errorf("encode Edit result: %w", err)
+	}
+	return string(payload), nil
+}
+
+func (t *EditTool) validatePath(p string) error {
+	if len(t.cfg.AllowedRoots) == 0 {
+		return nil
+	}
+	cleaned := filepath.Clean(p)
+	for _, root := range t.cfg.AllowedRoots {
+		rootClean := filepath.Clean(root)
+		if cleaned == rootClean || strings.HasPrefix(cleaned, rootClean+string(filepath.Separator)) {
+			return nil
+		}
+	}
+	return fmt.Errorf("path %q is outside the configured allowed_roots", p)
+}

--- a/internal/templates/languages/go/builtin/read.go.tmpl
+++ b/internal/templates/languages/go/builtin/read.go.tmpl
@@ -1,0 +1,185 @@
+package tools
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	server "github.com/inference-gateway/adk/server"
+	zap "go.uber.org/zap"
+)
+
+// ReadConfig is the compile-time config for the Read built-in. Values
+// flow in from spec.config.tools.read at generation time.
+type ReadConfig struct {
+	Enabled      bool
+	MaxLines     int
+	AllowedRoots []string
+}
+
+// ReadTool exposes a Read built-in. Disabled by default; flip
+// spec.config.tools.read.enabled: true in your ADL to activate.
+type ReadTool struct {
+	logger *zap.Logger
+	cfg    ReadConfig
+}
+
+// NewReadTool builds a Read tool with the resolved config baked in.
+func NewReadTool(logger *zap.Logger, cfg ReadConfig) server.Tool {
+	if cfg.MaxLines <= 0 {
+		cfg.MaxLines = 2000
+	}
+	t := &ReadTool{logger: logger, cfg: cfg}
+	return server.NewBasicTool(
+		"Read",
+		"Read a file from disk. Returns its contents, optionally sliced by line offset/limit. Use this to load SKILL.md bodies on demand.",
+		map[string]any{
+			"type":                 "object",
+			"additionalProperties": false,
+			"properties": map[string]any{
+				"file_path": map[string]any{
+					"type":        "string",
+					"description": "Path to the file (absolute or relative to the agent's working directory).",
+				},
+				"offset": map[string]any{
+					"type":        "integer",
+					"description": "1-based line number to start reading from.",
+					"minimum":     1,
+				},
+				"limit": map[string]any{
+					"type":        "integer",
+					"description": "Maximum number of lines to return.",
+					"minimum":     1,
+				},
+			},
+			"required": []string{"file_path"},
+		},
+		t.Handler,
+	)
+}
+
+// Handler executes the Read tool.
+func (t *ReadTool) Handler(ctx context.Context, args map[string]any) (string, error) {
+	if !t.cfg.Enabled {
+		return "", errors.New("Read tool is disabled; set spec.config.tools.read.enabled: true in the ADL and regenerate")
+	}
+
+	rawPath, _ := args["file_path"].(string)
+	if rawPath == "" {
+		return "", errors.New("file_path is required")
+	}
+
+	if err := t.validatePath(rawPath); err != nil {
+		return "", err
+	}
+
+	offset := 1
+	if v, ok := args["offset"]; ok {
+		if iv, ok := toInt(v); ok && iv > 0 {
+			offset = iv
+		}
+	}
+	limit := t.cfg.MaxLines
+	if v, ok := args["limit"]; ok {
+		if iv, ok := toInt(v); ok && iv > 0 {
+			limit = iv
+		}
+	}
+
+	cleaned := filepath.Clean(rawPath)
+
+	if isImagePath(cleaned) {
+		return "", fmt.Errorf("Read does not support image files (%s); use a multimodal API instead", filepath.Ext(cleaned))
+	}
+
+	file, err := os.Open(cleaned)
+	if err != nil {
+		return "", fmt.Errorf("open %s: %w", cleaned, err)
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			t.logger.Warn("failed to close file", zap.String("path", cleaned), zap.Error(closeErr))
+		}
+	}()
+
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+
+	var b strings.Builder
+	currentLine := 0
+	emitted := 0
+	for scanner.Scan() {
+		currentLine++
+		if currentLine < offset {
+			continue
+		}
+		if emitted >= limit {
+			break
+		}
+		b.WriteString(scanner.Text())
+		b.WriteByte('\n')
+		emitted++
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("read %s: %w", cleaned, err)
+	}
+
+	result := map[string]any{
+		"file_path":   cleaned,
+		"offset":      offset,
+		"limit":       limit,
+		"lines_read":  emitted,
+		"total_lines": currentLine,
+		"content":     b.String(),
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return "", fmt.Errorf("encode Read result: %w", err)
+	}
+	return string(payload), nil
+}
+
+// validatePath enforces allowed_roots if configured. Empty allowed_roots
+// means project-wide access.
+func (t *ReadTool) validatePath(p string) error {
+	if len(t.cfg.AllowedRoots) == 0 {
+		return nil
+	}
+	cleaned := filepath.Clean(p)
+	for _, root := range t.cfg.AllowedRoots {
+		rootClean := filepath.Clean(root)
+		if cleaned == rootClean || strings.HasPrefix(cleaned, rootClean+string(filepath.Separator)) {
+			return nil
+		}
+	}
+	return fmt.Errorf("path %q is outside the configured allowed_roots", p)
+}
+
+func isImagePath(p string) bool {
+	switch strings.ToLower(filepath.Ext(p)) {
+	case ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff":
+		return true
+	}
+	return false
+}
+
+func toInt(v any) (int, bool) {
+	switch x := v.(type) {
+	case int:
+		return x, true
+	case int32:
+		return int(x), true
+	case int64:
+		return int(x), true
+	case float32:
+		return int(x), true
+	case float64:
+		return int(x), true
+	}
+	return 0, false
+}

--- a/internal/templates/languages/go/builtin/write.go.tmpl
+++ b/internal/templates/languages/go/builtin/write.go.tmpl
@@ -1,0 +1,106 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	server "github.com/inference-gateway/adk/server"
+	zap "go.uber.org/zap"
+)
+
+// WriteConfig is the compile-time config for the Write built-in. Values
+// flow in from spec.config.tools.write at generation time.
+type WriteConfig struct {
+	Enabled      bool
+	AllowedRoots []string
+}
+
+// WriteTool exposes a Write built-in. Disabled by default; flip
+// spec.config.tools.write.enabled: true in your ADL to activate.
+type WriteTool struct {
+	logger *zap.Logger
+	cfg    WriteConfig
+}
+
+// NewWriteTool builds a Write tool with the resolved config baked in.
+func NewWriteTool(logger *zap.Logger, cfg WriteConfig) server.Tool {
+	t := &WriteTool{logger: logger, cfg: cfg}
+	return server.NewBasicTool(
+		"Write",
+		"Write content to a file, creating intermediate directories as needed. Overwrites the file if it already exists.",
+		map[string]any{
+			"type":                 "object",
+			"additionalProperties": false,
+			"properties": map[string]any{
+				"file_path": map[string]any{
+					"type":        "string",
+					"description": "Path to the file (absolute or relative to the agent's working directory).",
+				},
+				"content": map[string]any{
+					"type":        "string",
+					"description": "Content to write to the file.",
+				},
+			},
+			"required": []string{"file_path", "content"},
+		},
+		t.Handler,
+	)
+}
+
+// Handler executes the Write tool.
+func (t *WriteTool) Handler(ctx context.Context, args map[string]any) (string, error) {
+	if !t.cfg.Enabled {
+		return "", errors.New("Write tool is disabled; set spec.config.tools.write.enabled: true in the ADL and regenerate")
+	}
+
+	rawPath, _ := args["file_path"].(string)
+	if rawPath == "" {
+		return "", errors.New("file_path is required")
+	}
+	content, ok := args["content"].(string)
+	if !ok {
+		return "", errors.New("content is required")
+	}
+
+	if err := t.validatePath(rawPath); err != nil {
+		return "", err
+	}
+
+	cleaned := filepath.Clean(rawPath)
+	if err := os.MkdirAll(filepath.Dir(cleaned), 0o755); err != nil {
+		return "", fmt.Errorf("create parent dir for %s: %w", cleaned, err)
+	}
+	if err := os.WriteFile(cleaned, []byte(content), 0o644); err != nil {
+		return "", fmt.Errorf("write %s: %w", cleaned, err)
+	}
+
+	t.logger.Debug("write executed", zap.String("path", cleaned), zap.Int("bytes", len(content)))
+	result := map[string]any{
+		"file_path":     cleaned,
+		"bytes_written": len(content),
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return "", fmt.Errorf("encode Write result: %w", err)
+	}
+	return string(payload), nil
+}
+
+func (t *WriteTool) validatePath(p string) error {
+	if len(t.cfg.AllowedRoots) == 0 {
+		return nil
+	}
+	cleaned := filepath.Clean(p)
+	for _, root := range t.cfg.AllowedRoots {
+		rootClean := filepath.Clean(root)
+		if cleaned == rootClean || strings.HasPrefix(cleaned, rootClean+string(filepath.Separator)) {
+			return nil
+		}
+	}
+	return fmt.Errorf("path %q is outside the configured allowed_roots", p)
+}

--- a/internal/templates/languages/go/config.go.tmpl
+++ b/internal/templates/languages/go/config.go.tmpl
@@ -8,20 +8,23 @@ import (
 type Config struct {
 	// Core application settings
 	Environment string `env:"ENVIRONMENT"`
-	
+
 	// A2A configuration (all A2A_ prefixed vars)
 	A2A serverConfig.Config `env:",prefix=A2A_"`
 	{{- if .ADL.Spec.Config }}
-	
+
 	// Custom configuration sections
 	{{- range $sectionName, $sectionConfig := .ADL.Spec.Config }}
+	{{- if ne $sectionName "tools" }}
 	{{ $sectionName | toPascalCase }} {{ $sectionName | toPascalCase }}Config `env:",prefix={{ $sectionName | toUpperSnakeCase }}_"`
+	{{- end }}
 	{{- end }}
 	{{- end }}
 }
 
 {{- if .ADL.Spec.Config }}
 {{- range $sectionName, $sectionConfig := .ADL.Spec.Config }}
+{{- if ne $sectionName "tools" }}
 
 // {{ $sectionName | toPascalCase }}Config represents the {{ $sectionName }} configuration
 type {{ $sectionName | toPascalCase }}Config struct {
@@ -41,5 +44,6 @@ type {{ $sectionName | toPascalCase }}Config struct {
 	{{ $key | toPascalCase }} {{ $type }} `env:"{{ $key | toUpperSnakeCase }}{{- if or $value $isBool }},default={{ $value }}{{- end }}"`
 	{{- end }}
 }
+{{- end }}
 {{- end }}
 {{- end }}

--- a/internal/templates/languages/go/go.mod.tmpl
+++ b/internal/templates/languages/go/go.mod.tmpl
@@ -6,4 +6,5 @@ require (
 	github.com/inference-gateway/adk v0.17.1
 	github.com/sethvargo/go-envconfig v1.2.0
 	go.uber.org/zap v1.27.1
+	gopkg.in/yaml.v3 v3.0.1
 )

--- a/internal/templates/languages/go/main.go.tmpl
+++ b/internal/templates/languages/go/main.go.tmpl
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"os/signal"
@@ -14,6 +15,7 @@ import (
 	server "github.com/inference-gateway/adk/server"
 	envconfig "github.com/sethvargo/go-envconfig"
 	zap "go.uber.org/zap"
+	yaml "gopkg.in/yaml.v3"
 
 	config "{{ .ADL.Spec.Language.Go.Module }}/config"
 {{- if .ADL.Spec.Tools }}
@@ -43,16 +45,17 @@ var (
 	AgentDescription = "{{ .ADL.Metadata.Description }}"
 )
 
-// skillsDir is the directory the runtime loads markdown skills from at
+// skillsDir is the directory the runtime scans for skill manifests at
 // startup. Override with A2A_SKILLS_DIR.
 const skillsDir = "skills"
 
-// loadSkills walks the configured skills directory, reads each
-// <skill>/SKILL.md, strips its YAML frontmatter, and returns the
-// concatenated bodies in lexical order by skill directory. The result is
-// appended to the configured system prompt so the model sees skill
-// playbooks at runtime.
-func loadSkills(dir string) (string, error) {
+// loadSkillsManifest walks the configured skills directory, reads each
+// <skill>/SKILL.md, extracts the YAML frontmatter (name + description),
+// and returns an `AVAILABLE SKILLS:` block to append to the system
+// prompt. SKILL.md bodies are NOT inlined — the model must call the
+// Read tool to load a skill's playbook on demand. Returns "" when the
+// directory is missing or has no valid manifests.
+func loadSkillsManifest(dir string) (string, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -70,9 +73,14 @@ func loadSkills(dir string) (string, error) {
 	}
 	sort.Strings(dirs)
 
-	var out strings.Builder
-	for _, name := range dirs {
-		path := filepath.Join(dir, name, "SKILL.md")
+	type skillFrontmatter struct {
+		Name        string `yaml:"name"`
+		Description string `yaml:"description"`
+	}
+
+	var manifest strings.Builder
+	for _, id := range dirs {
+		path := filepath.Join(dir, id, "SKILL.md")
 		data, err := os.ReadFile(path)
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -80,34 +88,46 @@ func loadSkills(dir string) (string, error) {
 			}
 			return "", err
 		}
-		body := stripFrontmatter(data)
-		if len(body) == 0 {
+		fmBytes, ok := extractFrontmatter(data)
+		if !ok {
 			continue
 		}
-		if out.Len() > 0 {
-			out.WriteString("\n\n")
+		var fm skillFrontmatter
+		if err := yaml.Unmarshal(fmBytes, &fm); err != nil {
+			continue
 		}
-		out.Write(body)
+		if fm.Name == "" || fm.Description == "" {
+			continue
+		}
+		if manifest.Len() == 0 {
+			manifest.WriteString("AVAILABLE SKILLS:\n")
+			manifest.WriteString("Skills are reusable instructions for specific tasks. When a task matches a\n")
+			manifest.WriteString("skill's description, read the SKILL.md file at the listed path using the Read\n")
+			manifest.WriteString("tool, then follow its instructions.\n\n")
+		}
+		fmt.Fprintf(&manifest, "- %s: %s\n  Path: %s\n", fm.Name, fm.Description, path)
 	}
-	return out.String(), nil
+	return manifest.String(), nil
 }
 
-func stripFrontmatter(content []byte) []byte {
+// extractFrontmatter returns the bytes between the opening and closing
+// `---` fences of a SKILL.md file (without including the fences
+// themselves). The second return value is false when no frontmatter is
+// found.
+func extractFrontmatter(content []byte) ([]byte, bool) {
 	bom := []byte{0xEF, 0xBB, 0xBF}
-	trimmed := bytes.TrimPrefix(content, bom)
-	trimmed = bytes.TrimLeft(trimmed, "\r\n\t ")
-	if !bytes.HasPrefix(trimmed, []byte("---")) {
-		return bytes.TrimRight(content, "\r\n")
+	buf := bytes.TrimPrefix(content, bom)
+	buf = bytes.TrimLeft(buf, "\r\n\t ")
+	if !bytes.HasPrefix(buf, []byte("---")) {
+		return nil, false
 	}
-	rest := trimmed[3:]
+	rest := buf[3:]
 	rest = bytes.TrimLeft(rest, "\r\n")
 	idx := bytes.Index(rest, []byte("\n---"))
 	if idx < 0 {
-		return bytes.TrimRight(content, "\r\n")
+		return nil, false
 	}
-	body := rest[idx+4:]
-	body = bytes.TrimLeft(body, "\r\n")
-	return bytes.TrimRight(body, "\r\n")
+	return rest[:idx], true
 }
 
 func main() {
@@ -130,11 +150,11 @@ func main() {
 	if v := os.Getenv("A2A_SKILLS_DIR"); v != "" {
 		resolvedSkillsDir = v
 	}
-	skillsPrompt, err := loadSkills(resolvedSkillsDir)
+	skillsPrompt, err := loadSkillsManifest(resolvedSkillsDir)
 	if err != nil {
-		l.Warn("failed to load skills, continuing without them", zap.Error(err))
+		l.Warn("failed to load skills manifest, continuing without them", zap.Error(err))
 	} else if skillsPrompt != "" {
-		l.Info("loaded skills into system prompt", zap.String("dir", resolvedSkillsDir))
+		l.Info("loaded skills manifest into system prompt", zap.String("dir", resolvedSkillsDir))
 	}
 
 	{{- if .ADL.Spec.Services }}
@@ -174,11 +194,52 @@ func main() {
 	toolBox := server.NewDefaultToolBox(&cfg.A2A.AgentConfig.ToolBoxConfig)
 
 	{{- range .ADL.Spec.Tools }}
+	{{- if eq .ID "read" }}
+
+	// Register Read built-in
+	readTool := tools.NewReadTool(l, tools.ReadConfig{
+		Enabled:      {{ $.BuiltinConfigs.Read.Enabled }},
+		MaxLines:     {{ $.BuiltinConfigs.Read.MaxLines }},
+		AllowedRoots: []string{ {{- range $i, $r := $.BuiltinConfigs.Read.AllowedRoots }}{{ if $i }}, {{ end }}{{ $r | quote }}{{- end }} },
+	})
+	toolBox.AddTool(readTool)
+	l.Info("registered built-in: Read", zap.Bool("enabled", {{ $.BuiltinConfigs.Read.Enabled }}))
+	{{- else if eq .ID "bash" }}
+
+	// Register Bash built-in
+	bashTool := tools.NewBashTool(l, tools.BashConfig{
+		Enabled:        {{ $.BuiltinConfigs.Bash.Enabled }},
+		Whitelist:      []string{ {{- range $i, $w := $.BuiltinConfigs.Bash.Whitelist }}{{ if $i }}, {{ end }}{{ $w | quote }}{{- end }} },
+		TimeoutSeconds: {{ $.BuiltinConfigs.Bash.TimeoutSeconds }},
+		WorkingDir:     {{ $.BuiltinConfigs.Bash.WorkingDir | quote }},
+	})
+	toolBox.AddTool(bashTool)
+	l.Info("registered built-in: Bash", zap.Bool("enabled", {{ $.BuiltinConfigs.Bash.Enabled }}))
+	{{- else if eq .ID "write" }}
+
+	// Register Write built-in
+	writeTool := tools.NewWriteTool(l, tools.WriteConfig{
+		Enabled:      {{ $.BuiltinConfigs.Write.Enabled }},
+		AllowedRoots: []string{ {{- range $i, $r := $.BuiltinConfigs.Write.AllowedRoots }}{{ if $i }}, {{ end }}{{ $r | quote }}{{- end }} },
+	})
+	toolBox.AddTool(writeTool)
+	l.Info("registered built-in: Write", zap.Bool("enabled", {{ $.BuiltinConfigs.Write.Enabled }}))
+	{{- else if eq .ID "edit" }}
+
+	// Register Edit built-in
+	editTool := tools.NewEditTool(l, tools.EditConfig{
+		Enabled:      {{ $.BuiltinConfigs.Edit.Enabled }},
+		AllowedRoots: []string{ {{- range $i, $r := $.BuiltinConfigs.Edit.AllowedRoots }}{{ if $i }}, {{ end }}{{ $r | quote }}{{- end }} },
+	})
+	toolBox.AddTool(editTool)
+	l.Info("registered built-in: Edit", zap.Bool("enabled", {{ $.BuiltinConfigs.Edit.Enabled }}))
+	{{- else }}
 
 	// Register {{ .Name }} tool
 	{{ .Name | toCamelCase }}Tool := tools.New{{ .Name | toPascalCase }}Tool({{ range $index, $svc := .Inject }}{{ if $index }}, {{ end }}{{ if eq $svc "logger" }}l{{ else if eq $svc "config" }}&cfg{{ else if hasPrefix "config." $svc }}&cfg.{{ $svc | trimPrefix "config." | toPascalCase }}{{ else }}{{ $svc | toCamelCase }}Svc{{ end }}{{ end }})
 	toolBox.AddTool({{ .Name | toCamelCase }}Tool)
 	l.Info("registered tool: {{ .Name }} ({{ .Description }})")
+	{{- end }}
 	{{- end }}
 
 	llmClient, err := server.NewOpenAICompatibleLLMClient(&cfg.A2A.AgentConfig, l)

--- a/internal/templates/languages/rust/Cargo.toml.tmpl
+++ b/internal/templates/languages/rust/Cargo.toml.tmpl
@@ -17,6 +17,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
 anyhow = "1"
 async-trait = "0.1"
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/internal/templates/languages/rust/builtin/bash.rs.tmpl
+++ b/internal/templates/languages/rust/builtin/bash.rs.tmpl
@@ -1,0 +1,139 @@
+use anyhow::{anyhow, bail};
+use inference_gateway_sdk::{ChatCompletionTool, ChatCompletionToolType, FunctionObject, FunctionParameters};
+use serde_json::{Value, json};
+use std::env;
+use std::time::{Duration, Instant};
+use tokio::process::Command;
+use tokio::time::timeout;
+
+/// Compile-time config for the Bash built-in. Values flow in from
+/// spec.config.tools.bash at generation time. Runtime env vars
+/// `A2A_BASH_DISABLED` and `A2A_BASH_WHITELIST` override these.
+#[derive(Clone, Debug)]
+pub struct Config {
+    pub enabled: bool,
+    pub whitelist: Vec<String>,
+    pub timeout_seconds: u64,
+    pub working_dir: String,
+}
+
+impl Config {
+    /// Apply env-var overrides once, at startup.
+    pub fn with_env_overrides(mut self) -> Self {
+        if env::var("A2A_BASH_DISABLED").as_deref() == Ok("1") {
+            self.enabled = false;
+        }
+        if let Ok(value) = env::var("A2A_BASH_WHITELIST") {
+            self.whitelist = value
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+        }
+        if self.timeout_seconds == 0 {
+            self.timeout_seconds = 30;
+        }
+        self
+    }
+}
+
+/// Tool descriptor advertised to the LLM.
+pub fn descriptor() -> ChatCompletionTool {
+    ChatCompletionTool {
+        type_: ChatCompletionToolType::Function,
+        function: FunctionObject {
+            name: "Bash".to_string(),
+            description: Some(
+                "Execute a shell command. Subject to the configured whitelist and timeout; honors A2A_BASH_DISABLED as a runtime kill switch.".to_string(),
+            ),
+            parameters: Some(FunctionParameters(
+                json!({
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "command": {
+                            "type": "string",
+                            "description": "The shell command to execute."
+                        }
+                    },
+                    "required": ["command"]
+                })
+                .as_object()
+                .expect("schema literal must be an object")
+                .clone(),
+            )),
+            strict: false,
+        },
+    }
+}
+
+/// Handle a Bash invocation.
+pub async fn handle(args: Value, cfg: Config) -> anyhow::Result<String> {
+    if !cfg.enabled {
+        bail!("Bash tool is disabled; set spec.config.tools.bash.enabled: true and ensure A2A_BASH_DISABLED is not 1");
+    }
+
+    let command = args
+        .get("command")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("command is required"))?
+        .trim()
+        .to_string();
+    if command.is_empty() {
+        bail!("command is required");
+    }
+
+    check_whitelist(&cfg.whitelist, &command)?;
+
+    let mut cmd = Command::new("sh");
+    cmd.arg("-c").arg(&command);
+    if !cfg.working_dir.is_empty() {
+        cmd.current_dir(&cfg.working_dir);
+    }
+
+    let start = Instant::now();
+    let timed = timeout(Duration::from_secs(cfg.timeout_seconds), cmd.output()).await;
+    let duration_ms = start.elapsed().as_millis() as u64;
+
+    let (exit_code, output, error) = match timed {
+        Ok(Ok(out)) => {
+            let exit_code = out.status.code().unwrap_or(-1);
+            let combined =
+                format!("{}{}", String::from_utf8_lossy(&out.stdout), String::from_utf8_lossy(&out.stderr));
+            (exit_code, combined, None)
+        }
+        Ok(Err(e)) => (-1, String::new(), Some(e.to_string())),
+        Err(_) => (
+            -1,
+            String::new(),
+            Some(format!("bash timed out after {}s", cfg.timeout_seconds)),
+        ),
+    };
+
+    let mut payload = json!({
+        "command": command,
+        "exit_code": exit_code,
+        "duration_ms": duration_ms,
+        "output": output,
+    });
+    if let Some(err_msg) = error {
+        payload["error"] = Value::String(err_msg);
+    }
+    Ok(payload.to_string())
+}
+
+fn check_whitelist(whitelist: &[String], command: &str) -> anyhow::Result<()> {
+    if whitelist.is_empty() {
+        return Ok(());
+    }
+    for allowed in whitelist {
+        let allowed = allowed.trim();
+        if allowed.is_empty() {
+            continue;
+        }
+        if command == allowed || command.starts_with(&format!("{} ", allowed)) {
+            return Ok(());
+        }
+    }
+    bail!("command {:?} is not in the configured whitelist", command);
+}

--- a/internal/templates/languages/rust/builtin/edit.rs.tmpl
+++ b/internal/templates/languages/rust/builtin/edit.rs.tmpl
@@ -1,0 +1,119 @@
+use anyhow::{anyhow, bail};
+use inference_gateway_sdk::{ChatCompletionTool, ChatCompletionToolType, FunctionObject, FunctionParameters};
+use serde_json::{Value, json};
+use std::path::{Path, PathBuf};
+use tokio::fs;
+
+/// Compile-time config for the Edit built-in. Values flow in from
+/// spec.config.tools.edit at generation time.
+#[derive(Clone, Debug)]
+pub struct Config {
+    pub enabled: bool,
+    pub allowed_roots: Vec<String>,
+}
+
+/// Tool descriptor advertised to the LLM.
+pub fn descriptor() -> ChatCompletionTool {
+    ChatCompletionTool {
+        type_: ChatCompletionToolType::Function,
+        function: FunctionObject {
+            name: "Edit".to_string(),
+            description: Some(
+                "Replace a unique string in a file with a new value. Errors if old_string is not found or appears more than once.".to_string(),
+            ),
+            parameters: Some(FunctionParameters(
+                json!({
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "file_path": {
+                            "type": "string",
+                            "description": "Path to the file to edit."
+                        },
+                        "old_string": {
+                            "type": "string",
+                            "description": "Exact string in the file to replace. Must be unique."
+                        },
+                        "new_string": {
+                            "type": "string",
+                            "description": "Replacement string."
+                        }
+                    },
+                    "required": ["file_path", "old_string", "new_string"]
+                })
+                .as_object()
+                .expect("schema literal must be an object")
+                .clone(),
+            )),
+            strict: false,
+        },
+    }
+}
+
+/// Handle an Edit invocation.
+pub async fn handle(args: Value, cfg: Config) -> anyhow::Result<String> {
+    if !cfg.enabled {
+        bail!("Edit tool is disabled; set spec.config.tools.edit.enabled: true in the ADL and regenerate");
+    }
+
+    let file_path = args
+        .get("file_path")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("file_path is required"))?
+        .to_string();
+    let old_str = args
+        .get("old_string")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("old_string is required"))?;
+    if old_str.is_empty() {
+        bail!("old_string must be non-empty");
+    }
+    let new_str = args
+        .get("new_string")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("new_string is required"))?;
+
+    validate_path(&cfg.allowed_roots, &file_path)?;
+
+    let cleaned = PathBuf::from(&file_path);
+    let body = fs::read_to_string(&cleaned)
+        .await
+        .map_err(|e| anyhow!("read {}: {}", cleaned.display(), e))?;
+
+    let count = body.matches(old_str).count();
+    if count == 0 {
+        bail!("old_string not found in {}", cleaned.display());
+    }
+    if count > 1 {
+        bail!(
+            "old_string appears {} times in {}; refusing to edit (must be unique)",
+            count,
+            cleaned.display()
+        );
+    }
+
+    let replaced = body.replacen(old_str, new_str, 1);
+    fs::write(&cleaned, replaced.as_bytes())
+        .await
+        .map_err(|e| anyhow!("write {}: {}", cleaned.display(), e))?;
+
+    Ok(json!({
+        "file_path": cleaned.display().to_string(),
+        "replacements": 1,
+    })
+    .to_string())
+}
+
+fn validate_path(allowed_roots: &[String], p: &str) -> anyhow::Result<()> {
+    if allowed_roots.is_empty() {
+        return Ok(());
+    }
+    let cleaned = Path::new(p).to_path_buf();
+    for root in allowed_roots {
+        let root_clean = Path::new(root).to_path_buf();
+        if cleaned == root_clean || cleaned.starts_with(&root_clean) {
+            return Ok(());
+        }
+    }
+    bail!("path {:?} is outside the configured allowed_roots", p);
+}

--- a/internal/templates/languages/rust/builtin/read.rs.tmpl
+++ b/internal/templates/languages/rust/builtin/read.rs.tmpl
@@ -1,0 +1,146 @@
+use anyhow::{anyhow, bail};
+use inference_gateway_sdk::{ChatCompletionTool, ChatCompletionToolType, FunctionObject, FunctionParameters};
+use serde_json::{Value, json};
+use std::path::{Path, PathBuf};
+use tokio::fs;
+use tokio::io::{AsyncBufReadExt, BufReader};
+
+/// Compile-time config for the Read built-in. Values flow in from
+/// spec.config.tools.read at generation time.
+#[derive(Clone, Debug)]
+pub struct Config {
+    pub enabled: bool,
+    pub max_lines: usize,
+    pub allowed_roots: Vec<String>,
+}
+
+impl Config {
+    fn default_max_lines(&self) -> usize {
+        if self.max_lines == 0 { 2000 } else { self.max_lines }
+    }
+}
+
+/// Tool descriptor advertised to the LLM.
+pub fn descriptor() -> ChatCompletionTool {
+    ChatCompletionTool {
+        type_: ChatCompletionToolType::Function,
+        function: FunctionObject {
+            name: "Read".to_string(),
+            description: Some(
+                "Read a file from disk. Returns its contents, optionally sliced by line offset/limit. Use this to load SKILL.md bodies on demand.".to_string(),
+            ),
+            parameters: Some(FunctionParameters(
+                json!({
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "file_path": {
+                            "type": "string",
+                            "description": "Path to the file (absolute or relative to the agent's working directory)."
+                        },
+                        "offset": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "description": "1-based line number to start reading from."
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "description": "Maximum number of lines to return."
+                        }
+                    },
+                    "required": ["file_path"]
+                })
+                .as_object()
+                .expect("schema literal must be an object")
+                .clone(),
+            )),
+            strict: false,
+        },
+    }
+}
+
+/// Handle a Read invocation.
+pub async fn handle(args: Value, cfg: Config) -> anyhow::Result<String> {
+    if !cfg.enabled {
+        bail!("Read tool is disabled; set spec.config.tools.read.enabled: true in the ADL and regenerate");
+    }
+
+    let file_path = args
+        .get("file_path")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("file_path is required"))?
+        .to_string();
+
+    if is_image_path(&file_path) {
+        bail!("Read does not support image files ({}); use a multimodal API instead", file_path);
+    }
+
+    validate_path(&cfg.allowed_roots, &file_path)?;
+
+    let offset = args
+        .get("offset")
+        .and_then(Value::as_u64)
+        .filter(|n| *n > 0)
+        .unwrap_or(1) as usize;
+    let limit = args
+        .get("limit")
+        .and_then(Value::as_u64)
+        .filter(|n| *n > 0)
+        .map(|n| n as usize)
+        .unwrap_or_else(|| cfg.default_max_lines());
+
+    let cleaned = PathBuf::from(&file_path);
+    let file = fs::File::open(&cleaned)
+        .await
+        .map_err(|e| anyhow!("open {}: {}", cleaned.display(), e))?;
+    let mut reader = BufReader::new(file).lines();
+
+    let mut current_line: usize = 0;
+    let mut emitted: usize = 0;
+    let mut buf = String::new();
+
+    while let Some(line) = reader.next_line().await? {
+        current_line += 1;
+        if current_line < offset {
+            continue;
+        }
+        if emitted >= limit {
+            break;
+        }
+        buf.push_str(&line);
+        buf.push('\n');
+        emitted += 1;
+    }
+
+    Ok(json!({
+        "file_path": cleaned.display().to_string(),
+        "offset": offset,
+        "limit": limit,
+        "lines_read": emitted,
+        "total_lines": current_line,
+        "content": buf,
+    })
+    .to_string())
+}
+
+fn validate_path(allowed_roots: &[String], p: &str) -> anyhow::Result<()> {
+    if allowed_roots.is_empty() {
+        return Ok(());
+    }
+    let cleaned = Path::new(p).to_path_buf();
+    for root in allowed_roots {
+        let root_clean = Path::new(root).to_path_buf();
+        if cleaned == root_clean || cleaned.starts_with(&root_clean) {
+            return Ok(());
+        }
+    }
+    bail!("path {:?} is outside the configured allowed_roots", p);
+}
+
+fn is_image_path(p: &str) -> bool {
+    let lower = p.to_lowercase();
+    [".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff"]
+        .iter()
+        .any(|ext| lower.ends_with(ext))
+}

--- a/internal/templates/languages/rust/builtin/write.rs.tmpl
+++ b/internal/templates/languages/rust/builtin/write.rs.tmpl
@@ -1,0 +1,100 @@
+use anyhow::{anyhow, bail};
+use inference_gateway_sdk::{ChatCompletionTool, ChatCompletionToolType, FunctionObject, FunctionParameters};
+use serde_json::{Value, json};
+use std::path::{Path, PathBuf};
+use tokio::fs;
+
+/// Compile-time config for the Write built-in. Values flow in from
+/// spec.config.tools.write at generation time.
+#[derive(Clone, Debug)]
+pub struct Config {
+    pub enabled: bool,
+    pub allowed_roots: Vec<String>,
+}
+
+/// Tool descriptor advertised to the LLM.
+pub fn descriptor() -> ChatCompletionTool {
+    ChatCompletionTool {
+        type_: ChatCompletionToolType::Function,
+        function: FunctionObject {
+            name: "Write".to_string(),
+            description: Some(
+                "Write content to a file, creating intermediate directories as needed. Overwrites the file if it already exists.".to_string(),
+            ),
+            parameters: Some(FunctionParameters(
+                json!({
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "file_path": {
+                            "type": "string",
+                            "description": "Path to the file (absolute or relative to the agent's working directory)."
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": "Content to write to the file."
+                        }
+                    },
+                    "required": ["file_path", "content"]
+                })
+                .as_object()
+                .expect("schema literal must be an object")
+                .clone(),
+            )),
+            strict: false,
+        },
+    }
+}
+
+/// Handle a Write invocation.
+pub async fn handle(args: Value, cfg: Config) -> anyhow::Result<String> {
+    if !cfg.enabled {
+        bail!("Write tool is disabled; set spec.config.tools.write.enabled: true in the ADL and regenerate");
+    }
+
+    let file_path = args
+        .get("file_path")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("file_path is required"))?
+        .to_string();
+    let content = args
+        .get("content")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("content is required"))?
+        .to_string();
+
+    validate_path(&cfg.allowed_roots, &file_path)?;
+
+    let cleaned = PathBuf::from(&file_path);
+    if let Some(parent) = cleaned.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)
+                .await
+                .map_err(|e| anyhow!("create parent dir for {}: {}", cleaned.display(), e))?;
+        }
+    }
+    let bytes = content.as_bytes();
+    fs::write(&cleaned, bytes)
+        .await
+        .map_err(|e| anyhow!("write {}: {}", cleaned.display(), e))?;
+
+    Ok(json!({
+        "file_path": cleaned.display().to_string(),
+        "bytes_written": bytes.len(),
+    })
+    .to_string())
+}
+
+fn validate_path(allowed_roots: &[String], p: &str) -> anyhow::Result<()> {
+    if allowed_roots.is_empty() {
+        return Ok(());
+    }
+    let cleaned = Path::new(p).to_path_buf();
+    for root in allowed_roots {
+        let root_clean = Path::new(root).to_path_buf();
+        if cleaned == root_clean || cleaned.starts_with(&root_clean) {
+            return Ok(());
+        }
+    }
+    bail!("path {:?} is outside the configured allowed_roots", p);
+}

--- a/internal/templates/languages/rust/main.rs.tmpl
+++ b/internal/templates/languages/rust/main.rs.tmpl
@@ -1,23 +1,34 @@
 use inference_gateway_adk::{A2AServerBuilder, {{ if .ADL.Spec.Agent }}AgentBuilder, {{ end }}Config};
-{{- if and .ADL.Spec.Agent .ADL.Spec.Tools }}
+{{- if .ADL.Spec.Agent }}
 use serde_json::Value;
 {{- end }}
+use serde::Deserialize;
+use std::fmt::Write as _;
 use std::fs;
 use std::net::SocketAddr;
 use std::path::Path;
 use tracing::{error, info, warn};
 
-{{- if and .ADL.Spec.Agent .ADL.Spec.Tools }}
+{{- if and .ADL.Spec.Agent (or .ADL.Spec.Tools (gt (len .ADL.Spec.Skills) 0)) }}
 
 mod tools;
 {{- end }}
 
-/// Load each `<skill>/SKILL.md` from the configured directory, strip its
-/// YAML frontmatter, and concatenate the bodies in lexical order by skill
-/// directory. The result is appended to the configured system prompt at
-/// runtime so the model can read skill playbooks alongside the agent
-/// persona.
-fn load_skills(dir: &Path) -> std::io::Result<String> {
+#[derive(Debug, Deserialize)]
+struct SkillFrontmatter {
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    description: String,
+}
+
+/// Walk the configured skills directory, extract YAML frontmatter
+/// (name + description) from each `<skill>/SKILL.md`, and return an
+/// `AVAILABLE SKILLS:` block to append to the system prompt. SKILL.md
+/// bodies are NOT inlined — the model must call the Read tool to load a
+/// skill's playbook on demand. Returns an empty string when the
+/// directory is missing or has no valid manifests.
+fn load_skills_manifest(dir: &Path) -> std::io::Result<String> {
     if !dir.exists() {
         return Ok(String::new());
     }
@@ -28,43 +39,56 @@ fn load_skills(dir: &Path) -> std::io::Result<String> {
         .collect();
     dirs.sort();
 
-    let mut out = String::new();
+    let mut manifest = String::new();
     for path in dirs {
         let skill_path = path.join("SKILL.md");
         if !skill_path.exists() {
             continue;
         }
         let bytes = fs::read(&skill_path)?;
-        let body = strip_frontmatter(&bytes);
-        if body.is_empty() {
+        let Some(fm_bytes) = extract_frontmatter(&bytes) else {
+            continue;
+        };
+        let fm: SkillFrontmatter = match serde_yaml::from_slice(fm_bytes) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        if fm.name.is_empty() || fm.description.is_empty() {
             continue;
         }
-        if !out.is_empty() {
-            out.push_str("\n\n");
+        if manifest.is_empty() {
+            manifest.push_str("AVAILABLE SKILLS:\n");
+            manifest.push_str("Skills are reusable instructions for specific tasks. When a task matches a\n");
+            manifest.push_str("skill's description, read the SKILL.md file at the listed path using the Read\n");
+            manifest.push_str("tool, then follow its instructions.\n\n");
         }
-        out.push_str(&body);
+        let _ = writeln!(
+            manifest,
+            "- {}: {}\n  Path: {}",
+            fm.name,
+            fm.description,
+            skill_path.display()
+        );
     }
-    Ok(out)
+    Ok(manifest)
 }
 
-fn strip_frontmatter(content: &[u8]) -> String {
+/// Return the bytes between the opening and closing `---` fences of a
+/// SKILL.md file (without including the fences themselves).
+fn extract_frontmatter(content: &[u8]) -> Option<&[u8]> {
     let bom: &[u8] = &[0xEF, 0xBB, 0xBF];
-    let mut buf = content;
-    if buf.starts_with(bom) {
-        buf = &buf[bom.len()..];
+    let buf = if content.starts_with(bom) {
+        &content[bom.len()..]
+    } else {
+        content
+    };
+    let buf = trim_leading_whitespace(buf);
+    if !buf.starts_with(b"---") {
+        return None;
     }
-    let trimmed = trim_leading_whitespace(buf);
-    if !trimmed.starts_with(b"---") {
-        return String::from_utf8_lossy(buf).trim_end().to_string();
-    }
-    let rest = &trimmed[3..];
-    let rest = trim_leading_newlines(rest);
-    if let Some(idx) = find_subslice(rest, b"\n---") {
-        let body = &rest[idx + 4..];
-        let body = trim_leading_newlines(body);
-        return String::from_utf8_lossy(body).trim_end().to_string();
-    }
-    String::from_utf8_lossy(buf).trim_end().to_string()
+    let rest = trim_leading_newlines(&buf[3..]);
+    let idx = find_subslice(rest, b"\n---")?;
+    Some(&rest[..idx])
 }
 
 fn trim_leading_whitespace(buf: &[u8]) -> &[u8] {
@@ -108,15 +132,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config: Config = envy::prefixed("A2A_").from_env()?;
 
     let skills_dir = std::env::var("A2A_SKILLS_DIR").unwrap_or_else(|_| "skills".to_string());
-    let skills_prompt = match load_skills(Path::new(&skills_dir)) {
+    let skills_prompt = match load_skills_manifest(Path::new(&skills_dir)) {
         Ok(s) => {
             if !s.is_empty() {
-                info!(dir = %skills_dir, "loaded skills into system prompt");
+                info!(dir = %skills_dir, "loaded skills manifest into system prompt");
             }
             s
         }
         Err(e) => {
-            warn!(error = %e, "failed to load skills, continuing without them");
+            warn!(error = %e, "failed to load skills manifest, continuing without them");
             String::new()
         }
     };
@@ -141,7 +165,43 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 {{- if .ADL.Spec.Tools }}
         .with_toolbox(tools::all())
 {{- range .ADL.Spec.Tools }}
-{{- if .Inject }}
+{{- if eq .ID "read" }}
+        .with_async_function_tool("Read".to_string(), |args: Value| async move {
+            let cfg = tools::read::Config {
+                enabled: {{ $.BuiltinConfigs.Read.Enabled }},
+                max_lines: {{ $.BuiltinConfigs.Read.MaxLines }},
+                allowed_roots: vec![{{ range $i, $r := $.BuiltinConfigs.Read.AllowedRoots }}{{ if $i }}, {{ end }}{{ $r | quote }}.to_string(){{ end }}],
+            };
+            tools::read::handle(args, cfg).await
+        })
+{{- else if eq .ID "bash" }}
+        .with_async_function_tool("Bash".to_string(), |args: Value| async move {
+            let cfg = tools::bash::Config {
+                enabled: {{ $.BuiltinConfigs.Bash.Enabled }},
+                whitelist: vec![{{ range $i, $w := $.BuiltinConfigs.Bash.Whitelist }}{{ if $i }}, {{ end }}{{ $w | quote }}.to_string(){{ end }}],
+                timeout_seconds: {{ $.BuiltinConfigs.Bash.TimeoutSeconds }},
+                working_dir: {{ $.BuiltinConfigs.Bash.WorkingDir | quote }}.to_string(),
+            }
+            .with_env_overrides();
+            tools::bash::handle(args, cfg).await
+        })
+{{- else if eq .ID "write" }}
+        .with_async_function_tool("Write".to_string(), |args: Value| async move {
+            let cfg = tools::write::Config {
+                enabled: {{ $.BuiltinConfigs.Write.Enabled }},
+                allowed_roots: vec![{{ range $i, $r := $.BuiltinConfigs.Write.AllowedRoots }}{{ if $i }}, {{ end }}{{ $r | quote }}.to_string(){{ end }}],
+            };
+            tools::write::handle(args, cfg).await
+        })
+{{- else if eq .ID "edit" }}
+        .with_async_function_tool("Edit".to_string(), |args: Value| async move {
+            let cfg = tools::edit::Config {
+                enabled: {{ $.BuiltinConfigs.Edit.Enabled }},
+                allowed_roots: vec![{{ range $i, $r := $.BuiltinConfigs.Edit.AllowedRoots }}{{ if $i }}, {{ end }}{{ $r | quote }}.to_string(){{ end }}],
+            };
+            tools::edit::handle(args, cfg).await
+        })
+{{- else if .Inject }}
         .with_async_function_tool({{ .ID | quote }}.to_string(), |args: Value| async move {
             tools::{{ toSnakeCase .ID }}::handle(args).await
         })

--- a/internal/templates/languages/rust/tool.mod.rs.tmpl
+++ b/internal/templates/languages/rust/tool.mod.rs.tmpl
@@ -17,3 +17,4 @@ pub fn all() -> Vec<ChatCompletionTool> {
 {{- end }}
     ]
 }
+

--- a/internal/templates/registry.go
+++ b/internal/templates/registry.go
@@ -19,7 +19,7 @@ type Registry struct {
 
 // Embed template files at compile time
 //
-//go:embed languages/*/*.tmpl common/*/*.tmpl common/github/*/*.tmpl sandbox/*/*.tmpl
+//go:embed languages/*/*.tmpl languages/*/builtin/*.tmpl common/*/*.tmpl common/github/*/*.tmpl sandbox/*/*.tmpl
 var templateFS embed.FS
 
 // RegistryOptions holds options for creating a new registry
@@ -160,6 +160,10 @@ func (r *Registry) getGoFiles(adl *schema.ADL) map[string]string {
 	}
 
 	for _, tool := range adl.Spec.Tools {
+		if schema.IsReservedToolID(tool.ID) {
+			files[fmt.Sprintf("tools/%s.go", tool.ID)] = fmt.Sprintf("builtin/%s.go", tool.ID)
+			continue
+		}
 		snakeCaseName := strings.ReplaceAll(tool.ID, "-", "_")
 		files[fmt.Sprintf("tools/%s.go", snakeCaseName)] = "tool.go"
 	}
@@ -210,6 +214,10 @@ func (r *Registry) getRustFiles(adl *schema.ADL) map[string]string {
 
 	if adl.Spec.Agent != nil {
 		for _, tool := range adl.Spec.Tools {
+			if schema.IsReservedToolID(tool.ID) {
+				files[fmt.Sprintf("src/tools/%s.rs", tool.ID)] = fmt.Sprintf("builtin/%s.rs", tool.ID)
+				continue
+			}
 			snakeCaseName := strings.ReplaceAll(tool.ID, "-", "_")
 			files[fmt.Sprintf("src/tools/%s.rs", snakeCaseName)] = "tool.rs"
 		}


### PR DESCRIPTION
## Summary

Closes #109. Two changes together:

1. **Skill manifest swap.** Generated agents now parse only YAML frontmatter from each `skills/<id>/SKILL.md` and append an `AVAILABLE SKILLS:` block to the system prompt. SKILL.md bodies stay on disk and are read on demand via the new `Read` built-in. Frontmatter is parsed via `gopkg.in/yaml.v3` (Go) and `serde_yaml` (Rust).

2. **Reserved-ID built-in tools.** Listing `- id: read`, `- id: bash`, `- id: write`, or `- id: edit` under `spec.tools` makes the generator emit a typed built-in implementation. Built-ins default to disabled — flip `spec.config.tools.<id>.enabled: true` to activate. Values are baked into the generated constructor call in `main.<ext>` as compile-time literals.

## Worked example

```yaml
spec:
  config:
    tools:
      read:
        enabled: true
        max_lines: 2000
      bash:
        enabled: true
        whitelist: [ls, cat, grep]
        timeout_seconds: 30
  tools:
    - id: read
    - id: bash
    - id: query_db
      name: query_db
      description: "..."
      schema: { ... }
  skills:
    - id: incident-response
      bare: true
      name: incident-response
      description: "..."
```

Generated `main.go` registration:

```go
readTool := tools.NewReadTool(l, tools.ReadConfig{
    Enabled:      true,
    MaxLines:     2000,
    AllowedRoots: []string{},
})
toolBox.AddTool(readTool)

bashTool := tools.NewBashTool(l, tools.BashConfig{
    Enabled:        true,
    Whitelist:      []string{"ls", "cat", "grep"},
    TimeoutSeconds: 30,
    WorkingDir:     "",
})
toolBox.AddTool(bashTool)
```

## Validator additions

- Reserved IDs may set only `id` and `tags`; user-supplied `name`/`description`/`schema`/`inject` are rejected.
- `spec.config.tools.<reserved-id>` is decoded into a typed struct (`BashBuiltinConfig` etc.) with `mapstructure.ErrorUnused: true` — typos like `tymeout_seconds` fail with `spec.config.tools.bash.tymeout_seconds`.
- `inject: ["config.tools"]` is rejected (`tools` is the reserved namespace).
- When `spec.skills` is non-empty AND `spec.agent` is set: `spec.tools` MUST list `- id: read` AND set `spec.config.tools.read.enabled: true`. Skills-only manifests without an agent block stay valid.

## Bash runtime overrides

Read inside the generated `tools/bash.<ext>` constructor:

- `A2A_BASH_DISABLED=1` is a kill switch (overrides `enabled: true` back to false).
- `A2A_BASH_WHITELIST=ls,cat,grep` overrides the compile-time whitelist.

Resolution precedence: **env > compile-time literal > built-in default (disabled)**.

## Schema bump prerequisite — paired PR

Depends on **[inference-gateway/adl#4](https://github.com/inference-gateway/adl/pull/4)** (`Tool.required` → `["id"]`). The embedded `internal/schema/schema.json` here is hand-edited to match that PR so unit tests pass; `task verify-schema` will fail in CI until that PR merges + v0.4.0 is tagged. Once tagged: bump `ADL_SCHEMA_VERSION` in `Taskfile.yml`, run `task fetch-schema`, and the embedded copy reconciles.

## Out of scope (deliberate, follow-ups)

- TypeScript built-in templates (Go + Rust only here).
- `cmd/init.go` reserved-ID interactive prompts (pure UX polish; users can edit YAML directly).
- Built-in templates assume `inference-gateway-adk` / `inference-gateway-sdk` are available in the generated project, which is the existing pattern.

## Test plan

- [x] `task fmt` clean
- [x] `task lint` clean (0 issues)
- [x] `task test` green across all packages
- [x] `task examples:test` validates all examples including updated `go-agent.yaml` and `rust-agent.yaml`
- [x] Generated minimal Go project (read+bash+write+edit + 1 skill) compiles to a working binary
- [x] Generated Rust project for the updated `rust-agent.yaml` produces correct `src/tools/{read,echo,mod}.rs`
- [ ] `task verify-schema` (blocked on adl#4 merge + v0.4.0 tag)
- [ ] `task ci` (depends on verify-schema)

## Manual checks once schema lands

1. Bump `ADL_SCHEMA_VERSION` to `v0.4.0` in `Taskfile.yml`.
2. `task fetch-schema && task generate-types` → confirm clean diff against the hand-edited schema in this PR.
3. `task ci` green.
4. Generate a project with `- id: bash` but no `spec.config.tools.bash`; verify the built-in is registered but its handler returns the "disabled" error at invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)