### PR TITLE
fix(templates): COPY skills/ into runtime image when spec.skills is non-empty

### DIFF
--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -159,6 +160,70 @@ spec:
 	testSkillPath := filepath.Join(outputPath, "skills", "test-skill", "SKILL.md")
 	if _, err := os.Stat(testSkillPath); os.IsNotExist(err) {
 		t.Errorf("expected skills/test-skill/SKILL.md to be scaffolded")
+	}
+
+	dockerfilePath := filepath.Join(outputPath, "Dockerfile")
+	dockerfileBytes, err := os.ReadFile(dockerfilePath)
+	if err != nil {
+		t.Fatalf("failed to read generated Dockerfile: %v", err)
+	}
+	dockerfileContent := string(dockerfileBytes)
+	if !strings.Contains(dockerfileContent, "COPY --from=builder /app/skills ./skills") {
+		t.Errorf("expected Dockerfile to COPY skills/ when spec.skills is non-empty, got:\n%s", dockerfileContent)
+	}
+}
+
+func TestGenerateDockerfileOmitsSkillsCopyWhenAbsent(t *testing.T) {
+	tempDir := t.TempDir()
+	outputPath := filepath.Join(tempDir, "no-skills-output")
+
+	adlContent := `apiVersion: adl.inference-gateway.com/v1
+kind: Agent
+metadata:
+  name: no-skills-agent
+  description: Agent without skills
+  version: 1.0.0
+spec:
+  capabilities:
+    streaming: true
+    pushNotifications: false
+    stateTransitionHistory: false
+  server:
+    port: 8080
+    debug: false
+  language:
+    go:
+      module: github.com/test/no-skills
+      version: "1.26.2"
+`
+
+	adlPath := filepath.Join(tempDir, "agent.yaml")
+	if err := os.WriteFile(adlPath, []byte(adlContent), 0644); err != nil {
+		t.Fatalf("failed to write ADL file: %v", err)
+	}
+
+	originalADLFile := adlFile
+	originalOutputDir := outputDir
+	defer func() {
+		adlFile = originalADLFile
+		outputDir = originalOutputDir
+	}()
+
+	adlFile = adlPath
+	outputDir = outputPath
+
+	if err := runGenerate(generateCmd, []string{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	dockerfilePath := filepath.Join(outputPath, "Dockerfile")
+	dockerfileBytes, err := os.ReadFile(dockerfilePath)
+	if err != nil {
+		t.Fatalf("failed to read generated Dockerfile: %v", err)
+	}
+	dockerfileContent := string(dockerfileBytes)
+	if strings.Contains(dockerfileContent, "/app/skills") {
+		t.Errorf("expected Dockerfile to omit skills COPY when spec.skills is empty, got:\n%s", dockerfileContent)
 	}
 }
 

--- a/internal/templates/common/docker/dockerfile.go.tmpl
+++ b/internal/templates/common/docker/dockerfile.go.tmpl
@@ -46,6 +46,11 @@ COPY --from=builder /app/main .
 
 # Copy agent card
 COPY --from=builder /app/.well-known ./.well-known
+{{- if gt (len .ADL.Spec.Skills) 0 }}
+
+# Copy skills directory so loadSkillsManifest can read SKILL.md at runtime
+COPY --from=builder /app/skills ./skills
+{{- end }}
 
 # Change ownership to agent user
 RUN chown -R agent:a2a /app

--- a/internal/templates/common/docker/dockerfile.rust.tmpl
+++ b/internal/templates/common/docker/dockerfile.rust.tmpl
@@ -33,6 +33,11 @@ COPY --from=builder /app/target/release/{{ .ADL.Spec.Language.Rust.PackageName }
 
 # Copy agent card
 COPY --from=builder /app/.well-known ./.well-known
+{{- if gt (len .ADL.Spec.Skills) 0 }}
+
+# Copy skills directory so the runtime can read SKILL.md files
+COPY skills ./skills
+{{- end }}
 
 # Create a2a group and agent user
 RUN groupadd -g 1001 a2a && \


### PR DESCRIPTION
Fixes #117

## Summary

Generated Dockerfiles now copy the `skills/` directory into the final runtime stage when `spec.skills` declares at least one entry. Without this, the runtime `loadSkillsManifest` call silently returned an empty string in container builds because `skills/` was missing, so the model never saw the `AVAILABLE SKILLS` block in the system prompt.

The copy is guarded by `gt (len .ADL.Spec.Skills) 0` so manifests with no skills don't get an empty layer. For the Go template the directory is pulled from the builder stage (already present via `COPY . .`); the Rust builder doesn't stage `skills/`, so it's copied directly from the build context.

## Test plan

- [x] `TestGenerateWithoutInit` now asserts `COPY --from=builder /app/skills ./skills` is present when skills are declared
- [x] New `TestGenerateDockerfileOmitsSkillsCopyWhenAbsent` asserts no `/app/skills` line when skills are empty
- [x] `go test ./...` passes
- [x] `go vet ./...` passes

Generated with [Claude Code](https://claude.ai/code)