### PR TITLE
feat: Declarative --ai/--ci/--cd manifest fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,12 @@ The init command supports extensive configuration options:
 - `--flox` - Enable Flox environment
 - `--devcontainer` - Enable DevContainer environment
 
+**Pipeline / AI Options (declarative, written into the manifest as `false` by default):**
+
+- `--ai` - Sets `spec.ai.enabled: true` (generate `CLAUDE.md`/`AGENTS.md`, add claude-code to sandboxes)
+- `--ci` - Sets `spec.scm.ci: true` (generate CI workflow on `adl generate`)
+- `--cd` - Sets `spec.scm.cd: true` (generate CD pipeline + semantic-release on `adl generate`)
+
 ### Generate Command
 
 ```bash
@@ -299,10 +305,18 @@ adl generate --file agent.yaml --output ./test-my-agent --deployment cloudrun --
 | `--output`, `-o`   | Output directory for generated code (default: ".")                                         |
 | `--template`, `-t` | Template to use (default: "minimal")                                                       |
 | `--overwrite`      | Overwrite existing files (respects .adl-ignore)                                            |
-| `--ci`             | Generate CI workflow configuration (GitHub Actions)                                        |
-| `--cd`             | Generate CD pipeline configuration with semantic-release                                   |
+| `--ci`             | Generate CI workflow configuration (GitHub Actions). Overrides `spec.scm.ci`.              |
+| `--cd`             | Generate CD pipeline configuration with semantic-release. Overrides `spec.scm.cd`.         |
 | `--deployment`     | Generate deployment configuration (`kubernetes`, `cloudrun`)                               |
-| `--ai`             | Generate AI assistant instructions (CLAUDE.md) and add claude-code to sandbox environments |
+| `--ai`             | Generate AI assistant instructions (CLAUDE.md) and add claude-code to sandbox environments. Overrides `spec.ai.enabled`. |
+
+> **Declarative equivalents:** `--ai`, `--ci`, and `--cd` can also be set in the manifest as
+> `spec.ai.enabled: true`, `spec.scm.ci: true`, and `spec.scm.cd: true`. The CLI flag is OR'd
+> on top of the manifest value (passing the flag wins; omitting it falls back to the manifest).
+> `adl init` writes all three as `false` by default — they're opt-in. Generated files
+> (`CLAUDE.md`, `AGENTS.md`, `.github/workflows/ci.yml`, `.github/workflows/cd.yml`,
+> `.releaserc.yaml`) are tagged `linguist-generated=true` in `.gitattributes` so they collapse
+> in pull request diffs.
 
 **CI Generation Features:**
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -97,6 +97,7 @@ tasks:
           --schema-root-type=https://adl.inference-gateway.com/schemas/agent/v1=ADL \
           --capitalization ID --capitalization URL --capitalization SCM \
           --capitalization CPU --capitalization API --capitalization CI --capitalization CD \
+          --capitalization AI \
           --capitalization CloudRun --capitalization DevContainer --capitalization TypeScript \
           --only-models \
           --output internal/schema/types.go \

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -411,6 +411,265 @@ spec:
 	}
 }
 
+// TestGenerateWithAIFromManifest verifies that declaring spec.ai.enabled: true
+// in the manifest activates AI assistant docs without needing the --ai CLI flag.
+func TestGenerateWithAIFromManifest(t *testing.T) {
+	tempDir := t.TempDir()
+	outputPath := filepath.Join(tempDir, "ai-from-manifest")
+
+	adlContent := `apiVersion: adl.inference-gateway.com/v1
+kind: Agent
+metadata:
+  name: manifest-ai-agent
+  description: AI enabled declaratively
+  version: 1.0.0
+spec:
+  capabilities:
+    streaming: true
+    pushNotifications: false
+    stateTransitionHistory: false
+  server:
+    port: 8080
+    debug: false
+  language:
+    go:
+      module: github.com/test/manifest-ai
+      version: "1.26.2"
+  ai:
+    enabled: true
+`
+	adlPath := filepath.Join(tempDir, "agent.yaml")
+	if err := os.WriteFile(adlPath, []byte(adlContent), 0644); err != nil {
+		t.Fatalf("failed to write ADL file: %v", err)
+	}
+
+	originalADLFile := adlFile
+	originalOutputDir := outputDir
+	originalEnableAI := enableAI
+	defer func() {
+		adlFile = originalADLFile
+		outputDir = originalOutputDir
+		enableAI = originalEnableAI
+	}()
+
+	adlFile = adlPath
+	outputDir = outputPath
+	enableAI = false
+
+	if err := runGenerate(generateCmd, []string{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	claudeMdPath := filepath.Join(outputPath, "CLAUDE.md")
+	if _, err := os.Stat(claudeMdPath); os.IsNotExist(err) {
+		t.Errorf("expected CLAUDE.md to be generated when spec.ai.enabled is true (without --ai flag)")
+	}
+
+	gitattributesPath := filepath.Join(outputPath, ".gitattributes")
+	gitattributesBytes, err := os.ReadFile(gitattributesPath)
+	if err != nil {
+		t.Fatalf("failed to read .gitattributes: %v", err)
+	}
+	gitattributesContent := string(gitattributesBytes)
+	if !containsString(gitattributesContent, "CLAUDE.md linguist-generated=true") {
+		t.Errorf("expected .gitattributes to mark CLAUDE.md as linguist-generated, got:\n%s", gitattributesContent)
+	}
+	if !containsString(gitattributesContent, "AGENTS.md linguist-generated=true") {
+		t.Errorf("expected .gitattributes to mark AGENTS.md as linguist-generated, got:\n%s", gitattributesContent)
+	}
+}
+
+// TestGenerateWithCIFromManifest verifies that declaring spec.scm.ci: true
+// in the manifest activates CI workflow generation without needing --ci.
+func TestGenerateWithCIFromManifest(t *testing.T) {
+	tempDir := t.TempDir()
+	outputPath := filepath.Join(tempDir, "ci-from-manifest")
+
+	adlContent := `apiVersion: adl.inference-gateway.com/v1
+kind: Agent
+metadata:
+  name: manifest-ci-agent
+  description: CI enabled declaratively
+  version: 1.0.0
+spec:
+  capabilities:
+    streaming: true
+    pushNotifications: false
+    stateTransitionHistory: false
+  server:
+    port: 8080
+    debug: false
+  language:
+    go:
+      module: github.com/test/manifest-ci
+      version: "1.26.2"
+  scm:
+    provider: github
+    url: https://github.com/test/manifest-ci
+    ci: true
+`
+	adlPath := filepath.Join(tempDir, "agent.yaml")
+	if err := os.WriteFile(adlPath, []byte(adlContent), 0644); err != nil {
+		t.Fatalf("failed to write ADL file: %v", err)
+	}
+
+	originalADLFile := adlFile
+	originalOutputDir := outputDir
+	originalGenerateCI := generateCI
+	defer func() {
+		adlFile = originalADLFile
+		outputDir = originalOutputDir
+		generateCI = originalGenerateCI
+	}()
+
+	adlFile = adlPath
+	outputDir = outputPath
+	generateCI = false
+
+	if err := runGenerate(generateCmd, []string{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	ciWorkflowPath := filepath.Join(outputPath, ".github/workflows/ci.yml")
+	if _, err := os.Stat(ciWorkflowPath); os.IsNotExist(err) {
+		t.Errorf("expected .github/workflows/ci.yml to be generated when spec.scm.ci is true (without --ci flag)")
+	}
+}
+
+// TestGenerateWithCDFromManifest verifies that declaring spec.scm.cd: true
+// in the manifest activates CD pipeline generation without needing --cd.
+func TestGenerateWithCDFromManifest(t *testing.T) {
+	tempDir := t.TempDir()
+	outputPath := filepath.Join(tempDir, "cd-from-manifest")
+
+	adlContent := `apiVersion: adl.inference-gateway.com/v1
+kind: Agent
+metadata:
+  name: manifest-cd-agent
+  description: CD enabled declaratively
+  version: 1.0.0
+spec:
+  capabilities:
+    streaming: true
+    pushNotifications: false
+    stateTransitionHistory: false
+  server:
+    port: 8080
+    debug: false
+  language:
+    go:
+      module: github.com/test/manifest-cd
+      version: "1.26.2"
+  scm:
+    provider: github
+    url: https://github.com/test/manifest-cd
+    cd: true
+`
+	adlPath := filepath.Join(tempDir, "agent.yaml")
+	if err := os.WriteFile(adlPath, []byte(adlContent), 0644); err != nil {
+		t.Fatalf("failed to write ADL file: %v", err)
+	}
+
+	originalADLFile := adlFile
+	originalOutputDir := outputDir
+	originalGenerateCD := generateCD
+	defer func() {
+		adlFile = originalADLFile
+		outputDir = originalOutputDir
+		generateCD = originalGenerateCD
+	}()
+
+	adlFile = adlPath
+	outputDir = outputPath
+	generateCD = false
+
+	if err := runGenerate(generateCmd, []string{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cdWorkflowPath := filepath.Join(outputPath, ".github/workflows/cd.yml")
+	if _, err := os.Stat(cdWorkflowPath); os.IsNotExist(err) {
+		t.Errorf("expected .github/workflows/cd.yml to be generated when spec.scm.cd is true (without --cd flag)")
+	}
+
+	releasercPath := filepath.Join(outputPath, ".releaserc.yaml")
+	if _, err := os.Stat(releasercPath); os.IsNotExist(err) {
+		t.Errorf("expected .releaserc.yaml to be generated when spec.scm.cd is true (without --cd flag)")
+	}
+}
+
+// TestGenerateCLIFlagOverridesManifest verifies that the --ai/--ci/--cd flags
+// OR on top of the manifest value: setting the flag wins even if the manifest
+// has the field unset or false.
+func TestGenerateCLIFlagOverridesManifest(t *testing.T) {
+	tempDir := t.TempDir()
+	outputPath := filepath.Join(tempDir, "cli-overrides")
+
+	adlContent := `apiVersion: adl.inference-gateway.com/v1
+kind: Agent
+metadata:
+  name: cli-overrides-agent
+  description: Manifest leaves AI/CI/CD off but flags turn them on
+  version: 1.0.0
+spec:
+  capabilities:
+    streaming: true
+    pushNotifications: false
+    stateTransitionHistory: false
+  server:
+    port: 8080
+    debug: false
+  language:
+    go:
+      module: github.com/test/cli-overrides
+      version: "1.26.2"
+  scm:
+    provider: github
+    url: https://github.com/test/cli-overrides
+    ci: false
+    cd: false
+  ai:
+    enabled: false
+`
+	adlPath := filepath.Join(tempDir, "agent.yaml")
+	if err := os.WriteFile(adlPath, []byte(adlContent), 0644); err != nil {
+		t.Fatalf("failed to write ADL file: %v", err)
+	}
+
+	originalADLFile := adlFile
+	originalOutputDir := outputDir
+	originalEnableAI := enableAI
+	originalGenerateCI := generateCI
+	originalGenerateCD := generateCD
+	defer func() {
+		adlFile = originalADLFile
+		outputDir = originalOutputDir
+		enableAI = originalEnableAI
+		generateCI = originalGenerateCI
+		generateCD = originalGenerateCD
+	}()
+
+	adlFile = adlPath
+	outputDir = outputPath
+	enableAI = true
+	generateCI = true
+	generateCD = true
+
+	if err := runGenerate(generateCmd, []string{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, want := range []string{
+		"CLAUDE.md",
+		".github/workflows/ci.yml",
+		".github/workflows/cd.yml",
+	} {
+		if _, err := os.Stat(filepath.Join(outputPath, want)); os.IsNotExist(err) {
+			t.Errorf("expected %s to be generated when CLI flag is set even though manifest has it off", want)
+		}
+	}
+}
+
 func containsString(content, substr string) bool {
 	for i := 0; i <= len(content)-len(substr); i++ {
 		if content[i:i+len(substr)] == substr {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -56,6 +56,9 @@ func init() {
 	initCmd.Flags().String("typescript-name", "", "TypeScript package name")
 	initCmd.Flags().Bool("flox", false, "Enable Flox environment")
 	initCmd.Flags().Bool("devcontainer", false, "Enable DevContainer environment")
+	initCmd.Flags().Bool("ai", false, "Enable AI assistant docs (CLAUDE.md/AGENTS.md) and claude-code in sandboxes")
+	initCmd.Flags().Bool("ci", false, "Enable CI workflow generation")
+	initCmd.Flags().Bool("cd", false, "Enable CD pipeline generation")
 	initCmd.Flags().String("deployment", "", "Deployment type (kubernetes, defaults to empty for no deployment)")
 
 	if err := viper.BindPFlags(initCmd.Flags()); err != nil {
@@ -253,7 +256,12 @@ type adlData struct {
 			GithubApp      bool   `yaml:"github_app,omitempty"`
 			IssueTemplates bool   `yaml:"issue_templates"`
 			Dependabot     bool   `yaml:"dependabot"`
+			CI             bool   `yaml:"ci"`
+			CD             bool   `yaml:"cd"`
 		} `yaml:"scm,omitempty"`
+		AI *struct {
+			Enabled bool `yaml:"enabled"`
+		} `yaml:"ai,omitempty"`
 		Sandbox *struct {
 			Flox *struct {
 				Enabled bool `yaml:"enabled"`
@@ -721,6 +729,8 @@ func collectADLInfo(cmd *cobra.Command, projectName string, useDefaults bool) *a
 			GithubApp      bool   `yaml:"github_app,omitempty"`
 			IssueTemplates bool   `yaml:"issue_templates"`
 			Dependabot     bool   `yaml:"dependabot"`
+			CI             bool   `yaml:"ci"`
+			CD             bool   `yaml:"cd"`
 		}{
 			Provider: scmProvider,
 		}
@@ -751,6 +761,20 @@ func collectADLInfo(cmd *cobra.Command, projectName string, useDefaults bool) *a
 			} else {
 				adl.Spec.SCM.Dependabot = promptBool("Enable Dependabot configuration", false)
 			}
+		}
+
+		adl.Spec.SCM.CI = promptBoolWithConfig("ci", useDefaults, "Enable CI workflow generation", false)
+		adl.Spec.SCM.CD = promptBoolWithConfig("cd", useDefaults, "Enable CD pipeline generation", false)
+	}
+
+	fmt.Println("\n🤖 AI Assistant Documentation")
+	fmt.Println("-----------------------------")
+	aiEnabled := promptBoolWithConfig("ai", useDefaults, "Enable AI assistant docs (CLAUDE.md/AGENTS.md) and claude-code in sandboxes", false)
+	if aiEnabled {
+		adl.Spec.AI = &struct {
+			Enabled bool `yaml:"enabled"`
+		}{
+			Enabled: true,
 		}
 	}
 

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -209,6 +209,100 @@ func TestInitDoesNotGenerateCode(t *testing.T) {
 	}
 }
 
+// TestInitAICICDDefaults verifies that `adl init --defaults` writes
+// ai/ci/cd as false (or omitted) by default — they should be opt-in.
+func TestInitAICICDDefaults(t *testing.T) {
+	tempDir := t.TempDir()
+	outputPath := filepath.Join(tempDir, "test-output")
+
+	cmd := initCmd
+	if err := cmd.Flags().Set("defaults", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("path", outputPath); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runInit(cmd, []string{"test-agent"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	adlPath := filepath.Join(outputPath, "agent.yaml")
+	content, err := os.ReadFile(adlPath)
+	if err != nil {
+		t.Fatalf("failed to read ADL file: %v", err)
+	}
+
+	var adl adlData
+	if err := yaml.Unmarshal(content, &adl); err != nil {
+		t.Fatalf("failed to parse ADL YAML: %v", err)
+	}
+
+	if adl.Spec.SCM == nil {
+		t.Fatalf("expected SCM configuration to be present")
+	}
+	if adl.Spec.SCM.CI {
+		t.Errorf("expected SCM.CI to default to false")
+	}
+	if adl.Spec.SCM.CD {
+		t.Errorf("expected SCM.CD to default to false")
+	}
+
+	if adl.Spec.AI != nil && adl.Spec.AI.Enabled {
+		t.Errorf("expected spec.ai to be omitted or disabled by default, got enabled=true")
+	}
+
+	contentStr := string(content)
+	if !strings.Contains(contentStr, "ci: false") {
+		t.Errorf("ADL file should contain 'ci: false', got:\n%s", contentStr)
+	}
+	if !strings.Contains(contentStr, "cd: false") {
+		t.Errorf("ADL file should contain 'cd: false', got:\n%s", contentStr)
+	}
+}
+
+// TestInitAIFlag verifies that `--ai` flag at init time writes spec.ai.enabled: true.
+func TestInitAIFlag(t *testing.T) {
+	tempDir := t.TempDir()
+	outputPath := filepath.Join(tempDir, "test-output")
+
+	cmd := initCmd
+	if err := cmd.Flags().Set("defaults", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("path", outputPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("ai", "true"); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = cmd.Flags().Set("ai", "false") }()
+
+	if err := runInit(cmd, []string{"test-agent"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	adlPath := filepath.Join(outputPath, "agent.yaml")
+	content, err := os.ReadFile(adlPath)
+	if err != nil {
+		t.Fatalf("failed to read ADL file: %v", err)
+	}
+
+	var adl adlData
+	if err := yaml.Unmarshal(content, &adl); err != nil {
+		t.Fatalf("failed to parse ADL YAML: %v", err)
+	}
+
+	if adl.Spec.AI == nil || !adl.Spec.AI.Enabled {
+		t.Errorf("expected spec.ai.enabled to be true when --ai is passed to init")
+	}
+
+	contentStr := string(content)
+	if !strings.Contains(contentStr, "ai:") || !strings.Contains(contentStr, "enabled: true") {
+		t.Errorf("ADL file should contain ai.enabled: true, got:\n%s", contentStr)
+	}
+}
+
 func TestInitDefaultsVendorNeutral(t *testing.T) {
 	tempDir := t.TempDir()
 	outputPath := filepath.Join(tempDir, "test-output")

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -55,6 +55,41 @@ func (g *Generator) Generate(adlFile, outputDir string) error {
 		return fmt.Errorf("ADL validation failed: %w", err)
 	}
 
+	// Reconcile CLI flags with manifest fields. The CLI flag is OR'd on top
+	// of the manifest value, so passing --ai/--ci/--cd at the command line
+	// always wins; omitting the flag falls back to the manifest. After this
+	// block, both g.config.* and adl.Spec.* reflect the same effective state
+	// so templates (e.g. .gitattributes) can read either source of truth.
+	if adl.Spec.AI != nil && adl.Spec.AI.Enabled {
+		g.config.EnableAI = true
+	}
+	if g.config.EnableAI {
+		if adl.Spec.AI == nil {
+			adl.Spec.AI = &schema.AIConfig{Enabled: true}
+		} else {
+			adl.Spec.AI.Enabled = true
+		}
+	}
+	if adl.Spec.SCM != nil {
+		if adl.Spec.SCM.CI {
+			g.config.GenerateCI = true
+		}
+		if adl.Spec.SCM.CD {
+			g.config.GenerateCD = true
+		}
+	}
+	if g.config.GenerateCI || g.config.GenerateCD {
+		if adl.Spec.SCM == nil {
+			adl.Spec.SCM = &schema.SCM{}
+		}
+		if g.config.GenerateCI {
+			adl.Spec.SCM.CI = true
+		}
+		if g.config.GenerateCD {
+			adl.Spec.SCM.CD = true
+		}
+	}
+
 	if g.config.DeploymentType != "" {
 		if adl.Spec.Deployment == nil {
 			adl.Spec.Deployment = &schema.DeploymentConfig{}

--- a/internal/schema/schema.json
+++ b/internal/schema/schema.json
@@ -69,7 +69,8 @@
         "hooks": { "$ref": "#/definitions/Hooks" },
         "scm": { "$ref": "#/definitions/SCM" },
         "sandbox": { "$ref": "#/definitions/SandboxConfig" },
-        "deployment": { "$ref": "#/definitions/DeploymentConfig" }
+        "deployment": { "$ref": "#/definitions/DeploymentConfig" },
+        "ai": { "$ref": "#/definitions/AIConfig" }
       }
     },
     "Capabilities": {
@@ -273,7 +274,9 @@
         "url": { "type": "string" },
         "github_app": { "type": "boolean" },
         "issue_templates": { "type": "boolean" },
-        "dependabot": { "type": "boolean" }
+        "dependabot": { "type": "boolean" },
+        "ci": { "type": "boolean" },
+        "cd": { "type": "boolean" }
       }
     },
     "SandboxConfig": {
@@ -282,6 +285,14 @@
         "flox": { "$ref": "#/definitions/FloxConfig" },
         "devcontainer": { "$ref": "#/definitions/DevContainerConfig" },
         "dockerCompose": { "$ref": "#/definitions/DockerComposeConfig" }
+      }
+    },
+    "AIConfig": {
+      "type": "object",
+      "description": "Toggle generation of AI-assistant documentation (CLAUDE.md, AGENTS.md) and provisioning of claude-code in sandbox environments.",
+      "required": ["enabled"],
+      "properties": {
+        "enabled": { "type": "boolean" }
       }
     },
     "FloxConfig": {

--- a/internal/schema/types.go
+++ b/internal/schema/types.go
@@ -18,6 +18,13 @@ type ADL struct {
 	Spec Spec `json:"spec" yaml:"spec" mapstructure:"spec"`
 }
 
+// Toggle generation of AI-assistant documentation (CLAUDE.md, AGENTS.md) and
+// provisioning of claude-code in sandbox environments.
+type AIConfig struct {
+	// Enabled corresponds to the JSON schema field "enabled".
+	Enabled bool `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
+}
+
 type Agent struct {
 	// MaxTokens corresponds to the JSON schema field "maxTokens".
 	MaxTokens int `json:"maxTokens,omitempty,omitzero" yaml:"maxTokens,omitempty" mapstructure:"maxTokens,omitempty"`
@@ -218,6 +225,12 @@ type RustConfig struct {
 }
 
 type SCM struct {
+	// CD corresponds to the JSON schema field "cd".
+	CD bool `json:"cd,omitempty,omitzero" yaml:"cd,omitempty" mapstructure:"cd,omitempty"`
+
+	// CI corresponds to the JSON schema field "ci".
+	CI bool `json:"ci,omitempty,omitzero" yaml:"ci,omitempty" mapstructure:"ci,omitempty"`
+
 	// Dependabot corresponds to the JSON schema field "dependabot".
 	Dependabot bool `json:"dependabot,omitempty,omitzero" yaml:"dependabot,omitempty" mapstructure:"dependabot,omitempty"`
 
@@ -344,6 +357,9 @@ type Spec struct {
 
 	// Agent corresponds to the JSON schema field "agent".
 	Agent *Agent `json:"agent,omitempty,omitzero" yaml:"agent,omitempty" mapstructure:"agent,omitempty"`
+
+	// AI corresponds to the JSON schema field "ai".
+	AI *AIConfig `json:"ai,omitempty,omitzero" yaml:"ai,omitempty" mapstructure:"ai,omitempty"`
 
 	// Artifacts corresponds to the JSON schema field "artifacts".
 	Artifacts *ArtifactsConfig `json:"artifacts,omitempty,omitzero" yaml:"artifacts,omitempty" mapstructure:"artifacts,omitempty"`

--- a/internal/templates/common/config/gitattributes.tmpl
+++ b/internal/templates/common/config/gitattributes.tmpl
@@ -29,6 +29,13 @@ Taskfile.yml linguist-generated=true
 .github/workflows/cd.yml linguist-generated=true
 .releaserc.yaml linguist-generated=true
 
+{{- if or .EnableAI (and .ADL.Spec.AI .ADL.Spec.AI.Enabled) }}
+
+# AI assistant documentation (generated)
+CLAUDE.md linguist-generated=true
+AGENTS.md linguist-generated=true
+{{- end }}
+
 # Kubernetes manifests
 k8s/*.yaml linguist-generated=true
 k8s/*.yml linguist-generated=true


### PR DESCRIPTION
Closes #122

## Summary

Promotes `--ai`, `--ci`, and `--cd` generate flags into declarative ADL manifest fields:

* `--ai` → `spec.ai.enabled: bool`
* `--ci` → `spec.scm.ci: bool`
* `--cd` → `spec.scm.cd: bool`

CLI flag OR's on top of the manifest value. `adl init` writes all three as `false` by default. Generated AI docs (`CLAUDE.md`, `AGENTS.md`) are now tagged `linguist-generated=true` in `.gitattributes` so they collapse in PR diffs.

## Note

Vendored schema diverges from upstream `inference-gateway/adl@v0.4.0`; a mirror PR against `adl` and a bump of `ADL_SCHEMA_VERSION` here is needed before `task verify-schema` passes again. CI workflow does not call verify-schema, so PR CI is unaffected.

Generated with [Claude Code](https://claude.ai/code)