### PR TITLE
fix(generator): Mark dependabot.yml as generated in .gitattributes when enabled

### DIFF
--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -684,8 +684,32 @@ func TestGenerator_Dependabot(t *testing.T) {
 					t.Errorf("expected dependabot output NOT to contain %q, got:\n%s", unexpected, content)
 				}
 			}
+
+			gitattrContent, err := engine.ExecuteTemplate("config/gitattributes", templates.Context{ADL: tt.adl, Language: tt.registryLang})
+			if err != nil {
+				t.Fatalf("failed to execute gitattributes template: %v", err)
+			}
+			if !containsSubstring(gitattrContent, ".github/dependabot.yml linguist-generated=true") {
+				t.Errorf("expected .gitattributes to mark dependabot.yml as linguist-generated when enabled, got:\n%s", gitattrContent)
+			}
 		})
 	}
+
+	t.Run("gitattributes omits dependabot entry when disabled", func(t *testing.T) {
+		adl := makeADL("agent-off", false, goLang, nil)
+		registry, err := templates.NewRegistry("go")
+		if err != nil {
+			t.Fatalf("failed to create template registry: %v", err)
+		}
+		engine := templates.NewWithRegistry("", registry)
+		gitattrContent, err := engine.ExecuteTemplate("config/gitattributes", templates.Context{ADL: adl, Language: "go"})
+		if err != nil {
+			t.Fatalf("failed to execute gitattributes template: %v", err)
+		}
+		if containsSubstring(gitattrContent, ".github/dependabot.yml") {
+			t.Errorf("expected .gitattributes NOT to reference dependabot.yml when disabled, got:\n%s", gitattrContent)
+		}
+	})
 }
 
 func TestGenerator_buildGenerateCommand(t *testing.T) {

--- a/internal/templates/common/config/gitattributes.tmpl
+++ b/internal/templates/common/config/gitattributes.tmpl
@@ -29,6 +29,14 @@ Taskfile.yml linguist-generated=true
 .github/workflows/cd.yml linguist-generated=true
 .releaserc.yaml linguist-generated=true
 
+{{- $scmProvider := "" }}
+{{- if .ADL.Spec.SCM }}{{- $scmProvider = printf "%s" .ADL.Spec.SCM.Provider }}{{- end }}
+{{- if and .ADL.Spec.SCM .ADL.Spec.SCM.Dependabot (or (eq $scmProvider "github") (eq $scmProvider "")) }}
+
+# Dependabot configuration
+.github/dependabot.yml linguist-generated=true
+{{- end }}
+
 {{- if or .EnableAI (and .ADL.Spec.Development .ADL.Spec.Development.AI .ADL.Spec.Development.AI.Enabled) }}
 
 # AI assistant documentation (generated)


### PR DESCRIPTION
Closes #128

## Summary

When `spec.scm.dependabot` is enabled (with the github provider), the generated `.github/dependabot.yml` is now marked as `linguist-generated=true` in `.gitattributes`. This collapses it in PR diffs and excludes it from language statistics, matching how other generated files (main.go, Dockerfile, CI workflows, etc.) are treated.

When dependabot is disabled, no entry is added.

## Test plan

- [x] `go test ./...` passes
- [x] `TestGenerator_Dependabot` now asserts the `.gitattributes` entry is present when enabled and absent when disabled

Generated with [Claude Code](https://claude.ai/code)