### PR TITLE
chore: Mark .github/workflows/claude.yml as linguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 install.sh linguist-vendored=true
 internal/schema/schema.json linguist-vendored=true
 internal/schema/types.go linguist-generated=true
+.github/workflows/claude.yml linguist-generated=true


### PR DESCRIPTION
## Summary

Marks `.github/workflows/claude.yml` as `linguist-generated=true` in `.gitattributes` so the Claude Code workflow is collapsed in PR diffs and excluded from language stats, matching how CI/CD configs are treated.

The entry is only added because AI is enabled in this repo (the workflow is present and active).

Closes #135

## Test plan

- [ ] Open a PR touching `.github/workflows/claude.yml` and confirm the diff renders as collapsed/generated
- [ ] Confirm GitHub language stats no longer count the workflow

Generated with [Claude Code](https://claude.ai/code)