### PR TITLE
feat(templates): Generate unit tests for built-in tools

### DIFF
--- a/examples/cloudrun-agent.yaml
+++ b/examples/cloudrun-agent.yaml
@@ -45,6 +45,8 @@ spec:
     provider: github
     url: "https://github.com/example/cloudrun-example"
     issue_templates: false
+    ci: true
+    cd: false
   deployment:
     type: cloudrun
     cloudrun:

--- a/examples/cloudrun-ghcr-agent.yaml
+++ b/examples/cloudrun-ghcr-agent.yaml
@@ -44,6 +44,8 @@ spec:
   scm:
     provider: github
     url: "https://github.com/example/ghcr-example"
+    ci: true
+    cd: false
   deployment:
     type: cloudrun
     cloudrun:

--- a/examples/go-agent-artifacts-filesystem.yaml
+++ b/examples/go-agent-artifacts-filesystem.yaml
@@ -91,6 +91,8 @@ spec:
     url: "https://github.com/inference-gateway/adl-cli"
     github_app: true
     issue_templates: false
+    ci: true
+    cd: false
   development:
     sandbox:
       flox:

--- a/examples/go-agent-artifacts-minio.yaml
+++ b/examples/go-agent-artifacts-minio.yaml
@@ -107,6 +107,8 @@ spec:
     url: "https://github.com/inference-gateway/adl-cli"
     github_app: true
     issue_templates: false
+    ci: true
+    cd: false
   development:
     sandbox:
       flox:

--- a/examples/go-agent-builtin-tools.yaml
+++ b/examples/go-agent-builtin-tools.yaml
@@ -131,6 +131,13 @@ spec:
     go:
       module: "github.com/inference-gateway/adl-cli/test-output"
       version: "1.26.2"
+  scm:
+    provider: github
+    url: "https://github.com/inference-gateway/adl-cli"
+    github_app: true
+    issue_templates: false
+    ci: true
+    cd: false
   development:
     sandbox:
       flox:

--- a/examples/go-agent.yaml
+++ b/examples/go-agent.yaml
@@ -214,6 +214,8 @@ spec:
     url: "https://github.com/inference-gateway/adl-cli"
     github_app: true
     issue_templates: false
+    ci: true
+    cd: false
   development:
     sandbox:
       flox:

--- a/examples/kubernetes-agent.yaml
+++ b/examples/kubernetes-agent.yaml
@@ -45,6 +45,8 @@ spec:
     provider: github
     url: "https://github.com/example/kubernetes-example"
     issue_templates: false
