### PR TITLE
fix(templates): Respect sandbox enabled flags in AGENTS.md/CLAUDE.md

### DIFF
--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -681,3 +681,147 @@ func containsString(content, substr string) bool {
 	}
 	return false
 }
+
+// TestGenerateAIDocsRespectSandboxEnabledFlags verifies that AGENTS.md and
+// CLAUDE.md only mention sandbox environments that are actually enabled. This
+// guards against the regression in issue #129 where `init` populates all three
+// sandbox pointers (flox/devcontainer/dockerCompose), causing the templates to
+// document every environment regardless of its `enabled` flag.
+func TestGenerateAIDocsRespectSandboxEnabledFlags(t *testing.T) {
+	tests := []struct {
+		name              string
+		floxEnabled       bool
+		devContainerOn    bool
+		dockerComposeOn   bool
+		wantFlox          bool
+		wantDevContainer  bool
+		wantDockerCompose bool
+	}{
+		{
+			name:        "only flox enabled",
+			floxEnabled: true,
+			wantFlox:    true,
+		},
+		{
+			name:             "only devcontainer enabled",
+			devContainerOn:   true,
+			wantDevContainer: true,
+		},
+		{
+			name:              "only docker-compose enabled",
+			dockerComposeOn:   true,
+			wantDockerCompose: true,
+		},
+		{
+			name:              "all three enabled",
+			floxEnabled:       true,
+			devContainerOn:    true,
+			dockerComposeOn:   true,
+			wantFlox:          true,
+			wantDevContainer:  true,
+			wantDockerCompose: true,
+		},
+		{
+			name: "all three pointers present but disabled",
+			// emulates the init flow that populates all three pointers
+			// regardless of the user's enabled choice - none should render.
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			outputPath := filepath.Join(tempDir, "out")
+
+			adlContent := `apiVersion: adl.inference-gateway.com/v1
+kind: Agent
+metadata:
+  name: sandbox-docs-agent
+  description: Agent for verifying sandbox doc rendering
+  version: 1.0.0
+spec:
+  capabilities:
+    streaming: true
+    pushNotifications: false
+    stateTransitionHistory: false
+  server:
+    port: 8080
+    debug: false
+  language:
+    go:
+      module: github.com/test/sandbox-docs
+      version: "1.26.2"
+  development:
+    ai:
+      enabled: true
+    sandbox:
+      flox:
+        enabled: ` + boolStr(tc.floxEnabled) + `
+      devcontainer:
+        enabled: ` + boolStr(tc.devContainerOn) + `
+      dockerCompose:
+        enabled: ` + boolStr(tc.dockerComposeOn) + `
+`
+			adlPath := filepath.Join(tempDir, "agent.yaml")
+			if err := os.WriteFile(adlPath, []byte(adlContent), 0644); err != nil {
+				t.Fatalf("failed to write ADL file: %v", err)
+			}
+
+			originalADLFile := adlFile
+			originalOutputDir := outputDir
+			originalEnableAI := enableAI
+			defer func() {
+				adlFile = originalADLFile
+				outputDir = originalOutputDir
+				enableAI = originalEnableAI
+			}()
+
+			adlFile = adlPath
+			outputDir = outputPath
+			enableAI = false
+
+			if err := runGenerate(generateCmd, []string{}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			for _, doc := range []string{"AGENTS.md", "CLAUDE.md"} {
+				path := filepath.Join(outputPath, doc)
+				bytes, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatalf("failed to read %s: %v", doc, err)
+				}
+				content := string(bytes)
+
+				hasFlox := strings.Contains(content, "Flox Environment")
+				hasDevContainer := strings.Contains(content, "DevContainer")
+				hasDockerCompose := strings.Contains(content, "Docker Compose")
+
+				if hasFlox != tc.wantFlox {
+					t.Errorf("%s: Flox section present=%v, want=%v", doc, hasFlox, tc.wantFlox)
+				}
+				if hasDevContainer != tc.wantDevContainer {
+					t.Errorf("%s: DevContainer section present=%v, want=%v", doc, hasDevContainer, tc.wantDevContainer)
+				}
+				if hasDockerCompose != tc.wantDockerCompose {
+					t.Errorf("%s: Docker Compose section present=%v, want=%v", doc, hasDockerCompose, tc.wantDockerCompose)
+				}
+
+				noneEnabled := !tc.wantFlox && !tc.wantDevContainer && !tc.wantDockerCompose
+				hasFallback := strings.Contains(content, "No sandboxed environments are configured")
+				if noneEnabled && !hasFallback {
+					t.Errorf("%s: expected fallback message when no sandbox environments are enabled, got:\n%s", doc, content)
+				}
+				if !noneEnabled && hasFallback {
+					t.Errorf("%s: unexpected fallback message when at least one sandbox is enabled", doc)
+				}
+			}
+		})
+	}
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -723,8 +723,6 @@ func TestGenerateAIDocsRespectSandboxEnabledFlags(t *testing.T) {
 		},
 		{
 			name: "all three pointers present but disabled",
-			// emulates the init flow that populates all three pointers
-			// regardless of the user's enabled choice - none should render.
 		},
 	}
 

--- a/internal/templates/common/ai/agents.md.tmpl
+++ b/internal/templates/common/ai/agents.md.tmpl
@@ -153,13 +153,23 @@ Key environment variables you'll need to configure:
 - `PORT` - Server port (configured: {{ .ADL.Spec.Server.Port }})
 
 ### Development Environment
+{{- $sandbox := false }}
 {{- if and .ADL.Spec.Development .ADL.Spec.Development.Sandbox }}
