### PR TITLE
fix(templates): Lowercase builtin tool error strings to satisfy staticcheck ST1005

### DIFF
--- a/internal/templates/languages/go/builtin/bash.go.tmpl
+++ b/internal/templates/languages/go/builtin/bash.go.tmpl
@@ -74,7 +74,7 @@ func NewBashTool(logger *zap.Logger, cfg BashConfig) server.Tool {
 // Handler executes the Bash tool.
 func (t *BashTool) Handler(ctx context.Context, args map[string]any) (string, error) {
 	if !t.cfg.Enabled {
-		return "", errors.New("Bash tool is disabled; set spec.config.tools.bash.enabled: true and ensure A2A_BASH_DISABLED is not 1")
+		return "", errors.New("bash tool is disabled; set spec.config.tools.bash.enabled: true and ensure A2A_BASH_DISABLED is not 1")
 	}
 
 	command, _ := args["command"].(string)

--- a/internal/templates/languages/go/builtin/edit.go.tmpl
+++ b/internal/templates/languages/go/builtin/edit.go.tmpl
@@ -59,7 +59,7 @@ func NewEditTool(logger *zap.Logger, cfg EditConfig) server.Tool {
 // Handler executes the Edit tool.
 func (t *EditTool) Handler(ctx context.Context, args map[string]any) (string, error) {
 	if !t.cfg.Enabled {
-		return "", errors.New("Edit tool is disabled; set spec.config.tools.edit.enabled: true in the ADL and regenerate")
+		return "", errors.New("edit tool is disabled; set spec.config.tools.edit.enabled: true in the ADL and regenerate")
 	}
 
 	rawPath, _ := args["file_path"].(string)

--- a/internal/templates/languages/go/builtin/read.go.tmpl
+++ b/internal/templates/languages/go/builtin/read.go.tmpl
@@ -66,7 +66,7 @@ func NewReadTool(logger *zap.Logger, cfg ReadConfig) server.Tool {
 // Handler executes the Read tool.
 func (t *ReadTool) Handler(ctx context.Context, args map[string]any) (string, error) {
 	if !t.cfg.Enabled {
-		return "", errors.New("Read tool is disabled; set spec.config.tools.read.enabled: true in the ADL and regenerate")
+		return "", errors.New("read tool is disabled; set spec.config.tools.read.enabled: true in the ADL and regenerate")
 	}
 
 	rawPath, _ := args["file_path"].(string)
@@ -94,7 +94,7 @@ func (t *ReadTool) Handler(ctx context.Context, args map[string]any) (string, er
 	cleaned := filepath.Clean(rawPath)
 
 	if isImagePath(cleaned) {
-		return "", fmt.Errorf("Read does not support image files (%s); use a multimodal API instead", filepath.Ext(cleaned))
+		return "", fmt.Errorf("read does not support image files (%s); use a multimodal API instead", filepath.Ext(cleaned))
 	}
 
 	file, err := os.Open(cleaned)

--- a/internal/templates/languages/go/builtin/write.go.tmpl
+++ b/internal/templates/languages/go/builtin/write.go.tmpl
@@ -55,7 +55,7 @@ func NewWriteTool(logger *zap.Logger, cfg WriteConfig) server.Tool {
 // Handler executes the Write tool.
 func (t *WriteTool) Handler(ctx context.Context, args map[string]any) (string, error) {
 	if !t.cfg.Enabled {
-		return "", errors.New("Write tool is disabled; set spec.config.tools.write.enabled: true in the ADL and regenerate")
+		return "", errors.New("write tool is disabled; set spec.config.tools.write.enabled: true in the ADL and regenerate")
 	}
 
 	rawPath, _ := args["file_path"].(string)

--- a/internal/templates/languages/rust/builtin/bash.rs.tmpl
+++ b/internal/templates/languages/rust/builtin/bash.rs.tmpl
@@ -70,7 +70,7 @@ pub fn descriptor() -> ChatCompletionTool {
 /// Handle a Bash invocation.
 pub async fn handle(args: Value, cfg: Config) -> anyhow::Result<String> {
     if !cfg.enabled {
-        bail!("Bash tool is disabled; set spec.config.tools.bash.enabled: true and ensure A2A_BASH_DISABLED is not 1");
+        bail!("bash tool is disabled; set spec.config.tools.bash.enabled: true and ensure A2A_BASH_DISABLED is not 1");
     }
 
     let command = args

--- a/internal/templates/languages/rust/builtin/edit.rs.tmpl
+++ b/internal/templates/languages/rust/builtin/edit.rs.tmpl
@@ -53,7 +53,7 @@ pub fn descriptor() -> ChatCompletionTool {
 /// Handle an Edit invocation.
 pub async fn handle(args: Value, cfg: Config) -> anyhow::Result<String> {
     if !cfg.enabled {
-        bail!("Edit tool is disabled; set spec.config.tools.edit.enabled: true in the ADL and regenerate");
+        bail!("edit tool is disabled; set spec.config.tools.edit.enabled: true in the ADL and regenerate");
     }
 
     let file_path = args

--- a/internal/templates/languages/rust/builtin/read.rs.tmpl
+++ b/internal/templates/languages/rust/builtin/read.rs.tmpl
@@ -63,7 +63,7 @@ pub fn descriptor() -> ChatCompletionTool {
 /// Handle a Read invocation.
 pub async fn handle(args: Value, cfg: Config) -> anyhow::Result<String> {
     if !cfg.enabled {
-        bail!("Read tool is disabled; set spec.config.tools.read.enabled: true in the ADL and regenerate");
+        bail!("read tool is disabled; set spec.config.tools.read.enabled: true in the ADL and regenerate");
     }
 
     let file_path = args
@@ -73,7 +73,7 @@ pub async fn handle(args: Value, cfg: Config) -> anyhow::Result<String> {
         .to_string();
 
     if is_image_path(&file_path) {
-        bail!("Read does not support image files ({}); use a multimodal API instead", file_path);
+        bail!("read does not support image files ({}); use a multimodal API instead", file_path);
     }
 
     validate_path(&cfg.allowed_roots, &file_path)?;

--- a/internal/templates/languages/rust/builtin/write.rs.tmpl
+++ b/internal/templates/languages/rust/builtin/write.rs.tmpl
@@ -49,7 +49,7 @@ pub fn descriptor() -> ChatCompletionTool {
 /// Handle a Write invocation.
 pub async fn handle(args: Value, cfg: Config) -> anyhow::Result<String> {
     if !cfg.enabled {
-        bail!("Write tool is disabled; set spec.config.tools.write.enabled: true in the ADL and regenerate");
+        bail!("write tool is disabled; set spec.config.tools.write.enabled: true in the ADL and regenerate");
     }
 
     let file_path = args


### PR DESCRIPTION
## Summary

Fixes #113.

The generated Go `read` built-in emitted error strings beginning with a capital letter, causing downstream projects that regenerate it to fail `golangci-lint`'s `staticcheck` rule `ST1005: error strings should not be capitalized` out of the box.

- Lowercased the leading word in the two `read.go.tmpl` errors called out in the issue.
- Applied the same fix to the sibling Go builtins (`bash`, `edit`, `write`) which share the same pattern and would fail ST1005 identically.
- Aligned the wording in the matching Rust templates (`read`, `edit`, `bash`, `write`) per the issue's suggestion, so the two implementations stay in sync.

## Test plan

- [x] `task ci` (fmt, lint, test, build, verify-schema) passes locally.
- [ ] Regenerate a downstream agent (e.g. `mock-agent`) and confirm `golangci-lint run` no longer reports ST1005 on `tools/read.go`.

Generated with [Claude Code](https://claude.ai/code)