+    ci: true
+    cd: false
   deployment:
     type: kubernetes
     kubernetes:

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -410,7 +410,7 @@ func (g *Generator) generateProject(templateEngine *templates.Engine, adl *schem
 				}
 			}
 		} else if (templateKey == "tool.go" || templateKey == "tool.rs" || templateKey == "tool.ts" ||
-			strings.HasPrefix(templateKey, "builtin/")) && strings.Contains(fileName, "/") {
+			(strings.HasPrefix(templateKey, "builtin/") && !isBuiltinTestTemplate(templateKey))) && strings.Contains(fileName, "/") {
 			parts := strings.Split(fileName, "/")
 			if len(parts) >= 2 {
 				toolFileName := parts[len(parts)-1]
@@ -1089,4 +1089,16 @@ func titleCase(s string) string {
 		return s
 	}
 	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+// isBuiltinTestTemplate reports whether templateKey points to a built-in
+// tool's *_test.<ext> template. These templates don't need the per-tool
+// context (Config/ID/Name/...) the regular built-in path injects, so the
+// generator routes them through the plain ExecuteTemplate path instead.
+func isBuiltinTestTemplate(templateKey string) bool {
+	if !strings.HasPrefix(templateKey, "builtin/") {
+		return false
+	}
+	base := strings.TrimSuffix(filepath.Base(templateKey), filepath.Ext(templateKey))
+	return strings.HasSuffix(base, "_test")
 }

--- a/internal/templates/common/docs/README.md.tmpl
+++ b/internal/templates/common/docs/README.md.tmpl
@@ -6,7 +6,6 @@
 {{ if and .ADL.Spec.SCM (eq .ADL.Spec.SCM.Provider "github") .ADL.Spec.SCM.URL -}}
 {{ $url := .ADL.Spec.SCM.URL | trimSuffix ".git" | trimPrefix "https://github.com/" | trimPrefix "git@github.com:" -}}
 [![CI](https://github.com/{{ $url }}/workflows/CI/badge.svg)](https://github.com/{{ $url }}/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/github/actions/workflow/status/{{ $url }}/ci.yml?branch=main&label=tests&logo=github)](https://github.com/{{ $url }}/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/codecov/c/github/{{ $url }}?label=coverage&logo=codecov)](https://codecov.io/gh/{{ $url }})
 {{ end -}}
 {{ end -}}

--- a/internal/templates/common/docs/README.md.tmpl
+++ b/internal/templates/common/docs/README.md.tmpl
@@ -6,6 +6,8 @@
 {{ if and .ADL.Spec.SCM (eq .ADL.Spec.SCM.Provider "github") .ADL.Spec.SCM.URL -}}
 {{ $url := .ADL.Spec.SCM.URL | trimSuffix ".git" | trimPrefix "https://github.com/" | trimPrefix "git@github.com:" -}}
 [![CI](https://github.com/{{ $url }}/workflows/CI/badge.svg)](https://github.com/{{ $url }}/actions/workflows/ci.yml)
+[![Tests](https://img.shields.io/github/actions/workflow/status/{{ $url }}/ci.yml?branch=main&label=tests&logo=github)](https://github.com/{{ $url }}/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/codecov/c/github/{{ $url }}?label=coverage&logo=codecov)](https://codecov.io/gh/{{ $url }})
 {{ end -}}
 {{ end -}}
 {{ if eq .Language "go" -}}

--- a/internal/templates/languages/go/builtin/bash_test.go.tmpl
+++ b/internal/templates/languages/go/builtin/bash_test.go.tmpl
@@ -1,0 +1,84 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	zap "go.uber.org/zap"
+)
+
+// newTestBashTool builds a Bash tool with the supplied config, bypassing
+// envconfig so each test pins the exact behavior under test.
+func newTestBashTool(cfg BashConfig) *BashTool {
+	if cfg.TimeoutSeconds <= 0 {
+		cfg.TimeoutSeconds = 5
+	}
+	return &BashTool{logger: zap.NewNop(), cfg: cfg}
+}
+
+func TestBashTool_DisabledReturnsError(t *testing.T) {
+	t.Parallel()
+	tool := newTestBashTool(BashConfig{Enabled: false})
+	if _, err := tool.Handler(context.Background(), map[string]any{"command": "echo hi"}); err == nil {
+		t.Fatalf("expected error when tool is disabled, got nil")
+	}
+}
+
+func TestBashTool_RequiresCommand(t *testing.T) {
+	t.Parallel()
+	tool := newTestBashTool(BashConfig{Enabled: true})
+	if _, err := tool.Handler(context.Background(), map[string]any{"command": "   "}); err == nil {
+		t.Fatalf("expected error when command is blank, got nil")
+	}
+}
+
+func TestBashTool_ExecutesEcho(t *testing.T) {
+	t.Parallel()
+	tool := newTestBashTool(BashConfig{Enabled: true})
+	out, err := tool.Handler(context.Background(), map[string]any{"command": "echo hello-bash"})
+	if err != nil {
+		t.Fatalf("Handler returned error: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if exit := int(payload["exit_code"].(float64)); exit != 0 {
+		t.Fatalf("expected exit_code=0, got %d", exit)
+	}
+	if got := payload["output"].(string); !strings.Contains(got, "hello-bash") {
+		t.Fatalf("expected output to contain hello-bash, got %q", got)
+	}
+}
+
+func TestBashTool_EnforcesWhitelist(t *testing.T) {
+	t.Parallel()
+	tool := newTestBashTool(BashConfig{Enabled: true, Whitelist: []string{"echo"}})
+
+	if _, err := tool.Handler(context.Background(), map[string]any{"command": "echo allowed"}); err != nil {
+		t.Fatalf("expected whitelisted command to succeed, got: %v", err)
+	}
+	if _, err := tool.Handler(context.Background(), map[string]any{"command": "ls /"}); err == nil {
+		t.Fatalf("expected non-whitelisted command to fail, got nil")
+	}
+}
+
+func TestBashTool_NonZeroExitCodeIsReported(t *testing.T) {
+	t.Parallel()
+	tool := newTestBashTool(BashConfig{Enabled: true})
+	out, err := tool.Handler(context.Background(), map[string]any{"command": "exit 7"})
+	if err != nil {
+		t.Fatalf("Handler returned error for non-zero exit: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if exit := int(payload["exit_code"].(float64)); exit != 7 {
+		t.Fatalf("expected exit_code=7, got %d", exit)
+	}
+}

--- a/internal/templates/languages/go/builtin/edit_test.go.tmpl
+++ b/internal/templates/languages/go/builtin/edit_test.go.tmpl
@@ -1,0 +1,149 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	zap "go.uber.org/zap"
+)
+
+// newTestEditTool builds an Edit tool with the supplied config, bypassing
+// envconfig so each test pins the exact behavior under test.
+func newTestEditTool(cfg EditConfig) *EditTool {
+	return &EditTool{logger: zap.NewNop(), cfg: cfg}
+}
+
+func TestEditTool_DisabledReturnsError(t *testing.T) {
+	t.Parallel()
+	tool := newTestEditTool(EditConfig{Enabled: false})
+	if _, err := tool.Handler(context.Background(), map[string]any{
+		"file_path":  "x",
+		"old_string": "a",
+		"new_string": "b",
+	}); err == nil {
+		t.Fatalf("expected error when tool is disabled, got nil")
+	}
+}
+
+func TestEditTool_ValidatesRequiredArgs(t *testing.T) {
+	t.Parallel()
+	tool := newTestEditTool(EditConfig{Enabled: true})
+
+	if _, err := tool.Handler(context.Background(), map[string]any{
+		"old_string": "a",
+		"new_string": "b",
+	}); err == nil {
+		t.Fatalf("expected error when file_path is missing, got nil")
+	}
+	if _, err := tool.Handler(context.Background(), map[string]any{
+		"file_path":  "x",
+		"new_string": "b",
+	}); err == nil {
+		t.Fatalf("expected error when old_string is missing, got nil")
+	}
+	if _, err := tool.Handler(context.Background(), map[string]any{
+		"file_path":  "x",
+		"old_string": "",
+		"new_string": "b",
+	}); err == nil {
+		t.Fatalf("expected error when old_string is empty, got nil")
+	}
+}
+
+func TestEditTool_ReplacesUniqueMatch(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(path, []byte("hello world\n"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	tool := newTestEditTool(EditConfig{Enabled: true})
+	if _, err := tool.Handler(context.Background(), map[string]any{
+		"file_path":  path,
+		"old_string": "world",
+		"new_string": "there",
+	}); err != nil {
+		t.Fatalf("Handler returned error: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != "hello there\n" {
+		t.Fatalf("expected substitution applied, got %q", string(got))
+	}
+}
+
+func TestEditTool_RejectsMissingOldString(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(path, []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	tool := newTestEditTool(EditConfig{Enabled: true})
+	if _, err := tool.Handler(context.Background(), map[string]any{
+		"file_path":  path,
+		"old_string": "missing",
+		"new_string": "x",
+	}); err == nil {
+		t.Fatalf("expected error when old_string is not found, got nil")
+	}
+}
+
+func TestEditTool_RejectsAmbiguousOldString(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(path, []byte("dup\ndup\n"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	tool := newTestEditTool(EditConfig{Enabled: true})
+	if _, err := tool.Handler(context.Background(), map[string]any{
+		"file_path":  path,
+		"old_string": "dup",
+		"new_string": "x",
+	}); err == nil {
+		t.Fatalf("expected error when old_string appears multiple times, got nil")
+	}
+}
+
+func TestEditTool_EnforcesAllowedRoots(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	allowed := filepath.Join(dir, "allowed")
+	if err := os.MkdirAll(allowed, 0o755); err != nil {
+		t.Fatalf("mkdir allowed: %v", err)
+	}
+	insidePath := filepath.Join(allowed, "ok.txt")
+	if err := os.WriteFile(insidePath, []byte("hello world\n"), 0o644); err != nil {
+		t.Fatalf("seed inside: %v", err)
+	}
+	outsidePath := filepath.Join(dir, "outside.txt")
+	if err := os.WriteFile(outsidePath, []byte("hello world\n"), 0o644); err != nil {
+		t.Fatalf("seed outside: %v", err)
+	}
+
+	tool := newTestEditTool(EditConfig{Enabled: true, AllowedRoots: []string{allowed}})
+
+	if _, err := tool.Handler(context.Background(), map[string]any{
+		"file_path":  insidePath,
+		"old_string": "world",
+		"new_string": "there",
+	}); err != nil {
+		t.Fatalf("expected edit inside allowed root to succeed, got: %v", err)
+	}
+	if _, err := tool.Handler(context.Background(), map[string]any{
+		"file_path":  outsidePath,
+		"old_string": "world",
+		"new_string": "there",
+	}); err == nil {
+		t.Fatalf("expected edit outside allowed root to be rejected, got nil")
+	}
+}

--- a/internal/templates/languages/go/builtin/fetch_test.go.tmpl
+++ b/internal/templates/languages/go/builtin/fetch_test.go.tmpl
@@ -1,0 +1,243 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	zap "go.uber.org/zap"
+)
+
+// newTestFetchTool builds a Fetch tool with the supplied config and a
+// short-timeout HTTP client, bypassing envconfig so each test pins the
+// exact behavior under test.
+func newTestFetchTool(cfg FetchConfig) *FetchTool {
+	if cfg.TimeoutSeconds <= 0 {
+		cfg.TimeoutSeconds = 5
+	}
+	if cfg.MaxBytes <= 0 {
+		cfg.MaxBytes = defaultMaxBytes
+	}
+	if cfg.DownloadDir == "" {
+		cfg.DownloadDir = "/tmp"
+	}
+	return &FetchTool{
+		logger: zap.NewNop(),
+		cfg:    cfg,
+		client: &http.Client{Timeout: time.Duration(cfg.TimeoutSeconds) * time.Second},
+	}
+}
+
+func TestFetchTool_DisabledReturnsError(t *testing.T) {
+	t.Parallel()
+	tool := newTestFetchTool(FetchConfig{Enabled: false})
+	if _, err := tool.Handler(context.Background(), map[string]any{"url": "https://example.com"}); err == nil {
+		t.Fatalf("expected error when tool is disabled, got nil")
+	}
+}
+
+func TestFetchTool_RequiresURL(t *testing.T) {
+	t.Parallel()
+	tool := newTestFetchTool(FetchConfig{Enabled: true})
+	if _, err := tool.Handler(context.Background(), map[string]any{}); err == nil {
+		t.Fatalf("expected error when url is missing, got nil")
+	}
+}
+
+func TestFetchTool_RejectsUnsupportedScheme(t *testing.T) {
+	t.Parallel()
+	tool := newTestFetchTool(FetchConfig{Enabled: true})
+	if _, err := tool.Handler(context.Background(), map[string]any{"url": "ftp://example.com"}); err == nil {
+		t.Fatalf("expected error for ftp scheme, got nil")
+	}
+}
+
+func TestFetchTool_RejectsUnsupportedMethod(t *testing.T) {
+	t.Parallel()
+	tool := newTestFetchTool(FetchConfig{Enabled: true})
+	if _, err := tool.Handler(context.Background(), map[string]any{
+		"url":    "https://example.com",
+		"method": "POST",
+	}); err == nil {
+		t.Fatalf("expected error for POST method, got nil")
+	}
+}
+
+func TestFetchTool_EnforcesAllowedDomains(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	parsed, _ := url.Parse(server.URL)
+	tool := newTestFetchTool(FetchConfig{
+		Enabled:        true,
+		AllowedDomains: []string{"example.com"},
+	})
+
+	if _, err := tool.Handler(context.Background(), map[string]any{"url": server.URL}); err == nil {
+		t.Fatalf("expected non-whitelisted host %q to be rejected, got nil", parsed.Host)
+	}
+}
+
+func TestFetchTool_GetReadsBody(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("hello-fetch"))
+	}))
+	defer server.Close()
+
+	tool := newTestFetchTool(FetchConfig{Enabled: true})
+	out, err := tool.Handler(context.Background(), map[string]any{"url": server.URL})
+	if err != nil {
+		t.Fatalf("Handler returned error: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if status := int(payload["status_code"].(float64)); status != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", status)
+	}
+	if body := payload["body"].(string); body != "hello-fetch" {
+		t.Fatalf("expected body 'hello-fetch', got %q", body)
+	}
+}
+
+func TestFetchTool_HeadOmitsBody(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead {
+			t.Errorf("expected HEAD, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tool := newTestFetchTool(FetchConfig{Enabled: true})
+	out, err := tool.Handler(context.Background(), map[string]any{"url": server.URL, "method": "HEAD"})
+	if err != nil {
+		t.Fatalf("Handler returned error: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if _, ok := payload["body"]; ok {
+		t.Fatalf("HEAD response should not include body, got %v", payload["body"])
+	}
+}
+
+func TestFetchTool_TruncatesBodyOverMaxBytes(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(strings.Repeat("x", 32)))
+	}))
+	defer server.Close()
+
+	tool := newTestFetchTool(FetchConfig{Enabled: true, MaxBytes: 10})
+	out, err := tool.Handler(context.Background(), map[string]any{"url": server.URL})
+	if err != nil {
+		t.Fatalf("Handler returned error: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if !payload["truncated"].(bool) {
+		t.Fatalf("expected truncated=true when body exceeds max_bytes")
+	}
+	if br := int(payload["bytes_read"].(float64)); br != 10 {
+		t.Fatalf("expected bytes_read=10, got %d", br)
+	}
+}
+
+func TestFetchTool_DownloadsToSavePath(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("saved-body"))
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	tool := newTestFetchTool(FetchConfig{
+		Enabled:        true,
+		AllowDownloads: true,
+		DownloadDir:    dir,
+	})
+	out, err := tool.Handler(context.Background(), map[string]any{
+		"url":       server.URL,
+		"save_path": "downloaded.txt",
+	})
+	if err != nil {
+		t.Fatalf("Handler returned error: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	saved := payload["saved_to"].(string)
+	got, err := os.ReadFile(saved)
+	if err != nil {
+		t.Fatalf("read back saved file: %v", err)
+	}
+	if string(got) != "saved-body" {
+		t.Fatalf("expected saved-body, got %q", string(got))
+	}
+	if !strings.HasPrefix(saved, dir) {
+		t.Fatalf("expected save_path under download_dir, got %q", saved)
+	}
+	if filepath.Base(saved) != "downloaded.txt" {
+		t.Fatalf("expected file named downloaded.txt, got %q", filepath.Base(saved))
+	}
+}
+
+func TestFetchTool_RejectsSavePathWhenDownloadsDisabled(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("body"))
+	}))
+	defer server.Close()
+
+	tool := newTestFetchTool(FetchConfig{Enabled: true, AllowDownloads: false})
+	if _, err := tool.Handler(context.Background(), map[string]any{
+		"url":       server.URL,
+		"save_path": "should-fail.txt",
+	}); err == nil {
+		t.Fatalf("expected error when save_path requested but downloads disabled, got nil")
+	}
+}
+
+func TestFetchTool_RejectsParentDirTraversalInSavePath(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("body"))
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	tool := newTestFetchTool(FetchConfig{
+		Enabled:        true,
+		AllowDownloads: true,
+		DownloadDir:    dir,
+	})
+	if _, err := tool.Handler(context.Background(), map[string]any{
+		"url":       server.URL,
+		"save_path": "../escaped.txt",
+	}); err == nil {
+		t.Fatalf("expected error for parent-dir traversal save_path, got nil")
+	}
+}

--- a/internal/templates/languages/go/builtin/read_test.go.tmpl
+++ b/internal/templates/languages/go/builtin/read_test.go.tmpl
@@ -1,0 +1,123 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	zap "go.uber.org/zap"
+)
+
+// newTestReadTool builds a Read tool with the supplied config, bypassing
+// envconfig so each test pins the exact behavior under test.
+func newTestReadTool(cfg ReadConfig) *ReadTool {
+	return &ReadTool{logger: zap.NewNop(), cfg: cfg}
+}
+
+func TestReadTool_DisabledReturnsError(t *testing.T) {
+	t.Parallel()
+	tool := newTestReadTool(ReadConfig{Enabled: false, MaxLines: 100})
+	if _, err := tool.Handler(context.Background(), map[string]any{"file_path": "anything"}); err == nil {
+		t.Fatalf("expected error when tool is disabled, got nil")
+	}
+}
+
+func TestReadTool_RequiresFilePath(t *testing.T) {
+	t.Parallel()
+	tool := newTestReadTool(ReadConfig{Enabled: true, MaxLines: 100})
+	if _, err := tool.Handler(context.Background(), map[string]any{}); err == nil {
+		t.Fatalf("expected error when file_path is missing, got nil")
+	}
+}
+
+func TestReadTool_ReadsFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hello.txt")
+	if err := os.WriteFile(path, []byte("hello\nworld\n"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	tool := newTestReadTool(ReadConfig{Enabled: true, MaxLines: 100})
+	out, err := tool.Handler(context.Background(), map[string]any{"file_path": path})
+	if err != nil {
+		t.Fatalf("Handler returned error: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if got := payload["content"].(string); !strings.Contains(got, "hello") || !strings.Contains(got, "world") {
+		t.Fatalf("expected file content in response, got %q", got)
+	}
+	if got := int(payload["lines_read"].(float64)); got != 2 {
+		t.Fatalf("expected lines_read=2, got %d", got)
+	}
+}
+
+func TestReadTool_HonorsOffsetAndLimit(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "lines.txt")
+	if err := os.WriteFile(path, []byte("a\nb\nc\nd\ne\n"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	tool := newTestReadTool(ReadConfig{Enabled: true, MaxLines: 100})
+	out, err := tool.Handler(context.Background(), map[string]any{
+		"file_path": path,
+		"offset":    2,
+		"limit":     2,
+	})
+	if err != nil {
+		t.Fatalf("Handler returned error: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	got := payload["content"].(string)
+	want := "b\nc\n"
+	if got != want {
+		t.Fatalf("expected slice %q, got %q", want, got)
+	}
+}
+
+func TestReadTool_RejectsImageExtensions(t *testing.T) {
+	t.Parallel()
+	tool := newTestReadTool(ReadConfig{Enabled: true, MaxLines: 100})
+	if _, err := tool.Handler(context.Background(), map[string]any{"file_path": "screenshot.PNG"}); err == nil {
+		t.Fatalf("expected error for image extension, got nil")
+	}
+}
+
+func TestReadTool_EnforcesAllowedRoots(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	allowed := filepath.Join(dir, "allowed")
+	if err := os.MkdirAll(allowed, 0o755); err != nil {
+		t.Fatalf("mkdir allowed: %v", err)
+	}
+	insidePath := filepath.Join(allowed, "ok.txt")
+	if err := os.WriteFile(insidePath, []byte("ok\n"), 0o644); err != nil {
+		t.Fatalf("seed inside file: %v", err)
+	}
+	outsidePath := filepath.Join(dir, "outside.txt")
+	if err := os.WriteFile(outsidePath, []byte("nope\n"), 0o644); err != nil {
+		t.Fatalf("seed outside file: %v", err)
+	}
+
+	tool := newTestReadTool(ReadConfig{Enabled: true, MaxLines: 100, AllowedRoots: []string{allowed}})
+
+	if _, err := tool.Handler(context.Background(), map[string]any{"file_path": insidePath}); err != nil {
+		t.Fatalf("expected file inside allowed root to succeed, got: %v", err)
+	}
+	if _, err := tool.Handler(context.Background(), map[string]any{"file_path": outsidePath}); err == nil {
+		t.Fatalf("expected file outside allowed root to be rejected, got nil")
+	}
+}

--- a/internal/templates/languages/go/builtin/write_test.go.tmpl
+++ b/internal/templates/languages/go/builtin/write_test.go.tmpl
@@ -1,0 +1,116 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	zap "go.uber.org/zap"
+)
+
+// newTestWriteTool builds a Write tool with the supplied config, bypassing
+// envconfig so each test pins the exact behavior under test.
+func newTestWriteTool(cfg WriteConfig) *WriteTool {
+	return &WriteTool{logger: zap.NewNop(), cfg: cfg}
+}
+
+func TestWriteTool_DisabledReturnsError(t *testing.T) {
+	t.Parallel()
+	tool := newTestWriteTool(WriteConfig{Enabled: false})
+	if _, err := tool.Handler(context.Background(), map[string]any{"file_path": "x", "content": "y"}); err == nil {
+		t.Fatalf("expected error when tool is disabled, got nil")
+	}
+}
+
+func TestWriteTool_RequiresFilePathAndContent(t *testing.T) {
+	t.Parallel()
+	tool := newTestWriteTool(WriteConfig{Enabled: true})
+	if _, err := tool.Handler(context.Background(), map[string]any{"content": "hi"}); err == nil {
+		t.Fatalf("expected error when file_path is missing, got nil")
+	}
+	if _, err := tool.Handler(context.Background(), map[string]any{"file_path": "x"}); err == nil {
+		t.Fatalf("expected error when content is missing, got nil")
+	}
+}
+
+func TestWriteTool_WritesFileAndCreatesParentDir(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "nested", "deep", "out.txt")
+
+	tool := newTestWriteTool(WriteConfig{Enabled: true})
+	out, err := tool.Handler(context.Background(), map[string]any{
+		"file_path": target,
+		"content":   "payload",
+	})
+	if err != nil {
+		t.Fatalf("Handler returned error: %v", err)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != "payload" {
+		t.Fatalf("expected file to contain 'payload', got %q", string(got))
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if bw := int(payload["bytes_written"].(float64)); bw != len("payload") {
+		t.Fatalf("expected bytes_written=%d, got %d", len("payload"), bw)
+	}
+}
+
+func TestWriteTool_OverwritesExistingFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "out.txt")
+	if err := os.WriteFile(target, []byte("old"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	tool := newTestWriteTool(WriteConfig{Enabled: true})
+	if _, err := tool.Handler(context.Background(), map[string]any{
+		"file_path": target,
+		"content":   "new",
+	}); err != nil {
+		t.Fatalf("Handler returned error: %v", err)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != "new" {
+		t.Fatalf("expected file to be overwritten, got %q", string(got))
+	}
+}
+
+func TestWriteTool_EnforcesAllowedRoots(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	allowed := filepath.Join(dir, "allowed")
+	if err := os.MkdirAll(allowed, 0o755); err != nil {
+		t.Fatalf("mkdir allowed: %v", err)
+	}
+
+	tool := newTestWriteTool(WriteConfig{Enabled: true, AllowedRoots: []string{allowed}})
+
+	if _, err := tool.Handler(context.Background(), map[string]any{
+		"file_path": filepath.Join(allowed, "ok.txt"),
+		"content":   "ok",
+	}); err != nil {
+		t.Fatalf("expected write inside allowed root to succeed, got: %v", err)
+	}
+	if _, err := tool.Handler(context.Background(), map[string]any{
+		"file_path": filepath.Join(dir, "outside.txt"),
+		"content":   "nope",
+	}); err == nil {
+		t.Fatalf("expected write outside allowed root to be rejected, got nil")
+	}
+}

--- a/internal/templates/languages/rust/Cargo.toml.tmpl
+++ b/internal/templates/languages/rust/Cargo.toml.tmpl
@@ -25,13 +25,22 @@ chrono = { version = "0.4", features = ["serde"] }
 dotenvy = "0.15.7"
 envy = "0.4.2"
 {{- $hasFetch := false }}
+{{- $hasBuiltin := false }}
 {{- range .ADL.Spec.Tools }}
 {{- if eq .ID "fetch" }}
 {{- $hasFetch = true }}
 {{- end }}
+{{- if isBuiltinToolID .ID }}
+{{- $hasBuiltin = true }}
+{{- end }}
 {{- end }}
 {{- if $hasFetch }}
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+{{- end }}
+{{- if $hasBuiltin }}
+
+[dev-dependencies]
+tempfile = "3"
 {{- end }}
 
 [profile.release]

--- a/internal/templates/languages/rust/builtin/bash.rs.tmpl
+++ b/internal/templates/languages/rust/builtin/bash.rs.tmpl
@@ -137,3 +137,80 @@ fn check_whitelist(whitelist: &[String], command: &str) -> anyhow::Result<()> {
     }
     bail!("command {:?} is not in the configured whitelist", command);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn enabled_cfg() -> Config {
+        Config {
+            enabled: true,
+            whitelist: vec![],
+            timeout_seconds: 5,
+            working_dir: String::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn disabled_returns_error() {
+        let cfg = Config {
+            enabled: false,
+            ..enabled_cfg()
+        };
+        let err = handle(json!({"command": "echo hi"}), cfg).await.unwrap_err();
+        assert!(err.to_string().contains("disabled"));
+    }
+
+    #[tokio::test]
+    async fn requires_command() {
+        let err = handle(json!({"command": "   "}), enabled_cfg())
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("command"));
+    }
+
+    #[tokio::test]
+    async fn executes_echo() {
+        let out = handle(json!({"command": "echo hello-bash"}), enabled_cfg())
+            .await
+            .expect("handle");
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["exit_code"], json!(0));
+        assert!(parsed["output"].as_str().unwrap().contains("hello-bash"));
+    }
+
+    #[tokio::test]
+    async fn enforces_whitelist() {
+        let cfg = Config {
+            whitelist: vec!["echo".to_string()],
+            ..enabled_cfg()
+        };
+        assert!(handle(json!({"command": "echo ok"}), cfg.clone()).await.is_ok());
+        let err = handle(json!({"command": "ls /"}), cfg).await.unwrap_err();
+        assert!(err.to_string().contains("whitelist"));
+    }
+
+    #[tokio::test]
+    async fn non_zero_exit_code_is_reported() {
+        let out = handle(json!({"command": "exit 7"}), enabled_cfg())
+            .await
+            .expect("handle");
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["exit_code"], json!(7));
+    }
+
+    #[test]
+    fn check_whitelist_allows_empty_list() {
+        assert!(check_whitelist(&[], "rm -rf /").is_ok());
+    }
+
+    #[test]
+    fn check_whitelist_matches_prefix_only_with_space() {
+        let wl = vec!["echo".to_string()];
+        assert!(check_whitelist(&wl, "echo").is_ok());
+        assert!(check_whitelist(&wl, "echo hi").is_ok());
+        // "echoes" must NOT match "echo" - prefix needs a trailing space.
+        assert!(check_whitelist(&wl, "echoes").is_err());
+    }
+}

--- a/internal/templates/languages/rust/builtin/edit.rs.tmpl
+++ b/internal/templates/languages/rust/builtin/edit.rs.tmpl
@@ -117,3 +117,113 @@ fn validate_path(allowed_roots: &[String], p: &str) -> anyhow::Result<()> {
     }
     bail!("path {:?} is outside the configured allowed_roots", p);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    fn enabled_cfg() -> Config {
+        Config {
+            enabled: true,
+            allowed_roots: vec![],
+        }
+    }
+
+    #[tokio::test]
+    async fn disabled_returns_error() {
+        let cfg = Config {
+            enabled: false,
+            ..enabled_cfg()
+        };
+        let err = handle(
+            json!({"file_path": "x", "old_string": "a", "new_string": "b"}),
+            cfg,
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("disabled"));
+    }
+
+    #[tokio::test]
+    async fn requires_arguments() {
+        let err = handle(json!({"old_string": "a", "new_string": "b"}), enabled_cfg())
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("file_path"));
+
+        let err = handle(
+            json!({"file_path": "x", "old_string": "", "new_string": "b"}),
+            enabled_cfg(),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("old_string"));
+    }
+
+    #[tokio::test]
+    async fn replaces_unique_match() {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("f.txt");
+        tokio::fs::write(&path, b"hello world\n").await.unwrap();
+
+        handle(
+            json!({
+                "file_path": path.to_string_lossy(),
+                "old_string": "world",
+                "new_string": "there",
+            }),
+            enabled_cfg(),
+        )
+        .await
+        .expect("handle");
+        let got = tokio::fs::read_to_string(&path).await.unwrap();
+        assert_eq!(got, "hello there\n");
+    }
+
+    #[tokio::test]
+    async fn rejects_missing_old_string() {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("f.txt");
+        tokio::fs::write(&path, b"hello\n").await.unwrap();
+
+        let err = handle(
+            json!({
+                "file_path": path.to_string_lossy(),
+                "old_string": "missing",
+                "new_string": "x",
+            }),
+            enabled_cfg(),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn rejects_ambiguous_old_string() {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("f.txt");
+        tokio::fs::write(&path, b"dup\ndup\n").await.unwrap();
+
+        let err = handle(
+            json!({
+                "file_path": path.to_string_lossy(),
+                "old_string": "dup",
+                "new_string": "x",
+            }),
+            enabled_cfg(),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("times"));
+    }
+
+    #[test]
+    fn validate_path_enforces_roots() {
+        let roots = vec!["/srv/agent".to_string()];
+        assert!(validate_path(&roots, "/srv/agent/x.txt").is_ok());
+        assert!(validate_path(&roots, "/etc/passwd").is_err());
+    }
+}

--- a/internal/templates/languages/rust/builtin/fetch.rs.tmpl
+++ b/internal/templates/languages/rust/builtin/fetch.rs.tmpl
@@ -304,3 +304,119 @@ fn flatten_headers(h: &HeaderMap) -> Value {
     }
     Value::Object(out)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn enabled_cfg() -> Config {
+        Config {
+            enabled: true,
+            allowed_domains: vec![],
+            max_bytes: DEFAULT_MAX_BYTES,
+            timeout_seconds: DEFAULT_TIMEOUT_SECONDS,
+            download_dir: "/tmp".to_string(),
+            allow_downloads: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn disabled_returns_error() {
+        let cfg = Config {
+            enabled: false,
+            ..enabled_cfg()
+        };
+        let err = handle(json!({"url": "https://example.com"}), cfg)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("disabled"));
+    }
+
+    #[tokio::test]
+    async fn requires_url() {
+        let err = handle(json!({}), enabled_cfg()).await.unwrap_err();
+        assert!(err.to_string().contains("url"));
+    }
+
+    #[tokio::test]
+    async fn rejects_unsupported_scheme() {
+        let err = handle(json!({"url": "ftp://example.com"}), enabled_cfg())
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("scheme"));
+    }
+
+    #[tokio::test]
+    async fn rejects_unsupported_method() {
+        let err = handle(
+            json!({"url": "https://example.com", "method": "POST"}),
+            enabled_cfg(),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("method"));
+    }
+
+    #[tokio::test]
+    async fn rejects_non_whitelisted_host() {
+        let cfg = Config {
+            allowed_domains: vec!["example.com".to_string()],
+            ..enabled_cfg()
+        };
+        let err = handle(json!({"url": "https://other.test/"}), cfg)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("allowed_domains"));
+    }
+
+    #[tokio::test]
+    async fn rejects_save_path_when_downloads_disabled() {
+        let err = handle(
+            json!({"url": "https://example.com", "save_path": "x.bin"}),
+            enabled_cfg(),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("disabled"));
+    }
+
+    #[test]
+    fn check_domain_allows_empty_list() {
+        assert!(check_domain(&[], "example.com").is_ok());
+    }
+
+    #[test]
+    fn check_domain_exact_match() {
+        let allowed = vec!["example.com".to_string()];
+        assert!(check_domain(&allowed, "example.com").is_ok());
+        assert!(check_domain(&allowed, "Example.COM").is_ok());
+        assert!(check_domain(&allowed, "sub.example.com").is_err());
+    }
+
+    #[test]
+    fn check_domain_dot_suffix_matches_subdomains() {
+        let allowed = vec![".example.com".to_string()];
+        assert!(check_domain(&allowed, "example.com").is_ok());
+        assert!(check_domain(&allowed, "api.example.com").is_ok());
+        assert!(check_domain(&allowed, "a.b.example.com").is_ok());
+        assert!(check_domain(&allowed, "evil-example.com").is_err());
+    }
+
+    #[test]
+    fn resolve_download_path_joins_under_root() {
+        let resolved = resolve_download_path("/tmp/cache", "out.txt").unwrap();
+        assert_eq!(resolved, PathBuf::from("/tmp/cache/out.txt"));
+    }
+
+    #[test]
+    fn resolve_download_path_rejects_absolute() {
+        assert!(resolve_download_path("/tmp/cache", "/etc/passwd").is_err());
+    }
+
+    #[test]
+    fn resolve_download_path_rejects_traversal() {
+        assert!(resolve_download_path("/tmp/cache", "../escape").is_err());
+        assert!(resolve_download_path("/tmp/cache", "a/../../escape").is_err());
+    }
+}

--- a/internal/templates/languages/rust/builtin/read.rs.tmpl
+++ b/internal/templates/languages/rust/builtin/read.rs.tmpl
@@ -144,3 +144,92 @@ fn is_image_path(p: &str) -> bool {
         .iter()
         .any(|ext| lower.ends_with(ext))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    fn enabled_cfg() -> Config {
+        Config {
+            enabled: true,
+            max_lines: 100,
+            allowed_roots: vec![],
+        }
+    }
+
+    #[tokio::test]
+    async fn disabled_returns_error() {
+        let cfg = Config {
+            enabled: false,
+            ..enabled_cfg()
+        };
+        let err = handle(json!({"file_path": "any"}), cfg).await.unwrap_err();
+        assert!(err.to_string().contains("disabled"));
+    }
+
+    #[tokio::test]
+    async fn requires_file_path() {
+        let err = handle(json!({}), enabled_cfg()).await.unwrap_err();
+        assert!(err.to_string().contains("file_path"));
+    }
+
+    #[tokio::test]
+    async fn reads_file_contents() {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("hello.txt");
+        tokio::fs::write(&path, b"hello\nworld\n").await.unwrap();
+
+        let out = handle(json!({"file_path": path.to_string_lossy()}), enabled_cfg())
+            .await
+            .expect("handle");
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["lines_read"], json!(2));
+        assert!(parsed["content"].as_str().unwrap().contains("hello"));
+        assert!(parsed["content"].as_str().unwrap().contains("world"));
+    }
+
+    #[tokio::test]
+    async fn honors_offset_and_limit() {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("lines.txt");
+        tokio::fs::write(&path, b"a\nb\nc\nd\ne\n").await.unwrap();
+
+        let out = handle(
+            json!({"file_path": path.to_string_lossy(), "offset": 2, "limit": 2}),
+            enabled_cfg(),
+        )
+        .await
+        .expect("handle");
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["content"], json!("b\nc\n"));
+    }
+
+    #[tokio::test]
+    async fn rejects_image_extension() {
+        let err = handle(json!({"file_path": "shot.PNG"}), enabled_cfg())
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("image"));
+    }
+
+    #[test]
+    fn is_image_path_detects_extensions() {
+        assert!(is_image_path("foo.png"));
+        assert!(is_image_path("FOO.JPG"));
+        assert!(!is_image_path("foo.txt"));
+    }
+
+    #[test]
+    fn validate_path_allows_empty_roots() {
+        assert!(validate_path(&[], "/whatever").is_ok());
+    }
+
+    #[test]
+    fn validate_path_enforces_roots() {
+        let roots = vec!["/srv/agent".to_string()];
+        assert!(validate_path(&roots, "/srv/agent/x.txt").is_ok());
+        assert!(validate_path(&roots, "/etc/passwd").is_err());
+    }
+}

--- a/internal/templates/languages/rust/builtin/write.rs.tmpl
+++ b/internal/templates/languages/rust/builtin/write.rs.tmpl
@@ -98,3 +98,83 @@ fn validate_path(allowed_roots: &[String], p: &str) -> anyhow::Result<()> {
     }
     bail!("path {:?} is outside the configured allowed_roots", p);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    fn enabled_cfg() -> Config {
+        Config {
+            enabled: true,
+            allowed_roots: vec![],
+        }
+    }
+
+    #[tokio::test]
+    async fn disabled_returns_error() {
+        let cfg = Config {
+            enabled: false,
+            ..enabled_cfg()
+        };
+        let err = handle(json!({"file_path": "x", "content": "y"}), cfg)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("disabled"));
+    }
+
+    #[tokio::test]
+    async fn requires_file_path_and_content() {
+        let err = handle(json!({"content": "y"}), enabled_cfg())
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("file_path"));
+
+        let err = handle(json!({"file_path": "x"}), enabled_cfg())
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("content"));
+    }
+
+    #[tokio::test]
+    async fn writes_file_and_creates_parent_dirs() {
+        let dir = TempDir::new().expect("tempdir");
+        let target = dir.path().join("nested/deep/out.txt");
+
+        let out = handle(
+            json!({"file_path": target.to_string_lossy(), "content": "payload"}),
+            enabled_cfg(),
+        )
+        .await
+        .expect("handle");
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed["bytes_written"], json!(7));
+
+        let got = tokio::fs::read_to_string(&target).await.unwrap();
+        assert_eq!(got, "payload");
+    }
+
+    #[tokio::test]
+    async fn overwrites_existing_file() {
+        let dir = TempDir::new().expect("tempdir");
+        let target = dir.path().join("out.txt");
+        tokio::fs::write(&target, b"old").await.unwrap();
+
+        handle(
+            json!({"file_path": target.to_string_lossy(), "content": "new"}),
+            enabled_cfg(),
+        )
+        .await
+        .expect("handle");
+        let got = tokio::fs::read_to_string(&target).await.unwrap();
+        assert_eq!(got, "new");
+    }
+
+    #[test]
+    fn validate_path_enforces_roots() {
+        let roots = vec!["/srv/agent".to_string()];
+        assert!(validate_path(&roots, "/srv/agent/out.txt").is_ok());
+        assert!(validate_path(&roots, "/etc/passwd").is_err());
+    }
+}

