### PR TITLE
refactor(builtin-tools): Load Go built-in tool config from env vars via envconfig

### DIFF
--- a/internal/templates/common/docs/README.md.tmpl
+++ b/internal/templates/common/docs/README.md.tmpl
@@ -110,16 +110,26 @@ Configure the agent via environment variables:
 
 ### Custom Configuration
 
-The following custom configuration variables are available:
+The following custom configuration variables are available. Defaults are
+derived from `spec.config.*` in `agent.yaml`; the env vars below override
+them at runtime.
 
-| Category | Variable | Description | Default |
-|----------|----------|-------------|---------|
+| Category | Variable | Default |
+|----------|----------|---------|
 {{- range $category, $configs := .ADL.Spec.Config }}
 {{- range $key, $value := $configs }}
-| **{{ $category | title }}** | `{{ $category | toUpperSnakeCase }}_{{ $key | toUpperSnakeCase }}` | {{ $key | title }} configuration | `{{ $value }}` |
+{{- if kindIs "map" $value }}
+{{- range $leaf, $leafVal := $value }}
+| **{{ $category | title }}** | `{{ $category | toUpperSnakeCase }}_{{ $key | toUpperSnakeCase }}_{{ $leaf | toUpperSnakeCase }}` | `{{ $leafVal }}` |
+{{- end }}
+{{- else }}
+| **{{ $category | title }}** | `{{ $category | toUpperSnakeCase }}_{{ $key | toUpperSnakeCase }}` | `{{ $value }}` |
 {{- end }}
 {{- end }}
 {{- end }}
+{{- end }}
+
+### Environment Variables
 
 | Category | Variable | Description | Default |
 |----------|----------|-------------|---------|

--- a/internal/templates/languages/go/builtin/bash.go.tmpl
+++ b/internal/templates/languages/go/builtin/bash.go.tmpl
@@ -5,57 +5,46 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 	"time"
 
 	server "github.com/inference-gateway/adk/server"
+	envconfig "github.com/sethvargo/go-envconfig"
 	zap "go.uber.org/zap"
 )
 
-// BashConfig is the compile-time config for the Bash built-in. Values
-// flow in from spec.config.tools.bash at generation time. Runtime env
-// vars `A2A_BASH_DISABLED` and `A2A_BASH_WHITELIST` override the
-// compile-time values.
+// BashConfig is the runtime config for the Bash built-in. Defaults are
+// baked from spec.config.tools.bash at generation time; the TOOLS_BASH_*
+// env vars override them at startup.
 type BashConfig struct {
-	Enabled        bool
-	Whitelist      []string
-	TimeoutSeconds int
-	WorkingDir     string
+	Enabled        bool     `env:"TOOLS_BASH_ENABLED, default={{ printf "%t" .Config.Enabled }}"`
+	Whitelist      []string `env:"TOOLS_BASH_WHITELIST{{- if .Config.Whitelist }}, default={{ join "," .Config.Whitelist }}{{- end }}"`
+	TimeoutSeconds int      `env:"TOOLS_BASH_TIMEOUT_SECONDS, default={{ .Config.TimeoutSeconds }}"`
+	WorkingDir     string   `env:"TOOLS_BASH_WORKING_DIR, default={{ .Config.WorkingDir }}"`
 }
 
 // BashTool exposes a Bash built-in. Disabled by default; flip
 // spec.config.tools.bash.enabled: true in your ADL to activate.
-// Resolution: env > compile-time literal > built-in default.
 type BashTool struct {
 	logger *zap.Logger
 	cfg    BashConfig
 }
 