-{{- if .ADL.Spec.Development.Sandbox.Flox }}
-**Flox Environment**: ✅ Configured for reproducible development setup
+{{- if and .ADL.Spec.Development.Sandbox.Flox .ADL.Spec.Development.Sandbox.Flox.Enabled }}
+{{- $sandbox = true }}
+- **Flox Environment**: ✅ Configured for reproducible development setup (`flox activate`)
 {{- end }}
-{{- if .ADL.Spec.Development.Sandbox.DevContainer }}
-**DevContainer**: ✅ VS Code DevContainer configuration available
+{{- if and .ADL.Spec.Development.Sandbox.DevContainer .ADL.Spec.Development.Sandbox.DevContainer.Enabled }}
+{{- $sandbox = true }}
+- **DevContainer**: ✅ VS Code DevContainer configuration available (`.devcontainer/devcontainer.json`)
 {{- end }}
+{{- if and .ADL.Spec.Development.Sandbox.DockerCompose .ADL.Spec.Development.Sandbox.DockerCompose.Enabled }}
+{{- $sandbox = true }}
+- **Docker Compose**: ✅ Local service stack available (`docker compose up`)
+{{- end }}
+{{- end }}
+{{- if not $sandbox }}
+No sandboxed environments are configured. Set up your local toolchain manually (language runtime, Task runner, etc.) before running the agent.
 {{- end }}
 
 ## Usage

--- a/internal/templates/common/ai/claude.md.tmpl
+++ b/internal/templates/common/ai/claude.md.tmpl
@@ -142,31 +142,29 @@ When implementing tests:
 
 ## Environment Management
 
+### Development Environment
+{{- $sandbox := false }}
 {{- if and .ADL.Spec.Development .ADL.Spec.Development.Sandbox }}
-{{- if .ADL.Spec.Development.Sandbox.Flox }}
-The project includes Flox environment configuration (`.flox/env/manifest.toml`) providing:
-{{- if .ADL.Spec.Language.Go }}
-- Go {{ .ADL.Spec.Language.Go.Version | default "latest" }}
-{{- else if .ADL.Spec.Language.Rust }}
-- Rust {{ .ADL.Spec.Language.Rust.Version | default "latest" }}
-{{- else if .ADL.Spec.Language.TypeScript }}
-- Node.js {{ .ADL.Spec.Language.TypeScript.NodeVersion | default "latest" }}
-{{- else }}
-- Development runtime
+{{- if and .ADL.Spec.Development.Sandbox.Flox .ADL.Spec.Development.Sandbox.Flox.Enabled }}
+{{- $sandbox = true }}
+- **Flox Environment**: ✅ Configured via `.flox/env/manifest.toml` providing
+{{- if .ADL.Spec.Language.Go }} Go {{ .ADL.Spec.Language.Go.Version | default "latest" }},
+{{- else if .ADL.Spec.Language.Rust }} Rust {{ .ADL.Spec.Language.Rust.Version | default "latest" }},
+{{- else if .ADL.Spec.Language.TypeScript }} Node.js {{ .ADL.Spec.Language.TypeScript.NodeVersion | default "latest" }},
+{{- else }} the development runtime,
+{{- end }} linter, `go-task`, Docker, and the Claude Code CLI. Activate with `flox activate`.
 {{- end }}
-- golangci-lint (linter)
-- go-task (Task runner)
-- Docker
-- Claude Code CLI
-
-Activate with: `flox activate` (if Flox is installed)
-{{- else if .ADL.Spec.Development.Sandbox.DevContainer }}
-The project includes DevContainer configuration providing a consistent development environment.
-
-Open in DevContainer-compatible editor (VS Code, GitHub Codespaces) for automatic setup.
+{{- if and .ADL.Spec.Development.Sandbox.DevContainer .ADL.Spec.Development.Sandbox.DevContainer.Enabled }}
+{{- $sandbox = true }}
+- **DevContainer**: ✅ VS Code DevContainer config at `.devcontainer/devcontainer.json`. Open the project in a DevContainer-compatible editor (VS Code, GitHub Codespaces) for automatic setup.
 {{- end }}
-{{- else }}
-Standard development environment required. Install:
+{{- if and .ADL.Spec.Development.Sandbox.DockerCompose .ADL.Spec.Development.Sandbox.DockerCompose.Enabled }}
+{{- $sandbox = true }}
+- **Docker Compose**: ✅ Local service stack defined in `docker-compose.yaml`. Start dependencies (e.g. Redis) with `docker compose up`.
+{{- end }}
+{{- end }}
+{{- if not $sandbox }}
+No sandboxed environments are configured. Install the toolchain manually:
 {{- if .ADL.Spec.Language.Go }}
 - Go {{ .ADL.Spec.Language.Go.Version | default "1.26.2+" }}
 {{- else if .ADL.Spec.Language.Rust }}


### PR DESCRIPTION
## Summary

- AGENTS.md and CLAUDE.md now only list sandbox environments whose `enabled` flag is true (previously every non-nil pointer rendered, so `init`-populated but disabled environments were documented).
- Added Docker Compose to both docs (was missing).
- Synced CLAUDE.md's Environment Management section with AGENTS.md's Development Environment layout.
- Added a regression test covering each single sandbox, all three, and the disabled-but-populated case from the bug report.

Fixes #129

## Test plan

- [ ] `go test ./cmd -run TestGenerateAIDocsRespectSandboxEnabledFlags -v`
- [ ] `go test ./...`
- [ ] Generate a project with only `flox.enabled: true` and confirm AGENTS.md/CLAUDE.md mention only Flox

Generated with [Claude Code](https://claude.ai/code)