### PR TITLE
feat(schema): Adopt ADL v0.6.0 schema with spec.development.{sandbox,ai}

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,8 @@ main.go                       # Entry point, sets version
 ### Key Types (internal/schema/types.go)
 
 - `ADL` - Root structure with `apiVersion`, `kind`, `metadata`, `spec`
-- `Spec` - Contains `capabilities`, `agent`, `tools`, `skills`, `services`, `server`, `language`, `deployment`
+- `Spec` - Contains `capabilities`, `agent`, `tools`, `skills`, `services`, `server`, `language`, `deployment`, `development`
+- `DevelopmentConfig` - Local development experience under `spec.development`: `sandbox` (flox/devcontainer/dockerCompose) and `ai` (CLAUDE.md/AGENTS.md generation). Introduced in ADL v0.6.0 - previously these sat directly under `spec`.
 - `Tool` - Function-call entrypoint with `id` (only `id` is required since v0.4.0). User-defined tools also set `name`, `description`, `tags`, `schema`, optional `inject`. Reserved IDs (`read`, `bash`, `write`, `edit`) take `id` alone - the generator owns metadata. See `internal/schema/builtin_config.go` for the reserved-ID set.
 - `Skill` - Markdown playbook with `id` plus optional `version`/`source`/`bare`/`name`/`description`/`tags`. Generated as `skills/<id>/SKILL.md`. **At runtime, only the frontmatter is consumed** - the body lives on disk and the model reads it on demand via the `Read` built-in.
 - `Service` - Injectable service with `interface`, `factory`, `description`
@@ -135,7 +136,7 @@ spec:
 
 Runtime configuration (`A2A_QUEUE_PROVIDER`, `A2A_QUEUE_URL`, `A2A_QUEUE_NAMESPACE`)
 is documented in the generated `.env.example` - not baked into `main.rs`. When
-`spec.sandbox.dockerCompose.enabled: true` is also set, a working
+`spec.development.sandbox.dockerCompose.enabled: true` is also set, a working
 `docker-compose.yaml` with a Redis service is produced alongside the agent.
 
 ## Adding a New Language

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ The init command supports extensive configuration options:
 
 **Pipeline / AI Options (declarative, written into the manifest as `false` by default):**
 
-- `--ai` - Sets `spec.ai.enabled: true` (generate `CLAUDE.md`/`AGENTS.md`, add claude-code to sandboxes)
+- `--ai` - Sets `spec.development.ai.enabled: true` (generate `CLAUDE.md`/`AGENTS.md`, add claude-code to sandboxes)
 - `--ci` - Sets `spec.scm.ci: true` (generate CI workflow on `adl generate`)
 - `--cd` - Sets `spec.scm.cd: true` (generate CD pipeline + semantic-release on `adl generate`)
 
@@ -308,10 +308,10 @@ adl generate --file agent.yaml --output ./test-my-agent --deployment cloudrun --
 | `--ci`             | Generate CI workflow configuration (GitHub Actions). Overrides `spec.scm.ci`.              |
 | `--cd`             | Generate CD pipeline configuration with semantic-release. Overrides `spec.scm.cd`.         |
 | `--deployment`     | Generate deployment configuration (`kubernetes`, `cloudrun`)                               |
-| `--ai`             | Generate AI assistant instructions (CLAUDE.md) and add claude-code to sandbox environments. Overrides `spec.ai.enabled`. |
+| `--ai`             | Generate AI assistant instructions (CLAUDE.md) and add claude-code to sandbox environments. Overrides `spec.development.ai.enabled`. |
 
 > **Declarative equivalents:** `--ai`, `--ci`, and `--cd` can also be set in the manifest as
