### PR TITLE
fix(init): Always emit spec.development defaults in generated ADL

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -56,6 +56,7 @@ func init() {
 	initCmd.Flags().String("typescript-name", "", "TypeScript package name")
 	initCmd.Flags().Bool("flox", false, "Enable Flox environment")
 	initCmd.Flags().Bool("devcontainer", false, "Enable DevContainer environment")
+	initCmd.Flags().Bool("docker-compose", false, "Enable Docker Compose environment")
 	initCmd.Flags().Bool("ai", false, "Enable AI assistant docs (CLAUDE.md/AGENTS.md) and claude-code in sandboxes")
 	initCmd.Flags().Bool("ci", false, "Enable CI workflow generation")
 	initCmd.Flags().Bool("cd", false, "Enable CD pipeline generation")
@@ -267,6 +268,9 @@ type adlData struct {
 				DevContainer *struct {
 					Enabled bool `yaml:"enabled"`
 				} `yaml:"devcontainer,omitempty"`
+				DockerCompose *struct {
+					Enabled bool `yaml:"enabled"`
+				} `yaml:"dockerCompose,omitempty"`
 			} `yaml:"sandbox,omitempty"`
 			AI *struct {
 				Enabled bool `yaml:"enabled"`
@@ -678,35 +682,35 @@ func collectADLInfo(cmd *cobra.Command, projectName string, useDefaults bool) *a
 
 	floxEnabled := promptBoolWithConfig("flox", useDefaults, "Enable Flox environment", false)
 	devcontainerEnabled := promptBoolWithConfig("devcontainer", useDefaults, "Enable DevContainer environment", false)
+	dockerComposeEnabled := promptBoolWithConfig("docker-compose", useDefaults, "Enable Docker Compose environment", false)
 
-	if floxEnabled || devcontainerEnabled {
-		ensureDevelopment(adl)
-		sandboxConfig := &struct {
-			Flox *struct {
-				Enabled bool `yaml:"enabled"`
-			} `yaml:"flox,omitempty"`
-			DevContainer *struct {
-				Enabled bool `yaml:"enabled"`
-			} `yaml:"devcontainer,omitempty"`
-		}{}
-
-		if floxEnabled {
-			sandboxConfig.Flox = &struct {
-				Enabled bool `yaml:"enabled"`
-			}{
-				Enabled: true,
-			}
-		}
-
-		if devcontainerEnabled {
-			sandboxConfig.DevContainer = &struct {
-				Enabled bool `yaml:"enabled"`
-			}{
-				Enabled: true,
-			}
-		}
-
-		adl.Spec.Development.Sandbox = sandboxConfig
+	ensureDevelopment(adl)
+	adl.Spec.Development.Sandbox = &struct {
+		Flox *struct {
+			Enabled bool `yaml:"enabled"`
+		} `yaml:"flox,omitempty"`
+		DevContainer *struct {
+			Enabled bool `yaml:"enabled"`
+		} `yaml:"devcontainer,omitempty"`
+		DockerCompose *struct {
+			Enabled bool `yaml:"enabled"`
+		} `yaml:"dockerCompose,omitempty"`
+	}{
+		Flox: &struct {
+			Enabled bool `yaml:"enabled"`
+		}{
+			Enabled: floxEnabled,
+		},
+		DevContainer: &struct {
+			Enabled bool `yaml:"enabled"`
+		}{
+			Enabled: devcontainerEnabled,
+		},
+		DockerCompose: &struct {
+			Enabled bool `yaml:"enabled"`
+		}{
+			Enabled: dockerComposeEnabled,
+		},
 	}
 
 	fmt.Println("\n🚀 Deployment Configuration")
@@ -773,13 +777,11 @@ func collectADLInfo(cmd *cobra.Command, projectName string, useDefaults bool) *a
 	fmt.Println("\n🤖 AI Assistant Documentation")
 	fmt.Println("-----------------------------")
 	aiEnabled := promptBoolWithConfig("ai", useDefaults, "Enable AI assistant docs (CLAUDE.md/AGENTS.md) and claude-code in sandboxes", false)
-	if aiEnabled {
-		ensureDevelopment(adl)
-		adl.Spec.Development.AI = &struct {
-			Enabled bool `yaml:"enabled"`
-		}{
-			Enabled: true,
-		}
+	ensureDevelopment(adl)
+	adl.Spec.Development.AI = &struct {
+		Enabled bool `yaml:"enabled"`
+	}{
+		Enabled: aiEnabled,
 	}
 
 	return adl
@@ -800,6 +802,9 @@ func ensureDevelopment(adl *adlData) {
 			DevContainer *struct {
 				Enabled bool `yaml:"enabled"`
 			} `yaml:"devcontainer,omitempty"`
+			DockerCompose *struct {
+				Enabled bool `yaml:"enabled"`
+			} `yaml:"dockerCompose,omitempty"`
 		} `yaml:"sandbox,omitempty"`
 		AI *struct {
 			Enabled bool `yaml:"enabled"`

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -303,6 +303,114 @@ func TestInitAIFlag(t *testing.T) {
 	}
 }
 
+// TestInitDevelopmentDefaultsEmitted verifies that `adl init --defaults`
+// always writes spec.development.sandbox.{flox,devcontainer,dockerCompose}.enabled
+// and spec.development.ai.enabled as explicit `false` values, so the defaults
+// are discoverable in the generated agent.yaml rather than silently omitted.
+func TestInitDevelopmentDefaultsEmitted(t *testing.T) {
+	tempDir := t.TempDir()
+	outputPath := filepath.Join(tempDir, "test-output")
+
+	cmd := initCmd
+	if err := cmd.Flags().Set("defaults", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("path", outputPath); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runInit(cmd, []string{"test-agent"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	adlPath := filepath.Join(outputPath, "agent.yaml")
+	content, err := os.ReadFile(adlPath)
+	if err != nil {
+		t.Fatalf("failed to read ADL file: %v", err)
+	}
+
+	var adl adlData
+	if err := yaml.Unmarshal(content, &adl); err != nil {
+		t.Fatalf("failed to parse ADL YAML: %v", err)
+	}
+
+	if adl.Spec.Development == nil {
+		t.Fatalf("expected spec.development to be present by default")
+	}
+	if adl.Spec.Development.Sandbox == nil {
+		t.Fatalf("expected spec.development.sandbox to be present by default")
+	}
+	if adl.Spec.Development.Sandbox.Flox == nil || adl.Spec.Development.Sandbox.Flox.Enabled {
+		t.Errorf("expected spec.development.sandbox.flox.enabled to be false by default")
+	}
+	if adl.Spec.Development.Sandbox.DevContainer == nil || adl.Spec.Development.Sandbox.DevContainer.Enabled {
+		t.Errorf("expected spec.development.sandbox.devcontainer.enabled to be false by default")
+	}
+	if adl.Spec.Development.Sandbox.DockerCompose == nil || adl.Spec.Development.Sandbox.DockerCompose.Enabled {
+		t.Errorf("expected spec.development.sandbox.dockerCompose.enabled to be false by default")
+	}
+	if adl.Spec.Development.AI == nil || adl.Spec.Development.AI.Enabled {
+		t.Errorf("expected spec.development.ai.enabled to be false by default")
+	}
+
+	contentStr := string(content)
+	for _, want := range []string{
+		"development:",
+		"sandbox:",
+		"flox:",
+		"devcontainer:",
+		"dockerCompose:",
+		"ai:",
+	} {
+		if !strings.Contains(contentStr, want) {
+			t.Errorf("ADL file should contain %q, got:\n%s", want, contentStr)
+		}
+	}
+
+	t.Logf("Generated ADL content:\n%s", contentStr)
+}
+
+// TestInitDockerComposeFlag verifies that the --docker-compose flag at init
+// time writes spec.development.sandbox.dockerCompose.enabled: true.
+func TestInitDockerComposeFlag(t *testing.T) {
+	tempDir := t.TempDir()
+	outputPath := filepath.Join(tempDir, "test-output")
+
+	cmd := initCmd
+	if err := cmd.Flags().Set("defaults", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("path", outputPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("docker-compose", "true"); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = cmd.Flags().Set("docker-compose", "false") }()
+
+	if err := runInit(cmd, []string{"test-agent"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	adlPath := filepath.Join(outputPath, "agent.yaml")
+	content, err := os.ReadFile(adlPath)
+	if err != nil {
+		t.Fatalf("failed to read ADL file: %v", err)
+	}
+
+	var adl adlData
+	if err := yaml.Unmarshal(content, &adl); err != nil {
+		t.Fatalf("failed to parse ADL YAML: %v", err)
+	}
+
+	if adl.Spec.Development == nil ||
+		adl.Spec.Development.Sandbox == nil ||
+		adl.Spec.Development.Sandbox.DockerCompose == nil ||
+		!adl.Spec.Development.Sandbox.DockerCompose.Enabled {
+		t.Errorf("expected spec.development.sandbox.dockerCompose.enabled to be true when --docker-compose is passed to init")
+	}
+}
+
 func TestInitDefaultsVendorNeutral(t *testing.T) {
 	tempDir := t.TempDir()
 	outputPath := filepath.Join(tempDir, "test-output")


### PR DESCRIPTION
## Summary
- `adl init` now always writes `spec.development.sandbox.{flox,devcontainer,dockerCompose}.enabled` and `spec.development.ai.enabled` (false by default), so the defaults are visible in the generated `agent.yaml`.
- Adds a `--docker-compose` flag for parity with `--flox` / `--devcontainer`.
- New tests: `TestInitDevelopmentDefaultsEmitted`, `TestInitDockerComposeFlag`.

Closes #126

## Test plan
- [x] `go test ./...` passes locally
- [ ] `task ci` passes in CI

Generated with [Claude Code](https://claude.ai/code)