### PR TITLE
feat(agent): Convert generated agent binary into a proper CLI

### DIFF
--- a/internal/templates/cli_template_test.go
+++ b/internal/templates/cli_template_test.go
@@ -1,0 +1,229 @@
+package templates
+
+import (
+	"strings"
+	"testing"
+
+	schema "github.com/inference-gateway/adl-cli/internal/schema"
+)
+
+// TestGoMainTemplate_IsCobraCLI verifies that the generated Go main.go is
+// wired up as a cobra CLI with a `start` subcommand and a root that
+// exposes `--version`. Locks in the contract behind issue #140.
+func TestGoMainTemplate_IsCobraCLI(t *testing.T) {
+	r, err := NewRegistry("go")
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+
+	tmpl, err := r.GetTemplate("main.go")
+	if err != nil {
+		t.Fatalf("GetTemplate(main.go): %v", err)
+	}
+
+	engine := NewWithRegistry("main.go", r)
+	ctx := Context{
+		ADL:      minimalGoADL(),
+		Language: "go",
+	}
+	rendered, err := engine.Execute(tmpl, ctx)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	for _, want := range []string{
+		`cobra "github.com/spf13/cobra"`,
+		"func newRootCmd() *cobra.Command",
+		"func newStartCmd() *cobra.Command",
+		`Use:   "start"`,
+		"Version:       Version",
+		"root.AddCommand(newStartCmd())",
+		"func runStart(ctx context.Context) error",
+		"newRootCmd().ExecuteContext(ctx)",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("generated main.go missing %q\n--- rendered ---\n%s", want, rendered)
+		}
+	}
+
+	// The bare `func main()` must remain - it's the binary's entry point.
+	if !strings.Contains(rendered, "func main() {") {
+		t.Errorf("generated main.go is missing func main()")
+	}
+}
+
+// TestGoModTemplate_DeclaresCobra verifies the cobra dependency lands in
+// the rendered go.mod alongside the existing ADK deps.
+func TestGoModTemplate_DeclaresCobra(t *testing.T) {
+	r, err := NewRegistry("go")
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	tmpl, err := r.GetTemplate("go.mod")
+	if err != nil {
+		t.Fatalf("GetTemplate(go.mod): %v", err)
+	}
+	engine := NewWithRegistry("go.mod", r)
+	rendered, err := engine.Execute(tmpl, Context{ADL: minimalGoADL(), Language: "go"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(rendered, "github.com/spf13/cobra") {
+		t.Errorf("go.mod does not declare cobra dependency:\n%s", rendered)
+	}
+}
+
+// TestRustMainTemplate_IsClapCLI verifies the generated Rust main.rs is a
+// clap-derive CLI with a `Start` subcommand. The agent must require an
+// explicit subcommand to boot.
+func TestRustMainTemplate_IsClapCLI(t *testing.T) {
+	r, err := NewRegistry("rust")
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	tmpl, err := r.GetTemplate("main.rs")
+	if err != nil {
+		t.Fatalf("GetTemplate(main.rs): %v", err)
+	}
+
+	adl := &schema.ADL{
+		APIVersion: "adl.inference-gateway.com/v1",
+		Kind:       "Agent",
+		Metadata: schema.Metadata{
+			Name:        "rust-agent",
+			Description: "test",
+			Version:     "0.1.0",
+		},
+		Spec: schema.Spec{
+			Capabilities: schema.Capabilities{Streaming: true},
+			Server:       schema.Server{Port: 8080},
+			Language: schema.Language{
+				Rust: &schema.RustConfig{
+					PackageName: "rust-agent",
+					Version:     "1.94.1",
+					Edition:     "2024",
+				},
+			},
+		},
+	}
+
+	engine := NewWithRegistry("main.rs", r)
+	rendered, err := engine.Execute(tmpl, Context{ADL: adl, Language: "rust"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	for _, want := range []string{
+		"use clap::{Parser, Subcommand}",
+		"struct Cli {",
+		"enum Commands {",
+		"/// Start the A2A server",
+		"Start,",
+		"let cli = Cli::parse();",
+		"Commands::Start => run_start().await,",
+		"async fn run_start()",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("generated main.rs missing %q\n--- rendered ---\n%s", want, rendered)
+		}
+	}
+}
+
+// TestRustCargoToml_DeclaresClap verifies the clap dependency lands in
+// the rendered Cargo.toml.
+func TestRustCargoToml_DeclaresClap(t *testing.T) {
+	r, err := NewRegistry("rust")
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	tmpl, err := r.GetTemplate("Cargo.toml")
+	if err != nil {
+		t.Fatalf("GetTemplate(Cargo.toml): %v", err)
+	}
+	adl := &schema.ADL{
+		APIVersion: "adl.inference-gateway.com/v1",
+		Kind:       "Agent",
+		Metadata: schema.Metadata{
+			Name:    "rust-agent",
+			Version: "0.1.0",
+		},
+		Spec: schema.Spec{
+			Server: schema.Server{Port: 8080},
+			Language: schema.Language{
+				Rust: &schema.RustConfig{
+					PackageName: "rust-agent",
+					Version:     "1.94.1",
+					Edition:     "2024",
+				},
+			},
+		},
+	}
+	engine := NewWithRegistry("Cargo.toml", r)
+	rendered, err := engine.Execute(tmpl, Context{ADL: adl, Language: "rust"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(rendered, `clap = { version = "4", features = ["derive"] }`) {
+		t.Errorf("Cargo.toml does not declare clap with derive feature:\n%s", rendered)
+	}
+}
+
+// TestDockerfileGo_InvokesStart verifies the generated Go Dockerfile CMD
+// invokes the `start` subcommand rather than running the bare binary.
+// (Previously `CMD ["./main"]` - now the binary is a CLI.)
+func TestDockerfileGo_InvokesStart(t *testing.T) {
+	r, err := NewRegistry("go")
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	tmpl, err := r.GetTemplate("docker/dockerfile.go")
+	if err != nil {
+		t.Fatalf("GetTemplate(docker/dockerfile.go): %v", err)
+	}
+	engine := NewWithRegistry("docker/dockerfile.go", r)
+	rendered, err := engine.Execute(tmpl, Context{ADL: minimalGoADL(), Language: "go"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(rendered, `CMD ["./main", "start"]`) {
+		t.Errorf("Dockerfile CMD does not invoke the start subcommand:\n%s", rendered)
+	}
+}
+
+// TestDockerfileRust_InvokesStart mirrors the Go test for Rust.
+func TestDockerfileRust_InvokesStart(t *testing.T) {
+	r, err := NewRegistry("rust")
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	tmpl, err := r.GetTemplate("docker/dockerfile.rust")
+	if err != nil {
+		t.Fatalf("GetTemplate(docker/dockerfile.rust): %v", err)
+	}
+	adl := &schema.ADL{
+		APIVersion: "adl.inference-gateway.com/v1",
+		Kind:       "Agent",
+		Metadata: schema.Metadata{
+			Name:    "rust-agent",
+			Version: "0.1.0",
+		},
+		Spec: schema.Spec{
+			Server: schema.Server{Port: 8080},
+			Language: schema.Language{
+				Rust: &schema.RustConfig{
+					PackageName: "rust-agent",
+					Version:     "1.94.1",
+					Edition:     "2024",
+				},
+			},
+		},
+	}
+	engine := NewWithRegistry("docker/dockerfile.rust", r)
+	rendered, err := engine.Execute(tmpl, Context{ADL: adl, Language: "rust"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(rendered, `CMD ["./rust-agent", "start"]`) {
+		t.Errorf("Rust Dockerfile CMD does not invoke the start subcommand:\n%s", rendered)
+	}
+}

--- a/internal/templates/cli_template_test.go
+++ b/internal/templates/cli_template_test.go
@@ -46,7 +46,6 @@ func TestGoMainTemplate_IsCobraCLI(t *testing.T) {
 		}
 	}
 
-	// The bare `func main()` must remain - it's the binary's entry point.
 	if !strings.Contains(rendered, "func main() {") {
 		t.Errorf("generated main.go is missing func main()")
 	}

--- a/internal/templates/common/ai/agents.md.tmpl
+++ b/internal/templates/common/ai/agents.md.tmpl
@@ -181,8 +181,8 @@ No sandboxed environments are configured. Set up your local toolchain manually (
 # Install dependencies
 go mod download
 
-# Run the agent
-go run main.go
+# Run the agent (the binary is a CLI; `start` boots the server)
+go run . start
 
 # Or use Task
 task run
@@ -193,8 +193,8 @@ task run
 # Install dependencies
 cargo build
 
-# Run the agent
-cargo run
+# Run the agent (the binary is a CLI; `start` boots the server)
+cargo run -- start
 
 # Or use Task
 task run

--- a/internal/templates/common/ai/claude.md.tmpl
+++ b/internal/templates/common/ai/claude.md.tmpl
@@ -17,7 +17,8 @@ The codebase is generated using ADL CLI {{ .Metadata.CLIVersion }} and follows a
 
 ### Key Components
 
-- **Main Entry Point**: `main.go` - Configures and starts the A2A server with:
+- **Main Entry Point**: `main.go` - A cobra-based CLI. The root command exposes
+  `--version` and `--help`; the `start` subcommand boots the A2A server with:
   - OpenAI-compatible LLM client configuration
   - Agent builder with system prompt from `agent.yaml`
   - A2A server with streaming and background task handlers

--- a/internal/templates/common/docker/dockerfile.go.tmpl
+++ b/internal/templates/common/docker/dockerfile.go.tmpl
@@ -64,5 +64,5 @@ EXPOSE {{ .ADL.Spec.Server.Port | default 8080 }}
 # Set environment variables
 ENV A2A_SERVER_PORT={{ .ADL.Spec.Server.Port | default 8080 }}
 
-# Run the application
-CMD ["./main"]
+# Run the application (binary is a CLI; `start` boots the A2A server)
+CMD ["./main", "start"]

--- a/internal/templates/common/docker/dockerfile.rust.tmpl
+++ b/internal/templates/common/docker/dockerfile.rust.tmpl
@@ -51,5 +51,5 @@ EXPOSE {{ .ADL.Spec.Server.Port | default 8080 }}
 # Set environment variables
 ENV RUST_LOG=info
 
-# Run the application
-CMD ["./{{ .ADL.Metadata.Name }}"]
+# Run the application (binary is a CLI; `start` boots the A2A server)
+CMD ["./{{ .ADL.Metadata.Name }}", "start"]

--- a/internal/templates/common/docs/README.md.tmpl
+++ b/internal/templates/common/docs/README.md.tmpl
@@ -27,12 +27,27 @@ A enterprise-ready [Agent-to-Agent (A2A)](https://github.com/inference-gateway/a
 
 ## Quick Start
 
+The generated binary is a CLI. `start` boots the A2A server; `--help` and
+`--version` work as you'd expect.
+
 ```bash
 # Run the agent
 {{- if eq .Language "go" }}
-go run .
+go run . start
+
+# Or build and invoke the CLI directly
+task build
+./bin/{{ .ADL.Metadata.Name }} --help
+./bin/{{ .ADL.Metadata.Name }} --version
+./bin/{{ .ADL.Metadata.Name }} start
 {{- else if eq .Language "rust" }}
-cargo run
+cargo run -- start
+
+# Or build and invoke the CLI directly
+task build
+./target/release/{{ .ADL.Spec.Language.Rust.PackageName }} --help
+./target/release/{{ .ADL.Spec.Language.Rust.PackageName }} --version
+./target/release/{{ .ADL.Spec.Language.Rust.PackageName }} start
 {{- else if eq .Language "typescript" }}
 npm install
 npm run dev
@@ -42,6 +57,17 @@ npm run dev
 docker build -t {{ .ADL.Metadata.Name }} .
 docker run -p {{ .ADL.Spec.Server.Port | default 8080 }}:{{ .ADL.Spec.Server.Port | default 8080 }} {{ .ADL.Metadata.Name }}
 ```
+
+{{- if or (eq .Language "go") (eq .Language "rust") }}
+
+### CLI
+
+| Command | Description |
+|---------|-------------|
+| `{{ .ADL.Metadata.Name }} start` | Start the A2A server (blocks until SIGINT/SIGTERM) |
+| `{{ .ADL.Metadata.Name }} --help` | Show top-level help (and per-subcommand with `<cmd> --help`) |
+| `{{ .ADL.Metadata.Name }} --version` | Print the embedded version and exit |
+{{- end }}
 
 ## Quick Install
 

--- a/internal/templates/common/taskfile/taskfile.yml.tmpl
+++ b/internal/templates/common/taskfile/taskfile.yml.tmpl
@@ -22,8 +22,8 @@ tasks:
 
   run:
     desc: Run the application in development mode
-    cmd: {{- if eq .Language "go" }} go run .
-    {{- else if eq .Language "rust" }} cargo run
+    cmd: {{- if eq .Language "go" }} go run . start
+    {{- else if eq .Language "rust" }} cargo run -- start
     {{- else if eq .Language "typescript" }} npm run dev
     {{- end }}
     env:

--- a/internal/templates/languages/go/go.mod.tmpl
+++ b/internal/templates/languages/go/go.mod.tmpl
@@ -5,6 +5,7 @@ go {{ .ADL.Spec.Language.Go.Version }}
 require (
 	github.com/inference-gateway/adk v0.18.4
 	github.com/sethvargo/go-envconfig v1.3.0
+	github.com/spf13/cobra v1.10.1
 	go.uber.org/zap v1.28.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/internal/templates/languages/go/main.go.tmpl
+++ b/internal/templates/languages/go/main.go.tmpl
@@ -14,6 +14,7 @@ import (
 
 	server "github.com/inference-gateway/adk/server"
 	envconfig "github.com/sethvargo/go-envconfig"
+	cobra "github.com/spf13/cobra"
 	zap "go.uber.org/zap"
 	yaml "gopkg.in/yaml.v3"
 
@@ -39,6 +40,9 @@ import (
 )
 
 
+// Version, AgentName and AgentDescription are injected at build time
+// via `-ldflags "-X 'main.Version=...'"` (see Dockerfile). They default
+// to the values declared in the ADL.
 var (
 	Version          = "{{ .ADL.Metadata.Version }}"
 	AgentName        = "{{ .ADL.Metadata.Name }}"
@@ -130,18 +134,49 @@ func extractFrontmatter(content []byte) ([]byte, bool) {
 	return rest[:idx], true
 }
 
-func main() {
-	ctx := context.Background()
+// newRootCmd builds the top-level CLI for the agent binary. The
+// generated binary is a real CLI: `<bin> --version`, `<bin> --help`,
+// and `<bin> start` are all supported. Subcommands are added in
+// dedicated constructors so they can be unit-tested in isolation.
+func newRootCmd() *cobra.Command {
+	root := &cobra.Command{
+		Use:           AgentName,
+		Short:         AgentDescription,
+		Long:          AgentDescription + "\n\nThis is an A2A (Agent-to-Agent) protocol server. Use the `start` subcommand to run it.",
+		Version:       Version,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	root.AddCommand(newStartCmd())
+	return root
+}
 
+// newStartCmd returns the `start` subcommand which boots the A2A
+// server and blocks until SIGINT/SIGTERM.
+func newStartCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "start",
+		Short: "Start the A2A server",
+		Long:  "Start the A2A server and block until SIGINT or SIGTERM is received.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runStart(cmd.Context())
+		},
+	}
+}
+
+// runStart contains the original agent bootstrap. It is exported as a
+// dedicated function so the cobra command stays a thin shell - easier
+// to test, easier to embed.
+func runStart(ctx context.Context) error {
 	var cfg config.Config
 	if err := envconfig.Process(ctx, &cfg); err != nil {
-		log.Fatal("failed to load config:", err)
+		return fmt.Errorf("failed to load config: %w", err)
 	}
 
 	// Initialize logger
 	l, err := logger.NewLogger(ctx, &cfg)
 	if err != nil {
-		log.Fatal("failed to initialize logger:", err)
+		return fmt.Errorf("failed to initialize logger: %w", err)
 	}
 
 	l.Info("starting " + AgentName + " agent (version: " + Version + ", environment: " + cfg.Environment + ")")
@@ -184,7 +219,8 @@ func main() {
 	{{- if $svcUsed }}
 	{{ $serviceName | toCamelCase }}Svc, err := {{ $serviceName | toCamelCase }}.{{ $svc.Factory }}(l, &cfg)
 	if err != nil {
-		l.Fatal("failed to initialize {{ $serviceName }} service", zap.Error(err))
+		l.Error("failed to initialize {{ $serviceName }} service", zap.Error(err))
+		return fmt.Errorf("failed to initialize {{ $serviceName }} service: %w", err)
 	}
 	{{- end }}
 	{{- end }}
@@ -199,7 +235,7 @@ func main() {
 	// Register Read built-in
 	readTool, err := tools.NewReadTool(ctx, l)
 	if err != nil {
-		l.Fatal("failed to construct Read tool", zap.Error(err))
+		return fmt.Errorf("failed to construct Read tool: %w", err)
 	}
 	toolBox.AddTool(readTool)
 	l.Info("registered built-in: Read")
@@ -208,7 +244,7 @@ func main() {
 	// Register Bash built-in
 	bashTool, err := tools.NewBashTool(ctx, l)
 	if err != nil {
-		l.Fatal("failed to construct Bash tool", zap.Error(err))
+		return fmt.Errorf("failed to construct Bash tool: %w", err)
 	}
 	toolBox.AddTool(bashTool)
 	l.Info("registered built-in: Bash")
@@ -217,7 +253,7 @@ func main() {
 	// Register Write built-in
 	writeTool, err := tools.NewWriteTool(ctx, l)
 	if err != nil {
-		l.Fatal("failed to construct Write tool", zap.Error(err))
+		return fmt.Errorf("failed to construct Write tool: %w", err)
 	}
 	toolBox.AddTool(writeTool)
 	l.Info("registered built-in: Write")
@@ -226,7 +262,7 @@ func main() {
 	// Register Edit built-in
 	editTool, err := tools.NewEditTool(ctx, l)
 	if err != nil {
-		l.Fatal("failed to construct Edit tool", zap.Error(err))
+		return fmt.Errorf("failed to construct Edit tool: %w", err)
 	}
 	toolBox.AddTool(editTool)
 	l.Info("registered built-in: Edit")
@@ -235,7 +271,7 @@ func main() {
 	// Register Fetch built-in
 	fetchTool, err := tools.NewFetchTool(ctx, l)
 	if err != nil {
-		l.Fatal("failed to construct Fetch tool", zap.Error(err))
+		return fmt.Errorf("failed to construct Fetch tool: %w", err)
 	}
 	toolBox.AddTool(fetchTool)
 	l.Info("registered built-in: Fetch")
@@ -250,7 +286,7 @@ func main() {
 
 	llmClient, err := server.NewOpenAICompatibleLLMClient(&cfg.A2A.AgentConfig, l)
 	if err != nil {
-		l.Fatal("failed to create LLM client", zap.Error(err))
+		return fmt.Errorf("failed to create LLM client: %w", err)
 	}
 
 	systemPrompt := `{{- if and .ADL.Spec.Agent .ADL.Spec.Agent.SystemPrompt }}{{ .ADL.Spec.Agent.SystemPrompt }}{{- else }}You are a helpful AI assistant.{{- end }}`
@@ -266,7 +302,7 @@ func main() {
 		WithSystemPrompt(systemPrompt).
 		Build()
 	if err != nil {
-		l.Fatal("failed to create agent", zap.Error(err))
+		return fmt.Errorf("failed to create agent: %w", err)
 	}
 
 {{ if and .ADL.Spec.Artifacts .ADL.Spec.Artifacts.Enabled }}
@@ -303,7 +339,7 @@ func main() {
 		WithDefaultStreamingTaskHandler().
 		Build()
 	if err != nil {
-		l.Fatal("failed to create A2A server", zap.Error(err))
+		return fmt.Errorf("failed to create A2A server: %w", err)
 	}
 
 	go func() {
@@ -340,4 +376,12 @@ func main() {
 	}
 {{- end }}
 	l.Info("{{ .ADL.Metadata.Name }} agent stopped")
+	return nil
+}
+
+func main() {
+	ctx := context.Background()
+	if err := newRootCmd().ExecuteContext(ctx); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/internal/templates/languages/rust/Cargo.toml.tmpl
+++ b/internal/templates/languages/rust/Cargo.toml.tmpl
@@ -15,6 +15,7 @@ inference-gateway-sdk = "0.13.3"
 tokio = { version = "1", features = ["full", "signal"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/internal/templates/languages/rust/main.rs.tmpl
+++ b/internal/templates/languages/rust/main.rs.tmpl
@@ -2,6 +2,7 @@ use inference_gateway_adk::{A2AServerBuilder, {{ if .ADL.Spec.Agent }}AgentBuild
 {{- if .ADL.Spec.Agent }}
 use serde_json::Value;
 {{- end }}
+use clap::{Parser, Subcommand};
 use serde::Deserialize;
 use std::fmt::Write as _;
 use std::fs;
@@ -13,6 +14,25 @@ use tracing::{error, info, warn};
 
 mod tools;
 {{- end }}
+
+/// {{ .ADL.Metadata.Description }}
+#[derive(Parser, Debug)]
+#[command(
+    name = "{{ .ADL.Metadata.Name }}",
+    version,
+    about = "{{ .ADL.Metadata.Description }}",
+    long_about = "{{ .ADL.Metadata.Description }}\n\nThis is an A2A (Agent-to-Agent) protocol server. Use the `start` subcommand to run it.",
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+enum Commands {
+    /// Start the A2A server
+    Start,
+}
 
 #[derive(Debug, Deserialize)]
 struct SkillFrontmatter {
@@ -116,6 +136,13 @@ fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Start => run_start().await,
+    }
+}
+
+async fn run_start() -> Result<(), Box<dyn std::error::Error>> {
     dotenvy::dotenv().ok();
 
     tracing_subscriber::fmt()


### PR DESCRIPTION
## Summary
- Refactor the generated Go agent into a cobra-based CLI with a `start` subcommand (root exposes `--version`/`--help`).
- Refactor the generated Rust agent into a clap-derive CLI with a `Start` subcommand.
- Update Dockerfile CMDs, Taskfile `run`, README, and AI docs to use the new `start` command.
- Add six template tests locking in the CLI surface for both languages.

Closes #140

## Test plan
- [x] `task ci` (fmt/lint/test/build/verify-schema) passes
- [x] New CLI template tests pass
- [x] Generated Go agent (from `examples/go-agent.yaml`) still `go build`s cleanly with the new cobra wiring
- [ ] Sanity-check a generated Rust agent (`cargo check`) locally

🤖 Generated with [Claude Code](https://claude.ai/code)