-> `spec.ai.enabled: true`, `spec.scm.ci: true`, and `spec.scm.cd: true`. The CLI flag is OR'd
+> `spec.development.ai.enabled: true`, `spec.scm.ci: true`, and `spec.scm.cd: true`. The CLI flag is OR'd
 > on top of the manifest value (passing the flag wins; omitting it falls back to the manifest).
 > `adl init` writes all three as `false` by default — they're opt-in. Generated files
 > (`CLAUDE.md`, `AGENTS.md`, `.github/workflows/ci.yml`, `.github/workflows/cd.yml`,
@@ -564,9 +564,10 @@ spec:
       environment:
         LOG_LEVEL: info
         ENVIRONMENT: production
-  sandbox:
-    flox:
-      enabled: true
+  development:
+    sandbox:
+      flox:
+        enabled: true
 ```
 
 ## Skills vs. Tools
@@ -1306,9 +1307,10 @@ Configure Flox for your project by adding to your ADL file:
 
 ```yaml
 spec:
-  sandbox:
-    flox:
-      enabled: true
+  development:
+    sandbox:
+      flox:
+        enabled: true
 ```
 
 Generated files:
@@ -1324,9 +1326,10 @@ Configure DevContainer for your project:
 
 ```yaml
 spec:
-  sandbox:
-    devcontainer:
-      enabled: true
+  development:
+    sandbox:
+      devcontainer:
+        enabled: true
 ```
 
 Generated files:
@@ -1339,11 +1342,12 @@ You can enable multiple sandbox environments simultaneously:
 
 ```yaml
 spec:
-  sandbox:
-    flox:
-      enabled: true
-    devcontainer:
-      enabled: true
+  development:
+    sandbox:
+      flox:
+        enabled: true
+      devcontainer:
+        enabled: true
 ```
 
 This generates both Flox and DevContainer configurations, allowing developers to choose their preferred environment.
@@ -1487,7 +1491,7 @@ emits a weekly-schedule manifest covering the ecosystems present in your ADL:
 - **Language ecosystem** - `gomod`, `cargo`, or `npm` (selected from `spec.language`)
 - **`github-actions`** - Keeps `.github/workflows/` actions pinned
 - **`docker`** - Tracks the base image in the generated `Dockerfile`
-- **`devcontainers`** - Included when `spec.sandbox.devcontainer.enabled: true`
+- **`devcontainers`** - Included when `spec.development.sandbox.devcontainer.enabled: true`
 
 Each ecosystem groups all updates into a single PR per week to keep noise low.
 The default of `false` keeps the existing behavior unchanged for projects that

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -6,7 +6,7 @@ vars:
   VERSION: 0.32.0
   BUILD_DIR: bin
   DIST_DIR: dist
-  ADL_SCHEMA_VERSION: v0.5.0
+  ADL_SCHEMA_VERSION: v0.6.0
   ADL_SCHEMA_URL: https://raw.githubusercontent.com/inference-gateway/adl/{{.ADL_SCHEMA_VERSION}}/schema/v1/schema.json
   ADL_SCHEMA_PATH: internal/schema/schema.json
 

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -339,11 +339,12 @@ spec:
     go:
       module: github.com/test/ai-agent
       version: "1.26.2"
-  sandbox:
-    flox:
-      enabled: true
-    devcontainer:
-      enabled: true
+  development:
+    sandbox:
+      flox:
+        enabled: true
+      devcontainer:
+        enabled: true
 `
 	adlPath := filepath.Join(tempDir, "agent.yaml")
 	if err := os.WriteFile(adlPath, []byte(adlContent), 0644); err != nil {
@@ -411,7 +412,7 @@ spec:
 	}
 }
 
