### PR TITLE
feat(scm): Auto-generate Dependabot configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1016,6 +1016,7 @@ my-go-agent/
 │   ├── workflows/             # Generated when using --ci flag
 │   │   ├── ci.yml             # GitHub Actions CI workflow
 │   │   └── cd.yml             # GitHub Actions CD workflow (with --cd flag)
+│   ├── dependabot.yml         # Generated when scm.dependabot: true
 │   └── ISSUE_TEMPLATE/        # Generated when issue_templates: true
 │       ├── bug_report.md      # Bug report template
 │       ├── feature_request.md # Feature request template
@@ -1368,6 +1369,7 @@ spec:
     url: "https://github.com/company/my-agent"
     github_app: false # optional: enable GitHub App for CD
     issue_templates: true # optional: generate GitHub issue templates
+    dependabot: true # optional: generate Dependabot configuration
 ```
 
 **Features:**
@@ -1377,6 +1379,7 @@ spec:
 - **Workflow Optimization** - SCM-specific optimizations and best practices
 - **GitHub App Support** - Enhanced security for enterprise CD pipelines
 - **Issue Templates** - Generate GitHub issue templates for standardized bug reports and feature requests
+- **Dependabot Configuration** - Auto-generate `.github/dependabot.yml` for dependency upgrades
 
 #### GitHub App Integration
 
@@ -1449,6 +1452,32 @@ When `issue_templates: true` is set, the following templates are generated in `.
 - **GitHub Integration** - Automatic labels and assignees configured in frontmatter
 - **Severity Levels** - Priority classification for bug reports (critical, high, medium, low)
 - **Environment Info** - Sections for capturing logs, system details, and configurations
+
+## Dependabot Configuration
+
+The ADL CLI can generate a `.github/dependabot.yml` manifest so generated agent
+projects keep their dependencies up to date automatically. The feature defaults
+to `false` and is opted into via `spec.scm.dependabot`:
+
+```yaml
+spec:
+  scm:
+    provider: github
+    url: "https://github.com/company/my-agent"
+    dependabot: true # Enable Dependabot configuration
+```
+
+When `dependabot: true` is set (and the SCM provider is GitHub), the generator
+emits a weekly-schedule manifest covering the ecosystems present in your ADL:
+
+- **Language ecosystem** - `gomod`, `cargo`, or `npm` (selected from `spec.language`)
+- **`github-actions`** - Keeps `.github/workflows/` actions pinned
+- **`docker`** - Tracks the base image in the generated `Dockerfile`
+- **`devcontainers`** - Included when `spec.sandbox.devcontainer.enabled: true`
+
+Each ecosystem groups all updates into a single PR per week to keep noise low.
+The default of `false` keeps the existing behavior unchanged for projects that
+manage dependency upgrades themselves.
 
 ## Examples
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -252,6 +252,7 @@ type adlData struct {
 			URL            string `yaml:"url,omitempty"`
 			GithubApp      bool   `yaml:"github_app,omitempty"`
 			IssueTemplates bool   `yaml:"issue_templates"`
+			Dependabot     bool   `yaml:"dependabot"`
 		} `yaml:"scm,omitempty"`
 		Sandbox *struct {
 			Flox *struct {
@@ -719,6 +720,7 @@ func collectADLInfo(cmd *cobra.Command, projectName string, useDefaults bool) *a
 			URL            string `yaml:"url,omitempty"`
 			GithubApp      bool   `yaml:"github_app,omitempty"`
 			IssueTemplates bool   `yaml:"issue_templates"`
+			Dependabot     bool   `yaml:"dependabot"`
 		}{
 			Provider: scmProvider,
 		}
@@ -741,6 +743,13 @@ func collectADLInfo(cmd *cobra.Command, projectName string, useDefaults bool) *a
 				fmt.Printf("Enable issue templates [y/n] [n]: n\n")
 			} else {
 				adl.Spec.SCM.IssueTemplates = promptBool("Enable issue templates", false)
+			}
+
+			if useDefaults {
+				adl.Spec.SCM.Dependabot = false
+				fmt.Printf("Enable Dependabot configuration [y/n] [n]: n\n")
+			} else {
+				adl.Spec.SCM.Dependabot = promptBool("Enable Dependabot configuration", false)
 			}
 		}
 	}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -133,6 +133,47 @@ func TestInitIssueTemplatesDefault(t *testing.T) {
 	}
 }
 