-// NewBashTool builds a Bash tool with the resolved config baked in.
-// Env-var overrides are read here, once, at agent startup.
-func NewBashTool(logger *zap.Logger, cfg BashConfig) server.Tool {
+// NewBashTool builds a Bash tool, resolving config from TOOLS_BASH_* env
+// vars (or the spec.config.tools.bash defaults baked in at generation).
+func NewBashTool(ctx context.Context, logger *zap.Logger) (server.Tool, error) {
+	var cfg BashConfig
+	if err := envconfig.Process(ctx, &cfg); err != nil {
+		return nil, fmt.Errorf("load Bash config: %w", err)
+	}
 	if cfg.TimeoutSeconds <= 0 {
 		cfg.TimeoutSeconds = 30
-	}
-	if os.Getenv("A2A_BASH_DISABLED") == "1" {
-		cfg.Enabled = false
-	}
-	if v := os.Getenv("A2A_BASH_WHITELIST"); v != "" {
-		parts := strings.Split(v, ",")
-		out := make([]string, 0, len(parts))
-		for _, p := range parts {
-			if trimmed := strings.TrimSpace(p); trimmed != "" {
-				out = append(out, trimmed)
-			}
-		}
-		cfg.Whitelist = out
 	}
 	t := &BashTool{logger: logger, cfg: cfg}
 	return server.NewBasicTool(
 		"Bash",
-		"Execute a shell command. Subject to the configured whitelist and timeout; honors A2A_BASH_DISABLED as a runtime kill switch.",
+		"Execute a shell command. Subject to the configured whitelist and timeout.",
 		map[string]any{
 			"type":                 "object",
 			"additionalProperties": false,
@@ -68,13 +57,13 @@ func NewBashTool(logger *zap.Logger, cfg BashConfig) server.Tool {
 			"required": []string{"command"},
 		},
 		t.Handler,
-	)
+	), nil
 }
 
 // Handler executes the Bash tool.
 func (t *BashTool) Handler(ctx context.Context, args map[string]any) (string, error) {
 	if !t.cfg.Enabled {
-		return "", errors.New("bash tool is disabled; set spec.config.tools.bash.enabled: true and ensure A2A_BASH_DISABLED is not 1")
+		return "", errors.New("bash tool is disabled; set spec.config.tools.bash.enabled: true or TOOLS_BASH_ENABLED=true")
 	}
 
 	command, _ := args["command"].(string)

--- a/internal/templates/languages/go/builtin/edit.go.tmpl
+++ b/internal/templates/languages/go/builtin/edit.go.tmpl
@@ -10,14 +10,16 @@ import (
 	"strings"
 
 	server "github.com/inference-gateway/adk/server"
+	envconfig "github.com/sethvargo/go-envconfig"
 	zap "go.uber.org/zap"
 )
 
-// EditConfig is the compile-time config for the Edit built-in. Values
-// flow in from spec.config.tools.edit at generation time.
+// EditConfig is the runtime config for the Edit built-in. Defaults are
+// baked from spec.config.tools.edit at generation time; the TOOLS_EDIT_*
+// env vars override them at startup.
 type EditConfig struct {
-	Enabled      bool
-	AllowedRoots []string
+	Enabled      bool     `env:"TOOLS_EDIT_ENABLED, default={{ printf "%t" .Config.Enabled }}"`
+	AllowedRoots []string `env:"TOOLS_EDIT_ALLOWED_ROOTS{{- if .Config.AllowedRoots }}, default={{ join "," .Config.AllowedRoots }}{{- end }}"`
 }
 
 // EditTool exposes an Edit built-in. Disabled by default; flip
@@ -27,8 +29,13 @@ type EditTool struct {
 	cfg    EditConfig
 }
 
-// NewEditTool builds an Edit tool with the resolved config baked in.
-func NewEditTool(logger *zap.Logger, cfg EditConfig) server.Tool {
+// NewEditTool builds an Edit tool, resolving config from TOOLS_EDIT_* env
+// vars (or the spec.config.tools.edit defaults baked in at generation).
+func NewEditTool(ctx context.Context, logger *zap.Logger) (server.Tool, error) {
+	var cfg EditConfig
+	if err := envconfig.Process(ctx, &cfg); err != nil {
+		return nil, fmt.Errorf("load Edit config: %w", err)
+	}
 	t := &EditTool{logger: logger, cfg: cfg}
 	return server.NewBasicTool(
 		"Edit",
@@ -53,7 +60,7 @@ func NewEditTool(logger *zap.Logger, cfg EditConfig) server.Tool {
 			"required": []string{"file_path", "old_string", "new_string"},
 		},
 		t.Handler,
-	)
+	), nil
 }
 
 // Handler executes the Edit tool.

--- a/internal/templates/languages/go/builtin/read.go.tmpl
+++ b/internal/templates/languages/go/builtin/read.go.tmpl
@@ -11,15 +11,17 @@ import (
 	"strings"
 
 	server "github.com/inference-gateway/adk/server"
+	envconfig "github.com/sethvargo/go-envconfig"
 	zap "go.uber.org/zap"
 )
 
-// ReadConfig is the compile-time config for the Read built-in. Values
-// flow in from spec.config.tools.read at generation time.
+// ReadConfig is the runtime config for the Read built-in. Defaults are
+// baked from spec.config.tools.read at generation time; the TOOLS_READ_*
+// env vars override them at startup.
 type ReadConfig struct {
-	Enabled      bool
-	MaxLines     int
-	AllowedRoots []string
+	Enabled      bool     `env:"TOOLS_READ_ENABLED, default={{ printf "%t" .Config.Enabled }}"`
+	MaxLines     int      `env:"TOOLS_READ_MAX_LINES, default={{ .Config.MaxLines }}"`
+	AllowedRoots []string `env:"TOOLS_READ_ALLOWED_ROOTS{{- if .Config.AllowedRoots }}, default={{ join "," .Config.AllowedRoots }}{{- end }}"`
 }
 
 // ReadTool exposes a Read built-in. Disabled by default; flip
@@ -29,8 +31,13 @@ type ReadTool struct {
 	cfg    ReadConfig
 }
 
-// NewReadTool builds a Read tool with the resolved config baked in.
-func NewReadTool(logger *zap.Logger, cfg ReadConfig) server.Tool {
+// NewReadTool builds a Read tool, resolving config from TOOLS_READ_* env
+// vars (or the spec.config.tools.read defaults baked in at generation).
+func NewReadTool(ctx context.Context, logger *zap.Logger) (server.Tool, error) {
+	var cfg ReadConfig
+	if err := envconfig.Process(ctx, &cfg); err != nil {
+		return nil, fmt.Errorf("load Read config: %w", err)
+	}
 	if cfg.MaxLines <= 0 {
 		cfg.MaxLines = 2000
 	}
@@ -60,7 +67,7 @@ func NewReadTool(logger *zap.Logger, cfg ReadConfig) server.Tool {
 			"required": []string{"file_path"},
 		},
 		t.Handler,
-	)
+	), nil
 }
 
 // Handler executes the Read tool.

--- a/internal/templates/languages/go/builtin/write.go.tmpl
+++ b/internal/templates/languages/go/builtin/write.go.tmpl
@@ -10,14 +10,16 @@ import (
 	"strings"
 
 	server "github.com/inference-gateway/adk/server"
+	envconfig "github.com/sethvargo/go-envconfig"
 	zap "go.uber.org/zap"
 )
 
-// WriteConfig is the compile-time config for the Write built-in. Values
-// flow in from spec.config.tools.write at generation time.
+// WriteConfig is the runtime config for the Write built-in. Defaults are
+// baked from spec.config.tools.write at generation time; the TOOLS_WRITE_*
+// env vars override them at startup.
 type WriteConfig struct {
-	Enabled      bool
-	AllowedRoots []string
+	Enabled      bool     `env:"TOOLS_WRITE_ENABLED, default={{ printf "%t" .Config.Enabled }}"`
+	AllowedRoots []string `env:"TOOLS_WRITE_ALLOWED_ROOTS{{- if .Config.AllowedRoots }}, default={{ join "," .Config.AllowedRoots }}{{- end }}"`
 }
 
 // WriteTool exposes a Write built-in. Disabled by default; flip
@@ -27,8 +29,13 @@ type WriteTool struct {
 	cfg    WriteConfig
 }
 
-// NewWriteTool builds a Write tool with the resolved config baked in.
-func NewWriteTool(logger *zap.Logger, cfg WriteConfig) server.Tool {
+// NewWriteTool builds a Write tool, resolving config from TOOLS_WRITE_*
+// env vars (or the spec.config.tools.write defaults baked in at generation).
+func NewWriteTool(ctx context.Context, logger *zap.Logger) (server.Tool, error) {
+	var cfg WriteConfig
+	if err := envconfig.Process(ctx, &cfg); err != nil {
+		return nil, fmt.Errorf("load Write config: %w", err)
+	}
 	t := &WriteTool{logger: logger, cfg: cfg}
 	return server.NewBasicTool(
 		"Write",
@@ -49,7 +56,7 @@ func NewWriteTool(logger *zap.Logger, cfg WriteConfig) server.Tool {
 			"required": []string{"file_path", "content"},
 		},
 		t.Handler,
-	)
+	), nil
 }
 
 // Handler executes the Write tool.

--- a/internal/templates/languages/go/main.go.tmpl
+++ b/internal/templates/languages/go/main.go.tmpl
@@ -197,42 +197,39 @@ func main() {
 	{{- if eq .ID "read" }}
 
 	// Register Read built-in
-	readTool := tools.NewReadTool(l, tools.ReadConfig{
-		Enabled:      {{ $.BuiltinConfigs.Read.Enabled }},
-		MaxLines:     {{ $.BuiltinConfigs.Read.MaxLines }},
-		AllowedRoots: []string{ {{- range $i, $r := $.BuiltinConfigs.Read.AllowedRoots }}{{ if $i }}, {{ end }}{{ $r | quote }}{{- end }} },
-	})
+	readTool, err := tools.NewReadTool(ctx, l)
+	if err != nil {
+		l.Fatal("failed to construct Read tool", zap.Error(err))
+	}
 	toolBox.AddTool(readTool)
-	l.Info("registered built-in: Read", zap.Bool("enabled", {{ $.BuiltinConfigs.Read.Enabled }}))
+	l.Info("registered built-in: Read")
 	{{- else if eq .ID "bash" }}
 
 	// Register Bash built-in
-	bashTool := tools.NewBashTool(l, tools.BashConfig{
-		Enabled:        {{ $.BuiltinConfigs.Bash.Enabled }},
-		Whitelist:      []string{ {{- range $i, $w := $.BuiltinConfigs.Bash.Whitelist }}{{ if $i }}, {{ end }}{{ $w | quote }}{{- end }} },
-		TimeoutSeconds: {{ $.BuiltinConfigs.Bash.TimeoutSeconds }},
-		WorkingDir:     {{ $.BuiltinConfigs.Bash.WorkingDir | quote }},
-	})
+	bashTool, err := tools.NewBashTool(ctx, l)
+	if err != nil {
+		l.Fatal("failed to construct Bash tool", zap.Error(err))
+	}
 	toolBox.AddTool(bashTool)
-	l.Info("registered built-in: Bash", zap.Bool("enabled", {{ $.BuiltinConfigs.Bash.Enabled }}))
+	l.Info("registered built-in: Bash")
 	{{- else if eq .ID "write" }}
 
 	// Register Write built-in
-	writeTool := tools.NewWriteTool(l, tools.WriteConfig{
-		Enabled:      {{ $.BuiltinConfigs.Write.Enabled }},
-		AllowedRoots: []string{ {{- range $i, $r := $.BuiltinConfigs.Write.AllowedRoots }}{{ if $i }}, {{ end }}{{ $r | quote }}{{- end }} },
-	})
+	writeTool, err := tools.NewWriteTool(ctx, l)
+	if err != nil {
+		l.Fatal("failed to construct Write tool", zap.Error(err))
+	}
 	toolBox.AddTool(writeTool)
-	l.Info("registered built-in: Write", zap.Bool("enabled", {{ $.BuiltinConfigs.Write.Enabled }}))
+	l.Info("registered built-in: Write")
 	{{- else if eq .ID "edit" }}
 
 	// Register Edit built-in
-	editTool := tools.NewEditTool(l, tools.EditConfig{
-		Enabled:      {{ $.BuiltinConfigs.Edit.Enabled }},
-		AllowedRoots: []string{ {{- range $i, $r := $.BuiltinConfigs.Edit.AllowedRoots }}{{ if $i }}, {{ end }}{{ $r | quote }}{{- end }} },
-	})
+	editTool, err := tools.NewEditTool(ctx, l)
+	if err != nil {
+		l.Fatal("failed to construct Edit tool", zap.Error(err))
+	}
 	toolBox.AddTool(editTool)
-	l.Info("registered built-in: Edit", zap.Bool("enabled", {{ $.BuiltinConfigs.Edit.Enabled }}))
+	l.Info("registered built-in: Edit")
 	{{- else }}
 
 	// Register {{ .Name }} tool


### PR DESCRIPTION
## Summary

- Replace compile-time config struct literals + ad-hoc `os.Getenv` overrides in the Go Read/Bash/Write/Edit built-in templates with `sethvargo/go-envconfig` tags. Defaults are still baked from `spec.config.tools.<id>` at generation; every field is now overridable at runtime via `TOOLS_<TOOL>_<FIELD>` (e.g. `TOOLS_BASH_ENABLED`, `TOOLS_BASH_WHITELIST`, `TOOLS_READ_MAX_LINES`).
- Constructor signatures change to `New<Tool>Tool(ctx context.Context, logger *zap.Logger) (server.Tool, error)`; `main.go.tmpl` updated to call the new signatures and surface init errors via `l.Fatal`.
- README.md.tmpl: drop the description column from the custom-config table, recurse one level into nested maps (so `spec.config.tools.bash.timeout_seconds` renders as `TOOLS_BASH_TIMEOUT_SECONDS`), and fix the `### Environment Variables` heading to render outside the `if .ADL.Spec.Config` block so it always heads the static A2A_* table.

## Follow-ups

- `CLAUDE.md` still documents the legacy `A2A_BASH_DISABLED` / `A2A_BASH_WHITELIST` env vars in the "Reserved tool config" section - that doc needs updating to reflect the `TOOLS_BASH_*` names (not done here to keep this PR template-only).