-// TestGenerateWithAIFromManifest verifies that declaring spec.ai.enabled: true
+// TestGenerateWithAIFromManifest verifies that declaring spec.development.ai.enabled: true
 // in the manifest activates AI assistant docs without needing the --ai CLI flag.
 func TestGenerateWithAIFromManifest(t *testing.T) {
 	tempDir := t.TempDir()
@@ -435,8 +436,9 @@ spec:
     go:
       module: github.com/test/manifest-ai
       version: "1.26.2"
-  ai:
-    enabled: true
+  development:
+    ai:
+      enabled: true
 `
 	adlPath := filepath.Join(tempDir, "agent.yaml")
 	if err := os.WriteFile(adlPath, []byte(adlContent), 0644); err != nil {
@@ -462,7 +464,7 @@ spec:
 
 	claudeMdPath := filepath.Join(outputPath, "CLAUDE.md")
 	if _, err := os.Stat(claudeMdPath); os.IsNotExist(err) {
-		t.Errorf("expected CLAUDE.md to be generated when spec.ai.enabled is true (without --ai flag)")
+		t.Errorf("expected CLAUDE.md to be generated when spec.development.ai.enabled is true (without --ai flag)")
 	}
 
 	gitattributesPath := filepath.Join(outputPath, ".gitattributes")
@@ -628,8 +630,9 @@ spec:
     url: https://github.com/test/cli-overrides
     ci: false
     cd: false
-  ai:
-    enabled: false
+  development:
+    ai:
+      enabled: false
 `
 	adlPath := filepath.Join(tempDir, "agent.yaml")
 	if err := os.WriteFile(adlPath, []byte(adlContent), 0644); err != nil {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -259,17 +259,19 @@ type adlData struct {
 			CI             bool   `yaml:"ci"`
 			CD             bool   `yaml:"cd"`
 		} `yaml:"scm,omitempty"`
-		AI *struct {
-			Enabled bool `yaml:"enabled"`
-		} `yaml:"ai,omitempty"`
-		Sandbox *struct {
-			Flox *struct {
+		Development *struct {
+			Sandbox *struct {
+				Flox *struct {
+					Enabled bool `yaml:"enabled"`
+				} `yaml:"flox,omitempty"`
+				DevContainer *struct {
+					Enabled bool `yaml:"enabled"`
+				} `yaml:"devcontainer,omitempty"`
+			} `yaml:"sandbox,omitempty"`
+			AI *struct {
 				Enabled bool `yaml:"enabled"`
-			} `yaml:"flox,omitempty"`
-			DevContainer *struct {
-				Enabled bool `yaml:"enabled"`
-			} `yaml:"devcontainer,omitempty"`
-		} `yaml:"sandbox,omitempty"`
+			} `yaml:"ai,omitempty"`
+		} `yaml:"development,omitempty"`
 		Deployment *struct {
 			Type string `yaml:"type,omitempty"`
 		} `yaml:"deployment,omitempty"`
@@ -678,6 +680,7 @@ func collectADLInfo(cmd *cobra.Command, projectName string, useDefaults bool) *a
 	devcontainerEnabled := promptBoolWithConfig("devcontainer", useDefaults, "Enable DevContainer environment", false)
 
 	if floxEnabled || devcontainerEnabled {
+		ensureDevelopment(adl)
 		sandboxConfig := &struct {
 			Flox *struct {
 				Enabled bool `yaml:"enabled"`
@@ -703,7 +706,7 @@ func collectADLInfo(cmd *cobra.Command, projectName string, useDefaults bool) *a
 			}
 		}
 
-		adl.Spec.Sandbox = sandboxConfig
+		adl.Spec.Development.Sandbox = sandboxConfig
 	}
 
 	fmt.Println("\n🚀 Deployment Configuration")
@@ -771,7 +774,8 @@ func collectADLInfo(cmd *cobra.Command, projectName string, useDefaults bool) *a
 	fmt.Println("-----------------------------")
 	aiEnabled := promptBoolWithConfig("ai", useDefaults, "Enable AI assistant docs (CLAUDE.md/AGENTS.md) and claude-code in sandboxes", false)
 	if aiEnabled {
-		adl.Spec.AI = &struct {
+		ensureDevelopment(adl)
+		adl.Spec.Development.AI = &struct {
 			Enabled bool `yaml:"enabled"`
 		}{
 			Enabled: true,
@@ -779,6 +783,28 @@ func collectADLInfo(cmd *cobra.Command, projectName string, useDefaults bool) *a
 	}
 
 	return adl
+}
+
+// ensureDevelopment lazily initialises adl.Spec.Development so that callers
+// can populate adl.Spec.Development.Sandbox / adl.Spec.Development.AI without
+// repeating the nil check at every assignment site.
+func ensureDevelopment(adl *adlData) {
+	if adl.Spec.Development != nil {
+		return
+	}
+	adl.Spec.Development = &struct {
+		Sandbox *struct {
+			Flox *struct {
+				Enabled bool `yaml:"enabled"`
+			} `yaml:"flox,omitempty"`
+			DevContainer *struct {
+				Enabled bool `yaml:"enabled"`
+			} `yaml:"devcontainer,omitempty"`
+		} `yaml:"sandbox,omitempty"`
+		AI *struct {
+			Enabled bool `yaml:"enabled"`
+		} `yaml:"ai,omitempty"`
+	}{}
 }
 
 func parseGitRemote() (owner, repo string) {

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -248,8 +248,8 @@ func TestInitAICICDDefaults(t *testing.T) {
 		t.Errorf("expected SCM.CD to default to false")
 	}
 
-	if adl.Spec.AI != nil && adl.Spec.AI.Enabled {
-		t.Errorf("expected spec.ai to be omitted or disabled by default, got enabled=true")
+	if adl.Spec.Development != nil && adl.Spec.Development.AI != nil && adl.Spec.Development.AI.Enabled {
+		t.Errorf("expected spec.development.ai to be omitted or disabled by default, got enabled=true")
 	}
 
 	contentStr := string(content)
@@ -261,7 +261,7 @@ func TestInitAICICDDefaults(t *testing.T) {
 	}
 }
 
-// TestInitAIFlag verifies that `--ai` flag at init time writes spec.ai.enabled: true.
+// TestInitAIFlag verifies that `--ai` flag at init time writes spec.development.ai.enabled: true.
 func TestInitAIFlag(t *testing.T) {
 	tempDir := t.TempDir()
 	outputPath := filepath.Join(tempDir, "test-output")
@@ -293,13 +293,13 @@ func TestInitAIFlag(t *testing.T) {
 		t.Fatalf("failed to parse ADL YAML: %v", err)
 	}
 
-	if adl.Spec.AI == nil || !adl.Spec.AI.Enabled {
-		t.Errorf("expected spec.ai.enabled to be true when --ai is passed to init")
+	if adl.Spec.Development == nil || adl.Spec.Development.AI == nil || !adl.Spec.Development.AI.Enabled {
+		t.Errorf("expected spec.development.ai.enabled to be true when --ai is passed to init")
 	}
 
 	contentStr := string(content)
-	if !strings.Contains(contentStr, "ai:") || !strings.Contains(contentStr, "enabled: true") {
-		t.Errorf("ADL file should contain ai.enabled: true, got:\n%s", contentStr)
+	if !strings.Contains(contentStr, "development:") || !strings.Contains(contentStr, "ai:") || !strings.Contains(contentStr, "enabled: true") {
+		t.Errorf("ADL file should contain development.ai.enabled: true, got:\n%s", contentStr)
 	}
 }
 

--- a/examples/cloudrun-agent.yaml
+++ b/examples/cloudrun-agent.yaml
@@ -68,6 +68,7 @@ spec:
       environment:
         LOG_LEVEL: info
         ENVIRONMENT: production
-  sandbox:
-    devcontainer:
-      enabled: true
+  development:
+    sandbox:
+      devcontainer:
+        enabled: true

--- a/examples/cloudrun-ghcr-agent.yaml
+++ b/examples/cloudrun-ghcr-agent.yaml
@@ -67,6 +67,7 @@ spec:
       environment:
         LOG_LEVEL: debug
         CACHE_ENABLED: "true"
-  sandbox:
-    flox:
-      enabled: true
+  development:
+    sandbox:
+      flox:
+        enabled: true

--- a/examples/go-agent-artifacts-filesystem.yaml
+++ b/examples/go-agent-artifacts-filesystem.yaml
@@ -91,8 +91,9 @@ spec:
     url: "https://github.com/inference-gateway/adl-cli"
     github_app: true
     issue_templates: false
-  sandbox:
-    flox:
-      enabled: true
-    devcontainer:
-      enabled: false
+  development:
+    sandbox:
+      flox:
+        enabled: true
+      devcontainer:
+        enabled: false

--- a/examples/go-agent-artifacts-minio.yaml
+++ b/examples/go-agent-artifacts-minio.yaml
@@ -107,8 +107,9 @@ spec:
     url: "https://github.com/inference-gateway/adl-cli"
     github_app: true
     issue_templates: false
-  sandbox:
-    flox:
-      enabled: true
-    devcontainer:
-      enabled: false
+  development:
+    sandbox:
+      flox:
+        enabled: true
+      devcontainer:
+        enabled: false

--- a/examples/go-agent.yaml
+++ b/examples/go-agent.yaml
@@ -213,11 +213,12 @@ spec:
     url: "https://github.com/inference-gateway/adl-cli"
     github_app: true
     issue_templates: false
-  sandbox:
-    flox:
-      enabled: true
-    devcontainer:
-      enabled: false
+  development:
+    sandbox:
+      flox:
+        enabled: true
+      devcontainer:
+        enabled: false
   # hooks:
   #   post:
   #     - "go mod tidy"

--- a/examples/kubernetes-agent.yaml
+++ b/examples/kubernetes-agent.yaml
@@ -52,6 +52,7 @@ spec:
         registry: ghcr.io
         repository: example/kubernetes-example
         tag: v1.0.0
-  sandbox:
-    devcontainer:
-      enabled: true
+  development:
+    sandbox:
+      devcontainer:
+        enabled: true

--- a/examples/rust-agent-ai.yaml
+++ b/examples/rust-agent-ai.yaml
@@ -69,8 +69,11 @@ spec:
       packageName: "rust-agent-ai"
       version: "1.94.1"
       edition: "2024"
-  sandbox:
-    flox:
+  development:
+    sandbox:
+      flox:
+        enabled: true
+      devcontainer:
+        enabled: false
+    ai:
       enabled: true
-    devcontainer:
-      enabled: false

--- a/examples/rust-agent-redis.yaml
+++ b/examples/rust-agent-redis.yaml
@@ -58,10 +58,11 @@ spec:
       edition: "2024"
       features:
         - redis
-  sandbox:
-    flox:
-      enabled: true
-    devcontainer:
-      enabled: false
-    dockerCompose:
-      enabled: true
+  development:
+    sandbox:
+      flox:
+        enabled: true
+      devcontainer:
+        enabled: false
+      dockerCompose:
+        enabled: true

--- a/examples/rust-agent.yaml
+++ b/examples/rust-agent.yaml
@@ -67,8 +67,9 @@ spec:
       packageName: "rust-agent"
       version: "1.94.1"
       edition: "2024"
-  sandbox:
-    flox:
-      enabled: true
-    devcontainer:
-      enabled: false
+  development:
+    sandbox:
+      flox:
+        enabled: true
+      devcontainer:
+        enabled: false

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -58,16 +58,20 @@ func (g *Generator) Generate(adlFile, outputDir string) error {
 	// Reconcile CLI flags with manifest fields. The CLI flag is OR'd on top
 	// of the manifest value, so passing --ai/--ci/--cd at the command line
 	// always wins; omitting the flag falls back to the manifest. After this
-	// block, both g.config.* and adl.Spec.* reflect the same effective state
-	// so templates (e.g. .gitattributes) can read either source of truth.
-	if adl.Spec.AI != nil && adl.Spec.AI.Enabled {
+	// block, both g.config.* and adl.Spec.Development.* reflect the same
+	// effective state so templates (e.g. .gitattributes) can read either
+	// source of truth.
+	if adl.Spec.Development != nil && adl.Spec.Development.AI != nil && adl.Spec.Development.AI.Enabled {
 		g.config.EnableAI = true
 	}
 	if g.config.EnableAI {
-		if adl.Spec.AI == nil {
-			adl.Spec.AI = &schema.AIConfig{Enabled: true}
+		if adl.Spec.Development == nil {
+			adl.Spec.Development = &schema.DevelopmentConfig{}
+		}
+		if adl.Spec.Development.AI == nil {
+			adl.Spec.Development.AI = &schema.AIConfig{Enabled: true}
 		} else {
-			adl.Spec.AI.Enabled = true
+			adl.Spec.Development.AI.Enabled = true
 		}
 	}
 	if adl.Spec.SCM != nil {
@@ -117,14 +121,17 @@ func (g *Generator) Generate(adlFile, outputDir string) error {
 	}
 
 	if g.config.EnableFlox || g.config.EnableDevContainer {
-		if adl.Spec.Sandbox == nil {
-			adl.Spec.Sandbox = &schema.SandboxConfig{}
+		if adl.Spec.Development == nil {
+			adl.Spec.Development = &schema.DevelopmentConfig{}
 		}
-		if g.config.EnableFlox && (adl.Spec.Sandbox.Flox == nil || !adl.Spec.Sandbox.Flox.Enabled) {
-			adl.Spec.Sandbox.Flox = &schema.FloxConfig{Enabled: true}
+		if adl.Spec.Development.Sandbox == nil {
+			adl.Spec.Development.Sandbox = &schema.SandboxConfig{}
 		}
-		if g.config.EnableDevContainer && (adl.Spec.Sandbox.DevContainer == nil || !adl.Spec.Sandbox.DevContainer.Enabled) {
-			adl.Spec.Sandbox.DevContainer = &schema.DevContainerConfig{Enabled: true}
+		if g.config.EnableFlox && (adl.Spec.Development.Sandbox.Flox == nil || !adl.Spec.Development.Sandbox.Flox.Enabled) {
+			adl.Spec.Development.Sandbox.Flox = &schema.FloxConfig{Enabled: true}
+		}
+		if g.config.EnableDevContainer && (adl.Spec.Development.Sandbox.DevContainer == nil || !adl.Spec.Development.Sandbox.DevContainer.Enabled) {
+			adl.Spec.Development.Sandbox.DevContainer = &schema.DevContainerConfig{Enabled: true}
 		}
 	}
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -564,6 +564,25 @@ func TestGenerator_generateCD(t *testing.T) {
 
 func TestGenerator_Dependabot(t *testing.T) {
 	makeADL := func(name string, dependabot bool, lang schema.Language, sandbox *schema.SandboxConfig) *schema.ADL {
+		spec := schema.Spec{
+			Capabilities: schema.Capabilities{
+				Streaming:              true,
+				PushNotifications:      false,
+				StateTransitionHistory: false,
+			},
+			Server: schema.Server{
+				Port: 8080,
+			},
+			Language: lang,
+			SCM: &schema.SCM{
+				Provider:   schema.SCMProviderGithub,
+				URL:        "https://github.com/example/" + name,
+				Dependabot: dependabot,
+			},
+		}
+		if sandbox != nil {
+			spec.Development = &schema.DevelopmentConfig{Sandbox: sandbox}
+		}
 		return &schema.ADL{
 			APIVersion: "adl.inference-gateway.com/v1",
 			Kind:       "Agent",
@@ -572,23 +591,7 @@ func TestGenerator_Dependabot(t *testing.T) {
 				Description: "Test agent",
 				Version:     "1.0.0",
 			},
-			Spec: schema.Spec{
-				Capabilities: schema.Capabilities{
-					Streaming:              true,
-					PushNotifications:      false,
-					StateTransitionHistory: false,
-				},
-				Server: schema.Server{
-					Port: 8080,
-				},
-				Language: lang,
-				Sandbox:  sandbox,
-				SCM: &schema.SCM{
-					Provider:   schema.SCMProviderGithub,
-					URL:        "https://github.com/example/" + name,
-					Dependabot: dependabot,
-				},
-			},
+			Spec: spec,
 		}
 	}
 

--- a/internal/schema/schema.json
+++ b/internal/schema/schema.json
@@ -68,9 +68,8 @@
         "artifacts": { "$ref": "#/definitions/ArtifactsConfig" },
         "hooks": { "$ref": "#/definitions/Hooks" },
         "scm": { "$ref": "#/definitions/SCM" },
-        "sandbox": { "$ref": "#/definitions/SandboxConfig" },
-        "deployment": { "$ref": "#/definitions/DeploymentConfig" },
-        "ai": { "$ref": "#/definitions/AIConfig" }
+        "development": { "$ref": "#/definitions/DevelopmentConfig" },
+        "deployment": { "$ref": "#/definitions/DeploymentConfig" }
       }
     },
     "Capabilities": {
@@ -279,8 +278,17 @@
         "cd": { "type": "boolean" }
       }
     },
+    "DevelopmentConfig": {
+      "type": "object",
+      "description": "Local development experience for the agent: sandboxed dev environments (flox, devcontainer, dockerCompose) and AI-assistant integration (CLAUDE.md/AGENTS.md generation, claude-code provisioning).",
+      "properties": {
+        "sandbox": { "$ref": "#/definitions/SandboxConfig" },
+        "ai": { "$ref": "#/definitions/AIConfig" }
+      }
+    },
     "SandboxConfig": {
       "type": "object",
+      "description": "Reproducible development environments. flox, devcontainer, and dockerCompose are alternative ways to package the same sandbox; pick what suits the team.",
       "properties": {
         "flox": { "$ref": "#/definitions/FloxConfig" },
         "devcontainer": { "$ref": "#/definitions/DevContainerConfig" },

--- a/internal/schema/types.go
+++ b/internal/schema/types.go
@@ -138,6 +138,17 @@ type DevContainerConfig struct {
 	Enabled bool `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
 }
 
+// Local development experience for the agent: sandboxed dev environments (flox,
+// devcontainer, dockerCompose) and AI-assistant integration (CLAUDE.md/AGENTS.md
+// generation, claude-code provisioning).
+type DevelopmentConfig struct {
+	// AI corresponds to the JSON schema field "ai".
+	AI *AIConfig `json:"ai,omitempty,omitzero" yaml:"ai,omitempty" mapstructure:"ai,omitempty"`
+
+	// Sandbox corresponds to the JSON schema field "sandbox".
+	Sandbox *SandboxConfig `json:"sandbox,omitempty,omitzero" yaml:"sandbox,omitempty" mapstructure:"sandbox,omitempty"`
+}
+
 type DockerComposeConfig struct {
 	// Enabled corresponds to the JSON schema field "enabled".
 	Enabled bool `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
@@ -253,6 +264,8 @@ const SCMProviderBitbucket SCMProvider = "bitbucket"
 const SCMProviderGithub SCMProvider = "github"
 const SCMProviderGitlab SCMProvider = "gitlab"
 
+// Reproducible development environments. flox, devcontainer, and dockerCompose are
+// alternative ways to package the same sandbox; pick what suits the team.
 type SandboxConfig struct {
 	// DevContainer corresponds to the JSON schema field "devcontainer".
 	DevContainer *DevContainerConfig `json:"devcontainer,omitempty,omitzero" yaml:"devcontainer,omitempty" mapstructure:"devcontainer,omitempty"`
@@ -358,9 +371,6 @@ type Spec struct {
 	// Agent corresponds to the JSON schema field "agent".
 	Agent *Agent `json:"agent,omitempty,omitzero" yaml:"agent,omitempty" mapstructure:"agent,omitempty"`
 
-	// AI corresponds to the JSON schema field "ai".
-	AI *AIConfig `json:"ai,omitempty,omitzero" yaml:"ai,omitempty" mapstructure:"ai,omitempty"`
-
 	// Artifacts corresponds to the JSON schema field "artifacts".
 	Artifacts *ArtifactsConfig `json:"artifacts,omitempty,omitzero" yaml:"artifacts,omitempty" mapstructure:"artifacts,omitempty"`
 
@@ -376,14 +386,14 @@ type Spec struct {
 	// Deployment corresponds to the JSON schema field "deployment".
 	Deployment *DeploymentConfig `json:"deployment,omitempty,omitzero" yaml:"deployment,omitempty" mapstructure:"deployment,omitempty"`
 
+	// Development corresponds to the JSON schema field "development".
+	Development *DevelopmentConfig `json:"development,omitempty,omitzero" yaml:"development,omitempty" mapstructure:"development,omitempty"`
+
 	// Hooks corresponds to the JSON schema field "hooks".
 	Hooks *Hooks `json:"hooks,omitempty,omitzero" yaml:"hooks,omitempty" mapstructure:"hooks,omitempty"`
 
 	// Language corresponds to the JSON schema field "language".
 	Language Language `json:"language" yaml:"language" mapstructure:"language"`
-
-	// Sandbox corresponds to the JSON schema field "sandbox".
-	Sandbox *SandboxConfig `json:"sandbox,omitempty,omitzero" yaml:"sandbox,omitempty" mapstructure:"sandbox,omitempty"`
 
 	// SCM corresponds to the JSON schema field "scm".
 	SCM *SCM `json:"scm,omitempty,omitzero" yaml:"scm,omitempty" mapstructure:"scm,omitempty"`

--- a/internal/schema/validator.go
+++ b/internal/schema/validator.go
@@ -50,6 +50,15 @@ func (v *Validator) ValidateFile(filePath string) ([]string, error) {
 		return nil, fmt.Errorf("failed to parse YAML: %w", err)
 	}
 
+	// Reject pre-v0.6.0 manifests up front with a clear migration hint.
+	// JSON Schema lets unknown properties slip through Spec, so without
+	// this guard old `spec.sandbox` / `spec.ai` blocks would be silently
+	// dropped at unmarshal time and the agent would generate without
+	// sandboxes or AI docs.
+	if err := checkLegacySpecFields(yamlData); err != nil {
+		return nil, err
+	}
+
 	jsonData, err := json.Marshal(yamlData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert to JSON: %w", err)
@@ -85,6 +94,48 @@ func (v *Validator) ValidateFile(filePath string) ([]string, error) {
 	}
 
 	return warnings, nil
+}
+
+// checkLegacySpecFields rejects manifests that still use the pre-v0.6.0
+// shape where `sandbox` and `ai` sat directly under `spec`. In v0.6.0
+// they were grouped under `spec.development.{sandbox,ai}`. This catches
+// the typo before YAML unmarshal silently drops the unknown fields.
+func checkLegacySpecFields(yamlData any) error {
+	root, ok := yamlData.(map[string]any)
+	if !ok {
+		return nil
+	}
+	spec, ok := root["spec"].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	var legacy []string
+	if _, exists := spec["sandbox"]; exists {
+		legacy = append(legacy, "spec.sandbox -> spec.development.sandbox")
+	}
+	if _, exists := spec["ai"]; exists {
+		legacy = append(legacy, "spec.ai -> spec.development.ai")
+	}
+	if len(legacy) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf("manifest uses pre-v0.6.0 schema fields; move them under spec.development:\n  - %s\nThe ADL schema is pinned at v0.6.0 (see https://github.com/inference-gateway/adl/releases/tag/v0.6.0)",
+		joinWithIndent(legacy, "\n  - "))
+}
+
+// joinWithIndent is a tiny helper so we don't pull in strings just for one
+// formatted error.
+func joinWithIndent(items []string, sep string) string {
+	out := ""
+	for i, item := range items {
+		if i > 0 {
+			out += sep
+		}
+		out += item
+	}
+	return out
 }
 
 // reservedConfigSection is the namespace inside spec.config dedicated to

--- a/internal/schema/validator_test.go
+++ b/internal/schema/validator_test.go
@@ -214,6 +214,98 @@ metadata:
 	}
 }
 
+// TestValidator_RejectsLegacySpecFields locks in the v0.6.0 migration:
+// manifests that still nest `sandbox` or `ai` directly under `spec` must
+// fail validation with a hint pointing users at spec.development.
+func TestValidator_RejectsLegacySpecFields(t *testing.T) {
+	cases := []struct {
+		name   string
+		adl    string
+		errSub string
+	}{
+		{
+			name: "legacy spec.sandbox",
+			adl: `apiVersion: adl.inference-gateway.com/v1
+kind: Agent
+metadata:
+  name: legacy-sandbox
+  description: legacy
+  version: "0.1.0"
+spec:
+  capabilities:
+    streaming: true
+    pushNotifications: false
+    stateTransitionHistory: false
+  server:
+    port: 8080
+    debug: false
+  language:
+    go:
+      module: github.com/test/legacy
+      version: "1.26.2"
+  sandbox:
+    flox:
+      enabled: true
+`,
+			errSub: "spec.sandbox -> spec.development.sandbox",
+		},
+		{
+			name: "legacy spec.ai",
+			adl: `apiVersion: adl.inference-gateway.com/v1
+kind: Agent
+metadata:
+  name: legacy-ai
+  description: legacy
+  version: "0.1.0"
+spec:
+  capabilities:
+    streaming: true
+    pushNotifications: false
+    stateTransitionHistory: false
+  server:
+    port: 8080
+    debug: false
+  language:
+    go:
+      module: github.com/test/legacy
+      version: "1.26.2"
+  ai:
+    enabled: true
+`,
+			errSub: "spec.ai -> spec.development.ai",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpFile, err := os.CreateTemp("", "test-adl-legacy-*.yaml")
+			if err != nil {
+				t.Fatalf("Failed to create temp file: %v", err)
+			}
+			defer func() {
+				if err := os.Remove(tmpFile.Name()); err != nil {
+					t.Logf("Failed to remove temp file: %v", err)
+				}
+			}()
+			if _, err := tmpFile.WriteString(tc.adl); err != nil {
+				t.Fatalf("Failed to write temp file: %v", err)
+			}
+			if err := tmpFile.Close(); err != nil {
+				t.Fatalf("Failed to close temp file: %v", err)
+			}
+
+			validator := NewValidator()
+			_, err = validator.ValidateFile(tmpFile.Name())
+			if err == nil {
+				t.Fatalf("expected validation to fail for %s", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.errSub) {
+				t.Errorf("expected error to contain %q, got: %v", tc.errSub, err)
+			}
+		})
+	}
+}
+
 func TestValidator_SkillsAndTools(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/internal/templates/common/ai/agents.md.tmpl
+++ b/internal/templates/common/ai/agents.md.tmpl
@@ -153,11 +153,11 @@ Key environment variables you'll need to configure:
 - `PORT` - Server port (configured: {{ .ADL.Spec.Server.Port }})
 
 ### Development Environment
-{{- if .ADL.Spec.Sandbox }}
-{{- if .ADL.Spec.Sandbox.Flox }}
+{{- if and .ADL.Spec.Development .ADL.Spec.Development.Sandbox }}
+{{- if .ADL.Spec.Development.Sandbox.Flox }}
 **Flox Environment**: ✅ Configured for reproducible development setup
 {{- end }}
-{{- if .ADL.Spec.Sandbox.DevContainer }}
+{{- if .ADL.Spec.Development.Sandbox.DevContainer }}
 **DevContainer**: ✅ VS Code DevContainer configuration available
 {{- end }}
 {{- end }}

--- a/internal/templates/common/ai/claude.md.tmpl
+++ b/internal/templates/common/ai/claude.md.tmpl
@@ -142,8 +142,8 @@ When implementing tests:
 
 ## Environment Management
 
-{{- if .ADL.Spec.Sandbox }}
-{{- if .ADL.Spec.Sandbox.Flox }}
+{{- if and .ADL.Spec.Development .ADL.Spec.Development.Sandbox }}
+{{- if .ADL.Spec.Development.Sandbox.Flox }}
 The project includes Flox environment configuration (`.flox/env/manifest.toml`) providing:
 {{- if .ADL.Spec.Language.Go }}
 - Go {{ .ADL.Spec.Language.Go.Version | default "latest" }}
@@ -160,7 +160,7 @@ The project includes Flox environment configuration (`.flox/env/manifest.toml`) 
 - Claude Code CLI
 
 Activate with: `flox activate` (if Flox is installed)
-{{- else if .ADL.Spec.Sandbox.DevContainer }}
+{{- else if .ADL.Spec.Development.Sandbox.DevContainer }}
 The project includes DevContainer configuration providing a consistent development environment.
 
 Open in DevContainer-compatible editor (VS Code, GitHub Codespaces) for automatic setup.

--- a/internal/templates/common/config/gitattributes.tmpl
+++ b/internal/templates/common/config/gitattributes.tmpl
@@ -29,7 +29,7 @@ Taskfile.yml linguist-generated=true
 .github/workflows/cd.yml linguist-generated=true
 .releaserc.yaml linguist-generated=true
 
-{{- if or .EnableAI (and .ADL.Spec.AI .ADL.Spec.AI.Enabled) }}
+{{- if or .EnableAI (and .ADL.Spec.Development .ADL.Spec.Development.AI .ADL.Spec.Development.AI.Enabled) }}
 
 # AI assistant documentation (generated)
 CLAUDE.md linguist-generated=true

--- a/internal/templates/common/github/dependabot.yaml.tmpl
+++ b/internal/templates/common/github/dependabot.yaml.tmpl
@@ -49,7 +49,7 @@ updates:
       docker:
         patterns:
           - "*"
-{{- if and .ADL.Spec.Sandbox .ADL.Spec.Sandbox.DevContainer }}{{- if .ADL.Spec.Sandbox.DevContainer.Enabled }}
+{{- if and .ADL.Spec.Development .ADL.Spec.Development.Sandbox .ADL.Spec.Development.Sandbox.DevContainer }}{{- if .ADL.Spec.Development.Sandbox.DevContainer.Enabled }}
 
   - package-ecosystem: devcontainers
     directory: /

--- a/internal/templates/registry.go
+++ b/internal/templates/registry.go
@@ -234,9 +234,10 @@ func (r *Registry) getRustFiles(adl *schema.ADL) map[string]string {
 		}
 	}
 
-	if adl.Spec.Sandbox != nil &&
-		adl.Spec.Sandbox.DockerCompose != nil &&
-		adl.Spec.Sandbox.DockerCompose.Enabled {
+	if adl.Spec.Development != nil &&
+		adl.Spec.Development.Sandbox != nil &&
+		adl.Spec.Development.Sandbox.DockerCompose != nil &&
+		adl.Spec.Development.Sandbox.DockerCompose.Enabled {
 		files["docker-compose.yaml"] = "docker-compose.yaml"
 	}
 
@@ -301,18 +302,20 @@ func (r *Registry) addAIFiles(files map[string]string) {
 
 // addSandboxFiles adds sandbox-related files to the file mapping
 func (r *Registry) addSandboxFiles(adl *schema.ADL, files map[string]string) {
-	if adl.Spec.Sandbox == nil {
+	if adl.Spec.Development == nil || adl.Spec.Development.Sandbox == nil {
 		return
 	}
 
-	if adl.Spec.Sandbox.Flox != nil && adl.Spec.Sandbox.Flox.Enabled {
+	sandbox := adl.Spec.Development.Sandbox
+
+	if sandbox.Flox != nil && sandbox.Flox.Enabled {
 		files[".flox/env/manifest.toml"] = "flox/manifest.toml"
 		files[".flox/env.json"] = "flox/env.json"
 		files[".flox/.gitignore"] = "flox/gitignore"
 		files[".flox/.gitattributes"] = "flox/gitattributes"
 	}
 
-	if adl.Spec.Sandbox.DevContainer != nil && adl.Spec.Sandbox.DevContainer.Enabled {
+	if sandbox.DevContainer != nil && sandbox.DevContainer.Enabled {
 		files[".devcontainer/devcontainer.json"] = "devcontainer/devcontainer.json"
 	}
 }

--- a/internal/templates/registry_rust_test.go
+++ b/internal/templates/registry_rust_test.go
@@ -52,8 +52,10 @@ func TestRegistry_getRustFiles_DockerComposeOnlyWhenEnabled(t *testing.T) {
 		t.Fatalf("docker-compose.yaml unexpectedly emitted when sandbox flag unset")
 	}
 
-	adl.Spec.Sandbox = &schema.SandboxConfig{
-		DockerCompose: &schema.DockerComposeConfig{Enabled: true},
+	adl.Spec.Development = &schema.DevelopmentConfig{
+		Sandbox: &schema.SandboxConfig{
+			DockerCompose: &schema.DockerComposeConfig{Enabled: true},
+		},
 	}
 	if _, ok := r.getRustFiles(adl)["docker-compose.yaml"]; !ok {
 		t.Fatalf("docker-compose.yaml missing when sandbox.dockerCompose.enabled=true")


### PR DESCRIPTION
## Summary

Adopts ADL v0.6.0 (https://github.com/inference-gateway/adl/releases/tag/v0.6.0), which groups `sandbox` and `ai` under a new `spec.development` parent. Straight cut — no backward compatibility code.

- Bump `ADL_SCHEMA_VERSION` `v0.5.0` → `v0.6.0`, refresh vendored schema, regenerate `internal/schema/types.go`
- Validator rejects legacy `spec.sandbox` / `spec.ai` with a migration hint
- Generator, templates, `init` prompts, examples, and tests all use `spec.development.*`
- README + CLAUDE.md updated

Resolves #124

## Test plan

- [x] `task ci` passes (fmt, lint, test, build, verify-schema)
- [x] `task examples:test` validates all 9 example manifests
- [x] `task examples:generate` regenerates every example project
- [x] New `TestValidator_RejectsLegacySpecFields` covers both legacy fields

Generated with [Claude Code](https://claude.ai/code)