--- a/internal/templates/registry.go
+++ b/internal/templates/registry.go
@@ -162,9 +162,6 @@ func (r *Registry) getGoFiles(adl *schema.ADL) map[string]string {
 	for _, tool := range adl.Spec.Tools {
 		if schema.IsReservedToolID(tool.ID) {
 			files[fmt.Sprintf("tools/%s.go", tool.ID)] = fmt.Sprintf("builtin/%s.go", tool.ID)
-			// Scaffold a unit-test file next to each built-in. Custom
-			// tools deliberately don't get a test scaffold - users can
-			// crib from the built-in tests if they want one.
 			files[fmt.Sprintf("tools/%s_test.go", tool.ID)] = fmt.Sprintf("builtin/%s_test.go", tool.ID)
 			continue
 		}

--- a/internal/templates/registry.go
+++ b/internal/templates/registry.go
@@ -162,6 +162,10 @@ func (r *Registry) getGoFiles(adl *schema.ADL) map[string]string {
 	for _, tool := range adl.Spec.Tools {
 		if schema.IsReservedToolID(tool.ID) {
 			files[fmt.Sprintf("tools/%s.go", tool.ID)] = fmt.Sprintf("builtin/%s.go", tool.ID)
+			// Scaffold a unit-test file next to each built-in. Custom
+			// tools deliberately don't get a test scaffold - users can
+			// crib from the built-in tests if they want one.
+			files[fmt.Sprintf("tools/%s_test.go", tool.ID)] = fmt.Sprintf("builtin/%s_test.go", tool.ID)
 			continue
 		}
 		snakeCaseName := strings.ReplaceAll(tool.ID, "-", "_")

--- a/internal/templates/registry_go_test.go
+++ b/internal/templates/registry_go_test.go
@@ -1,0 +1,157 @@
+package templates
+
+import (
+	"strings"
+	"testing"
+
+	schema "github.com/inference-gateway/adl-cli/internal/schema"
+)
+
+func minimalGoADL() *schema.ADL {
+	return &schema.ADL{
+		APIVersion: "adl.inference-gateway.com/v1",
+		Kind:       "Agent",
+		Metadata: schema.Metadata{
+			Name:        "go-agent",
+			Description: "test",
+			Version:     "0.1.0",
+		},
+		Spec: schema.Spec{
+			Capabilities: schema.Capabilities{Streaming: true},
+			Server:       schema.Server{Port: 8080},
+			Language: schema.Language{
+				Go: &schema.GoConfig{
+					Module:  "github.com/example/go-agent",
+					Version: "1.26.2",
+				},
+			},
+		},
+	}
+}
+
+// TestRegistry_getGoFiles_ScaffoldsTestForEachBuiltin verifies that each
+// reserved built-in tool emits both an implementation and a unit-test
+// file - the second AC of #138.
+func TestRegistry_getGoFiles_ScaffoldsTestForEachBuiltin(t *testing.T) {
+	r, err := NewRegistry("go")
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+
+	adl := minimalGoADL()
+	adl.Spec.Tools = []schema.Tool{
+		{ID: "read"},
+		{ID: "bash"},
+		{ID: "write"},
+		{ID: "edit"},
+		{ID: "fetch"},
+	}
+
+	files := r.getGoFiles(adl)
+
+	for _, id := range []string{"read", "bash", "write", "edit", "fetch"} {
+		implPath := "tools/" + id + ".go"
+		testPath := "tools/" + id + "_test.go"
+
+		implKey, ok := files[implPath]
+		if !ok {
+			t.Errorf("missing implementation file mapping for %s", implPath)
+			continue
+		}
+		if implKey != "builtin/"+id+".go" {
+			t.Errorf("expected impl template builtin/%s.go for %s, got %q", id, implPath, implKey)
+		}
+
+		testKey, ok := files[testPath]
+		if !ok {
+			t.Errorf("missing test file mapping for %s", testPath)
+			continue
+		}
+		if testKey != "builtin/"+id+"_test.go" {
+			t.Errorf("expected test template builtin/%s_test.go for %s, got %q", id, testPath, testKey)
+		}
+	}
+}
+
+// TestRegistry_getGoFiles_NoTestForCustomTools ensures the test scaffold
+// only ships with built-in tools. Custom tools deliberately don't get a
+// test file - users can crib from the built-in tests as an example.
+func TestRegistry_getGoFiles_NoTestForCustomTools(t *testing.T) {
+	r, err := NewRegistry("go")
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+
+	adl := minimalGoADL()
+	adl.Spec.Tools = []schema.Tool{
+		{
+			ID:          "weather",
+			Name:        "get_weather",
+			Description: "Get weather data",
+			Tags:        []string{"weather"},
+			Schema:      schema.ToolSchema{},
+		},
+	}
+
+	files := r.getGoFiles(adl)
+
+	if _, ok := files["tools/weather_test.go"]; ok {
+		t.Errorf("custom tool should not receive a _test.go scaffold; got entry in files map")
+	}
+	if _, ok := files["tools/weather.go"]; !ok {
+		t.Errorf("expected custom tool implementation tools/weather.go to be present")
+	}
+}
+
+// TestRegistry_BuiltinTestTemplates_AreLoaded verifies that every
+// builtin/<id>_test.go template ships with the binary and can be
+// retrieved through the registry by templateKey.
+func TestRegistry_BuiltinTestTemplates_AreLoaded(t *testing.T) {
+	r, err := NewRegistry("go")
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+
+	for _, id := range []string{"read", "bash", "write", "edit", "fetch"} {
+		key := "builtin/" + id + "_test.go"
+		tmpl, err := r.GetTemplate(key)
+		if err != nil {
+			t.Errorf("GetTemplate(%q): %v", key, err)
+			continue
+		}
+		if !strings.Contains(tmpl, "package tools") {
+			t.Errorf("template %q does not declare package tools", key)
+		}
+		if !strings.Contains(tmpl, "func Test") {
+			t.Errorf("template %q has no Test* functions", key)
+		}
+	}
+}
+
+// TestRegistry_GoFetchTest_RendersFromTemplateEngine renders one of the
+// built-in test templates end-to-end through the template engine, with a
+// minimal ADL context. This guards against template-syntax regressions:
+// the test files are deliberately static (no {{ ... }} variables), so
+// any Go-template parsing error here means we accidentally introduced a
+// template directive.
+func TestRegistry_GoFetchTest_RendersFromTemplateEngine(t *testing.T) {
+	registry, err := NewRegistry("go")
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	engine := NewWithRegistry("minimal", registry)
+
+	adl := minimalGoADL()
+	adl.Spec.Tools = []schema.Tool{{ID: "fetch"}}
+
+	out, err := engine.ExecuteTemplate("builtin/fetch_test.go", Context{ADL: adl})
+	if err != nil {
+		t.Fatalf("ExecuteTemplate: %v", err)
+	}
+	if !strings.Contains(out, "package tools") {
+		t.Fatalf("rendered template missing package declaration:\n%s", out)
+	}
+	if !strings.Contains(out, "func TestFetchTool_") {
+		t.Fatalf("rendered template missing Fetch test functions:\n%s", out)
+	}
+}

--- a/internal/templates/registry_rust_test.go
+++ b/internal/templates/registry_rust_test.go
@@ -62,6 +62,78 @@ func TestRegistry_getRustFiles_DockerComposeOnlyWhenEnabled(t *testing.T) {
 	}
 }
 
+// TestRustBuiltinTemplates_ContainTestModule verifies that each Rust
+// built-in template ships an inline `#[cfg(test)] mod tests` block so
+// the generated agent has unit tests next to each built-in tool.
+func TestRustBuiltinTemplates_ContainTestModule(t *testing.T) {
+	r, err := NewRegistry("rust")
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+
+	for _, id := range []string{"read", "bash", "write", "edit", "fetch"} {
+		key := "builtin/" + id + ".rs"
+		tmpl, err := r.GetTemplate(key)
+		if err != nil {
+			t.Errorf("GetTemplate(%q): %v", key, err)
+			continue
+		}
+		if !strings.Contains(tmpl, "#[cfg(test)]") {
+			t.Errorf("template %q missing #[cfg(test)] test module", key)
+		}
+		if !strings.Contains(tmpl, "mod tests") {
+			t.Errorf("template %q missing mod tests block", key)
+		}
+	}
+}
+
+// TestRustCargoToml_DevDepsForBuiltins verifies that tempfile shows up
+// as a dev-dependency when the spec includes any reserved built-in -
+// the Rust unit tests rely on it for TempDir-based fixtures.
+func TestRustCargoToml_DevDepsForBuiltins(t *testing.T) {
+	cases := []struct {
+		name    string
+		toolIDs []string
+		wantDev bool
+	}{
+		{name: "no tools -> no dev-deps", toolIDs: nil, wantDev: false},
+		{name: "custom-only -> no dev-deps", toolIDs: []string{"my_custom"}, wantDev: false},
+		{name: "any builtin -> dev-deps", toolIDs: []string{"read"}, wantDev: true},
+		{name: "multiple builtins -> dev-deps", toolIDs: []string{"read", "bash", "edit"}, wantDev: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			registry, err := NewRegistry("rust")
+			if err != nil {
+				t.Fatalf("NewRegistry: %v", err)
+			}
+			engine := NewWithRegistry("minimal", registry)
+
+			adl := minimalRustADL()
+			for _, id := range tc.toolIDs {
+				tool := schema.Tool{ID: id}
+				if !schema.IsReservedToolID(id) {
+					tool.Name = id
+					tool.Description = "custom"
+					tool.Tags = []string{"custom"}
+					tool.Schema = schema.ToolSchema{}
+				}
+				adl.Spec.Tools = append(adl.Spec.Tools, tool)
+			}
+
+			out, err := engine.ExecuteTemplate("Cargo.toml", Context{ADL: adl})
+			if err != nil {
+				t.Fatalf("ExecuteTemplate: %v", err)
+			}
+			hasDev := strings.Contains(out, "[dev-dependencies]") && strings.Contains(out, `tempfile = "3"`)
+			if hasDev != tc.wantDev {
+				t.Fatalf("dev-deps present=%v, want=%v\nCargo.toml:\n%s", hasDev, tc.wantDev, out)
+			}
+		})
+	}
+}
+
 func TestRustCargoToml_RedisFeatureFlag(t *testing.T) {
 	cases := []struct {
 		name     string


### PR DESCRIPTION
Closes #138

## Summary

Scaffold a unit-test file alongside every reserved built-in (read, bash, write, edit, fetch) so the generated agent ships with a runnable test suite for the tools the generator owns. Custom tools deliberately do not get a test scaffold - users can crib from the built-in tests as an example.

- **Go**: new `tools/<id>_test.go` per built-in, generated from `languages/go/builtin/<id>_test.go.tmpl`. Tests construct the tool struct directly with a fixture config to avoid env-var coupling and cover the disabled-by-default guard, argument validation, success paths, allowed-roots/whitelist enforcement, and (for Fetch) httptest-backed network paths.
- **Rust**: append `#[cfg(test)] mod tests { ... }` to each `languages/rust/builtin/<id>.rs.tmpl`. `tempfile = "3"` is added to `[dev-dependencies]` in `Cargo.toml` only when any built-in tool is selected.
- **Generator**: `builtin/*_test.{go,rs}` templates now flow through the plain ExecuteTemplate path (via a new `isBuiltinTestTemplate` helper) instead of the per-tool context resolver.
- **Registry**: emits the test-file mapping next to the impl mapping for every reserved tool ID.
- **CI**: no template change needed - the existing Go/Rust CI jobs already run `task test`, which now picks up the new files.

## Test plan
- [x] `go test ./...` in adl-cli (covers new registry-level tests)
- [x] Generate `examples/go-agent-builtin-tools.yaml` and run `go test ./tools/...` in the output (all 28 cases pass)
- [x] Generate `examples/rust-agent.yaml` and confirm `Cargo.toml` has `[dev-dependencies] tempfile = "3"` and `src/tools/read.rs` has the inline test module

🤖 Generated with [Claude Code](https://claude.ai/code)