+func TestInitDependabotDefault(t *testing.T) {
+	tempDir := t.TempDir()
+	outputPath := filepath.Join(tempDir, "test-output")
+
+	cmd := initCmd
+	if err := cmd.Flags().Set("defaults", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("path", outputPath); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runInit(cmd, []string{"test-agent"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	adlPath := filepath.Join(outputPath, "agent.yaml")
+	content, err := os.ReadFile(adlPath)
+	if err != nil {
+		t.Fatalf("failed to read ADL file: %v", err)
+	}
+
+	var adl adlData
+	if err := yaml.Unmarshal(content, &adl); err != nil {
+		t.Fatalf("failed to parse ADL YAML: %v", err)
+	}
+
+	if adl.Spec.SCM == nil {
+		t.Fatalf("expected SCM configuration to be present")
+	}
+	if adl.Spec.SCM.Dependabot {
+		t.Errorf("expected Dependabot to be false by default, got true")
+	}
+
+	contentStr := string(content)
+	if !strings.Contains(contentStr, "dependabot: false") {
+		t.Errorf("ADL file should contain 'dependabot: false'")
+	}
+}
+
 func TestInitDoesNotGenerateCode(t *testing.T) {
 	tempDir := t.TempDir()
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -562,6 +562,129 @@ func TestGenerator_generateCD(t *testing.T) {
 	}
 }
 
+func TestGenerator_Dependabot(t *testing.T) {
+	makeADL := func(name string, dependabot bool, lang schema.Language, sandbox *schema.SandboxConfig) *schema.ADL {
+		return &schema.ADL{
+			APIVersion: "adl.inference-gateway.com/v1",
+			Kind:       "Agent",
+			Metadata: schema.Metadata{
+				Name:        name,
+				Description: "Test agent",
+				Version:     "1.0.0",
+			},
+			Spec: schema.Spec{
+				Capabilities: schema.Capabilities{
+					Streaming:              true,
+					PushNotifications:      false,
+					StateTransitionHistory: false,
+				},
+				Server: schema.Server{
+					Port: 8080,
+				},
+				Language: lang,
+				Sandbox:  sandbox,
+				SCM: &schema.SCM{
+					Provider:   schema.SCMProviderGithub,
+					URL:        "https://github.com/example/" + name,
+					Dependabot: dependabot,
+				},
+			},
+		}
+	}
+
+	goLang := schema.Language{
+		Go: &schema.GoConfig{
+			Module:  "github.com/example/test",
+			Version: "1.26.2",
+		},
+	}
+	rustLang := schema.Language{
+		Rust: &schema.RustConfig{
+			PackageName: "test",
+			Version:     "1.94.1",
+			Edition:     "2024",
+		},
+	}
+
+	tests := []struct {
+		name             string
+		adl              *schema.ADL
+		registryLang     string
+		expectDependabot bool
+		mustContain      []string
+		mustNotContain   []string
+	}{
+		{
+			name:             "dependabot disabled: no file mapped",
+			adl:              makeADL("agent-off", false, goLang, nil),
+			registryLang:     "go",
+			expectDependabot: false,
+		},
+		{
+			name:             "go agent with dependabot: gomod ecosystem present",
+			adl:              makeADL("go-agent", true, goLang, nil),
+			registryLang:     "go",
+			expectDependabot: true,
+			mustContain:      []string{"package-ecosystem: gomod", "package-ecosystem: github-actions", "package-ecosystem: docker"},
+			mustNotContain:   []string{"package-ecosystem: cargo", "package-ecosystem: npm", "package-ecosystem: devcontainers"},
+		},
+		{
+			name:             "rust agent with dependabot: cargo ecosystem present",
+			adl:              makeADL("rust-agent", true, rustLang, nil),
+			registryLang:     "rust",
+			expectDependabot: true,
+			mustContain:      []string{"package-ecosystem: cargo", "package-ecosystem: github-actions", "package-ecosystem: docker"},
+			mustNotContain:   []string{"package-ecosystem: gomod", "package-ecosystem: npm"},
+		},
+		{
+			name: "devcontainer enabled: devcontainers ecosystem included",
+			adl: makeADL("dev-agent", true, goLang, &schema.SandboxConfig{
+				DevContainer: &schema.DevContainerConfig{Enabled: true},
+			}),
+			registryLang:     "go",
+			expectDependabot: true,
+			mustContain:      []string{"package-ecosystem: devcontainers"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry, err := templates.NewRegistry(tt.registryLang)
+			if err != nil {
+				t.Fatalf("failed to create template registry: %v", err)
+			}
+
+			files := registry.GetFiles(tt.adl)
+
+			_, found := files[".github/dependabot.yml"]
+			if tt.expectDependabot != found {
+				t.Fatalf("dependabot file mapping: expected %v, got %v (files=%v)", tt.expectDependabot, found, files)
+			}
+
+			if !tt.expectDependabot {
+				return
+			}
+
+			engine := templates.NewWithRegistry("", registry)
+			content, err := engine.ExecuteTemplate("github/dependabot.yaml", templates.Context{ADL: tt.adl})
+			if err != nil {
+				t.Fatalf("failed to execute dependabot template: %v", err)
+			}
+
+			for _, expected := range tt.mustContain {
+				if !containsSubstring(content, expected) {
+					t.Errorf("expected dependabot output to contain %q, got:\n%s", expected, content)
+				}
+			}
+			for _, unexpected := range tt.mustNotContain {
+				if containsSubstring(content, unexpected) {
+					t.Errorf("expected dependabot output NOT to contain %q, got:\n%s", unexpected, content)
+				}
+			}
+		})
+	}
+}
+
 func TestGenerator_buildGenerateCommand(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/schema/schema.json
+++ b/internal/schema/schema.json
@@ -272,7 +272,8 @@
         },
         "url": { "type": "string" },
         "github_app": { "type": "boolean" },
-        "issue_templates": { "type": "boolean" }
+        "issue_templates": { "type": "boolean" },
+        "dependabot": { "type": "boolean" }
       }
     },
     "SandboxConfig": {

--- a/internal/schema/types.go
+++ b/internal/schema/types.go
@@ -218,6 +218,9 @@ type RustConfig struct {
 }
 
 type SCM struct {
+	// Dependabot corresponds to the JSON schema field "dependabot".
+	Dependabot bool `json:"dependabot,omitempty,omitzero" yaml:"dependabot,omitempty" mapstructure:"dependabot,omitempty"`
+
 	// GithubApp corresponds to the JSON schema field "github_app".
 	GithubApp bool `json:"github_app,omitempty,omitzero" yaml:"github_app,omitempty" mapstructure:"github_app,omitempty"`
 

--- a/internal/templates/common/github/dependabot.yaml.tmpl
+++ b/internal/templates/common/github/dependabot.yaml.tmpl
@@ -1,0 +1,58 @@
+---
+version: 2
+updates:
+{{- if .ADL.Spec.Language.Go }}
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      gomod:
+        patterns:
+          - "*"
+{{- end }}
+{{- if .ADL.Spec.Language.Rust }}
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      cargo:
+        patterns:
+          - "*"
+{{- end }}
+{{- if .ADL.Spec.Language.TypeScript }}
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      npm:
+        patterns:
+          - "*"
+{{- end }}
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      docker:
+        patterns:
+          - "*"
+{{- if and .ADL.Spec.Sandbox .ADL.Spec.Sandbox.DevContainer }}{{- if .ADL.Spec.Sandbox.DevContainer.Enabled }}
+
+  - package-ecosystem: devcontainers
+    directory: /
+    schedule:
+      interval: weekly
+{{- end }}{{- end }}

--- a/internal/templates/registry.go
+++ b/internal/templates/registry.go
@@ -184,6 +184,7 @@ func (r *Registry) getGoFiles(adl *schema.ADL) map[string]string {
 	r.addSandboxFiles(adl, files)
 	r.addAIFiles(files)
 	r.addIssueTemplateFiles(adl, files)
+	r.addDependabotFiles(adl, files)
 
 	return files
 }
@@ -242,6 +243,7 @@ func (r *Registry) getRustFiles(adl *schema.ADL) map[string]string {
 	r.addSandboxFiles(adl, files)
 	r.addAIFiles(files)
 	r.addIssueTemplateFiles(adl, files)
+	r.addDependabotFiles(adl, files)
 
 	return files
 }
@@ -284,6 +286,7 @@ func (r *Registry) getTypeScriptFiles(adl *schema.ADL) map[string]string {
 	r.addSandboxFiles(adl, files)
 	r.addAIFiles(files)
 	r.addIssueTemplateFiles(adl, files)
+	r.addDependabotFiles(adl, files)
 
 	return files
 }
@@ -332,6 +335,20 @@ func (r *Registry) addIssueTemplateFiles(adl *schema.ADL, files map[string]strin
 		files[".github/ISSUE_TEMPLATE/bug_report.md"] = "github/bug_report.md"
 		files[".github/ISSUE_TEMPLATE/feature_request.md"] = "github/feature_request.md"
 		files[".github/ISSUE_TEMPLATE/refactor_request.md"] = "github/refactor_request.md"
+	}
+}
+
+// addDependabotFiles adds the GitHub Dependabot configuration when enabled.
+// The generated manifest enumerates ecosystems based on the ADL spec
+// (gomod/cargo/npm by language plus github-actions, docker, and
+// devcontainers when applicable). Only emitted for the GitHub SCM
+// provider - GitLab/Bitbucket equivalents are out of scope for now.
+func (r *Registry) addDependabotFiles(adl *schema.ADL, files map[string]string) {
+	if adl.Spec.SCM == nil || !adl.Spec.SCM.Dependabot {
+		return
+	}
+	if adl.Spec.SCM.Provider == schema.SCMProviderGithub || adl.Spec.SCM.Provider == "" {
+		files[".github/dependabot.yml"] = "github/dependabot.yaml"
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds an opt-in `spec.scm.dependabot` boolean (defaults to `false`) that generates a `.github/dependabot.yml` manifest for GitHub-hosted agent projects. The generated config covers the language ecosystem (`gomod`/`cargo`/`npm`), `github-actions`, `docker`, and `devcontainers` (when `sandbox.devcontainer` is enabled), grouping updates per ecosystem on a weekly schedule.

The `adl init` wizard prompts for the new flag with a default of `false`, preserving existing behavior for projects that manage dependency upgrades themselves.

Closes #120

## Notes

- `internal/schema/schema.json` is vendored from `inference-gateway/adl`; a matching bump there + `ADL_SCHEMA_VERSION` update in `Taskfile.yml` will be needed before `task verify-schema` passes in CI.
- Templates follow the existing `addIssueTemplateFiles` pattern for consistency.

## Test plan

- [ ] `task test` passes locally
- [ ] `adl init --defaults` writes `dependabot: false`
- [ ] `adl generate` with `scm.dependabot: true` emits `.github/dependabot.yml` containing the expected ecosystems
- [ ] `adl generate` with `scm.dependabot: false` does NOT emit the file

🤖 Generated with [Claude Code](https://claude.ai/code)