### PR TITLE
fix(templates): Render built-in tools with proper name/description in AGENTS.md and CLAUDE.md

### DIFF
--- a/internal/templates/common/ai/agents.md.tmpl
+++ b/internal/templates/common/ai/agents.md.tmpl
@@ -64,6 +64,12 @@ No AI provider configured - this is a minimal agent.
 
 This agent exposes {{ len .ADL.Spec.Tools }} function-call tools:
 {{- range .ADL.Spec.Tools }}
+{{- if isBuiltinToolID .ID }}{{- $m := builtinToolMeta .ID }}
+
+### {{ $m.Name }} (built-in)
+- **Description**: {{ $m.Description }}
+- **Parameters**: {{ if $m.Parameters }}{{ $m.Parameters | join ", " }}{{ else }}None{{ end }}
+{{- else }}
 
 ### {{ .Name }}
 - **Description**: {{ .Description }}
@@ -72,6 +78,7 @@ This agent exposes {{ len .ADL.Spec.Tools }} function-call tools:
 {{- end }}
 - **Input Schema**: Defined in agent configuration
 - **Output Schema**: Defined in agent configuration
+{{- end }}
 {{- end }}
 {{- else }}
 
@@ -267,7 +274,11 @@ docker run -p {{ .ADL.Spec.Server.Port }}:{{ .ADL.Spec.Server.Port }} {{ .ADL.Me
 ├── main.go                       # Server entry point
 ├── tools/                        # Function-call tools
 {{- range .ADL.Spec.Tools }}
-│   └── {{ printf "%-26s" (printf "%s.go" .Name) }}# {{ .Description }}
+{{- if isBuiltinToolID .ID }}{{- $m := builtinToolMeta .ID }}
+│   └── {{ printf "%-26s" (printf "%s.go" .ID) }}# {{ $m.Description }}
+{{- else }}
+│   └── {{ printf "%-26s" (printf "%s.go" .ID) }}# {{ .Description }}
+{{- end }}
 {{- end }}
 ├── skills/                       # Skill directories (SKILL.md + optional assets)
 {{- range .Skills }}
@@ -287,7 +298,11 @@ docker run -p {{ .ADL.Spec.Server.Port }}:{{ .ADL.Spec.Server.Port }} {{ .ADL.Me
 │   ├── main.rs                   # Server entry point
 │   └── tools/                    # Tool descriptors + handlers
 {{- range .ADL.Spec.Tools }}
-│       ├── {{ printf "%-21s" (printf "%s.rs" .Name) }}# {{ .Description }}
+{{- if isBuiltinToolID .ID }}{{- $m := builtinToolMeta .ID }}
+│       ├── {{ printf "%-21s" (printf "%s.rs" .ID) }}# {{ $m.Description }}
+{{- else }}
+│       ├── {{ printf "%-21s" (printf "%s.rs" .ID) }}# {{ .Description }}
+{{- end }}
 {{- end }}
 │       └── mod.rs                # Tools module
 ├── skills/                       # Skill directories (SKILL.md + optional assets)
@@ -308,7 +323,11 @@ docker run -p {{ .ADL.Spec.Server.Port }}:{{ .ADL.Spec.Server.Port }} {{ .ADL.Me
 │   ├── index.ts                  # Server entry point
 │   └── tools/                    # Function-call tools
 {{- range .ADL.Spec.Tools }}
-│       └── {{ printf "%-21s" (printf "%s.ts" .Name) }}# {{ .Description }}
+{{- if isBuiltinToolID .ID }}{{- $m := builtinToolMeta .ID }}
+│       └── {{ printf "%-21s" (printf "%s.ts" .ID) }}# {{ $m.Description }}
+{{- else }}
+│       └── {{ printf "%-21s" (printf "%s.ts" .ID) }}# {{ .Description }}
+{{- end }}
 {{- end }}
 ├── skills/                       # Skill directories (SKILL.md + optional assets)
 {{- range .Skills }}

--- a/internal/templates/common/ai/claude.md.tmpl
+++ b/internal/templates/common/ai/claude.md.tmpl
@@ -77,7 +77,11 @@ The agent uses OpenAI-compatible LLM client. Configure with:
 {{- if .ADL.Spec.Tools }}
 The following tools are currently defined:
 {{- range .ADL.Spec.Tools }}
+{{- if isBuiltinToolID .ID }}{{- $m := builtinToolMeta .ID }}
+- **{{ $m.Name }}** (built-in): {{ $m.Description }}
+{{- else }}
 - **{{ .Name }}**: {{ .Description }}
+{{- end }}
 {{- end }}
 
 To modify tools:


### PR DESCRIPTION
Fixes #112

## Summary

Built-in, config-gated tools (e.g. `read`, `bash`) declared with only `id` have empty `.Name`/`.Description` fields, which caused malformed rows like `.go` / `****: ` in the generated AGENTS.md and CLAUDE.md. The templates now detect reserved tool IDs via `isBuiltinToolID` and pull metadata from `builtinToolMeta`, matching the pattern already used in `README.md.tmpl`.

Affects:
- Tools section + Go/Rust/TypeScript structure blocks in `agents.md.tmpl`
- "Tools (function-call)" list in `claude.md.tmpl`

## Test plan
- [x] `task ci` passes (fmt, lint, test, build, verify-schema)
- [x] Verified generated output for `examples/go-agent.yaml` and `examples/rust-agent.yaml`

🤖 Generated with [Claude Code](https://claude.ai/code)