### PR TITLE
fix(templates): Rework generated Claude Code workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ adl generate --file agent.yaml --output ./test-my-agent --deployment cloudrun --
 > - see the matrix below.
 > `adl init` writes all toggles as `false` by default - they're opt-in. Generated files
 > (`CLAUDE.md`, `GEMINI.md`, `AGENTS.md`, `.github/workflows/ci.yml`,
-> `.github/workflows/cd.yml`, `.github/workflows/claude-code.yml`,
+> `.github/workflows/cd.yml`, `.github/workflows/claude.yml`,
 > `.github/workflows/codex.yml`, `.github/workflows/gemini.yml`,
 > `.releaserc.yaml`) are tagged `linguist-generated=true` in `.gitattributes`
 > so they collapse in pull request diffs.
@@ -350,7 +350,7 @@ spec:
   development:
     ai:
       claudecode:
-        enabled: true   # generates CLAUDE.md + .github/workflows/claude-code.yml
+        enabled: true   # generates CLAUDE.md + .github/workflows/claude.yml
       codex:
         enabled: false  # would generate AGENTS.md + .github/workflows/codex.yml
       gemini:
@@ -365,7 +365,7 @@ spec:
 
 | Agent toggle  | Docs file the agent reads | GitHub Actions workflow generated? |
 |---------------|---------------------------|------------------------------------|
-| `claudecode`  | `CLAUDE.md`               | yes (`.github/workflows/claude-code.yml`, uses `anthropics/claude-code-action`) |
+| `claudecode`  | `CLAUDE.md`               | yes (`.github/workflows/claude.yml`, uses `anthropics/claude-code-action`) |
 | `codex`       | `AGENTS.md` (shared)      | yes (`.github/workflows/codex.yml`, uses `openai/codex-action`) |
 | `gemini`      | `GEMINI.md`               | yes (`.github/workflows/gemini.yml`, uses `google-github-actions/run-gemini-cli`) |
 | `opencode`    | `AGENTS.md` (shared)      | no upstream action yet - docs only |

--- a/internal/generator/ai_test.go
+++ b/internal/generator/ai_test.go
@@ -86,7 +86,6 @@ func TestGenerator_AI_ClaudeCodeOnly(t *testing.T) {
 	assertFile(t, out, "CLAUDE.md", true)
 	assertFile(t, out, ".github/workflows/claude.yml", true)
 
-	// Sibling agents must stay off when only claudecode is enabled.
 	assertFile(t, out, "AGENTS.md", false)
 	assertFile(t, out, "GEMINI.md", false)
 	assertFile(t, out, ".github/workflows/codex.yml", false)
@@ -263,49 +262,38 @@ func TestGenerator_AI_ClaudeWorkflowGoContent(t *testing.T) {
 
 	body := readGenerated(t, out, ".github/workflows/claude.yml")
 
-	// Filename invariants — the file is named claude.yml, not the
-	// old claude-code.yml. The old name lives only in the changelog
-	// note about the rename.
 	assertNotContains(t, body, "claude-code.yml", "Claude Code workflow body")
 
-	// The redundant comment block describing CLAUDE.md should be gone.
 	assertNotContains(t, body, "picks up CLAUDE.md", "Claude Code workflow body")
 
-	// YAML triggers use bullet-list form, not the inline [created] form.
 	assertContains(t, body, "issue_comment:\n    types:\n      - created", "Claude Code workflow body")
 	assertContains(t, body, "issues:\n    types:\n      - opened\n      - assigned", "Claude Code workflow body")
 	assertNotContains(t, body, "types: [created]", "Claude Code workflow body")
 
-	// New permission for the action's internal poller.
 	assertContains(t, body, "actions: read", "Claude Code workflow body")
 
-	// Go-specific setup must appear; Rust-specific setup must not.
 	assertContains(t, body, "Set up Go", "Claude Code workflow body (go)")
 	assertContains(t, body, "actions/setup-go@v6.4.0", "Claude Code workflow body (go)")
 	assertContains(t, body, "Install golangci-lint", "Claude Code workflow body (go)")
 	assertNotContains(t, body, "Set up Rust", "Claude Code workflow body (go)")
 	assertNotContains(t, body, "actions-rs/toolchain", "Claude Code workflow body (go)")
 
-	// Shared setup steps.
 	assertContains(t, body, "arduino/setup-task@v2.0.0", "Claude Code workflow body")
 	assertContains(t, body, "Install maintainer skill", "Claude Code workflow body")
 	assertContains(t, body, "raw.githubusercontent.com/inference-gateway/skills/main/skills/maintainer/SKILL.md", "Claude Code workflow body")
 
-	// New Run Claude Code step shape.
 	assertContains(t, body, "anthropics/claude-code-action@v1.0.131", "Claude Code workflow body")
 	assertContains(t, body, "claude_code_oauth_token:", "Claude Code workflow body")
 	assertContains(t, body, "use_commit_signing: true", "Claude Code workflow body")
 	assertContains(t, body, "branch_prefix: 'claude/'", "Claude Code workflow body")
 	assertContains(t, body, "--model claude-opus-4-7", "Claude Code workflow body")
 
-	// Language-specific Bash allowlist: Go gets Bash(go:*), not Bash(cargo:*).
 	assertContains(t, body, "Bash(go:*)", "Claude Code workflow body (go)")
 	assertNotContains(t, body, "Bash(cargo:*)", "Claude Code workflow body (go)")
 }
 
 func TestGenerator_AI_ClaudeWorkflowRustContent(t *testing.T) {
 	tmp := t.TempDir()
-	// Override the language block — Rust instead of Go.
 	manifest := filepath.Join(tmp, "agent.yaml")
 	body := `apiVersion: adl.inference-gateway.com/v1
 kind: Agent
@@ -337,7 +325,6 @@ spec:
 
 	wf := readGenerated(t, out, ".github/workflows/claude.yml")
 
-	// Rust-specific setup must appear; Go-specific setup must not.
 	assertContains(t, wf, "Set up Rust", "Claude Code workflow body (rust)")
 	assertContains(t, wf, "actions-rs/toolchain@v1", "Claude Code workflow body (rust)")
 	assertContains(t, wf, "1.94.1", "Claude Code workflow body (rust)")
@@ -345,7 +332,6 @@ spec:
 	assertNotContains(t, wf, "actions/setup-go", "Claude Code workflow body (rust)")
 	assertNotContains(t, wf, "Install golangci-lint", "Claude Code workflow body (rust)")
 
-	// Language-specific Bash allowlist: Rust gets Bash(cargo:*), not Bash(go:*).
 	assertContains(t, wf, "Bash(cargo:*)", "Claude Code workflow body (rust)")
 	assertNotContains(t, wf, "Bash(go:*)", "Claude Code workflow body (rust)")
 }

--- a/internal/generator/ai_test.go
+++ b/internal/generator/ai_test.go
@@ -3,6 +3,7 @@ package generator
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -66,7 +67,7 @@ func TestGenerator_AI_NoTogglesNoFiles(t *testing.T) {
 	assertFile(t, out, "CLAUDE.md", false)
 	assertFile(t, out, "AGENTS.md", false)
 	assertFile(t, out, "GEMINI.md", false)
-	assertFile(t, out, ".github/workflows/claude-code.yml", false)
+	assertFile(t, out, ".github/workflows/claude.yml", false)
 	assertFile(t, out, ".github/workflows/codex.yml", false)
 	assertFile(t, out, ".github/workflows/gemini.yml", false)
 }
@@ -83,7 +84,7 @@ func TestGenerator_AI_ClaudeCodeOnly(t *testing.T) {
 	mustGenerate(t, manifest, out, Config{Overwrite: true, Version: "test"})
 
 	assertFile(t, out, "CLAUDE.md", true)
-	assertFile(t, out, ".github/workflows/claude-code.yml", true)
+	assertFile(t, out, ".github/workflows/claude.yml", true)
 
 	// Sibling agents must stay off when only claudecode is enabled.
 	assertFile(t, out, "AGENTS.md", false)
@@ -108,7 +109,7 @@ func TestGenerator_AI_GeminiOnly(t *testing.T) {
 
 	assertFile(t, out, "CLAUDE.md", false)
 	assertFile(t, out, "AGENTS.md", false)
-	assertFile(t, out, ".github/workflows/claude-code.yml", false)
+	assertFile(t, out, ".github/workflows/claude.yml", false)
 	assertFile(t, out, ".github/workflows/codex.yml", false)
 }
 
@@ -170,7 +171,7 @@ func TestGenerator_AI_AgentsMDSharedAcrossCodexOpencodeInfer(t *testing.T) {
 			assertFile(t, out, "CLAUDE.md", false)
 			assertFile(t, out, "GEMINI.md", false)
 			assertFile(t, out, ".github/workflows/codex.yml", tt.wantCodexWorkflow)
-			assertFile(t, out, ".github/workflows/claude-code.yml", false)
+			assertFile(t, out, ".github/workflows/claude.yml", false)
 			assertFile(t, out, ".github/workflows/gemini.yml", false)
 		})
 	}
@@ -199,7 +200,7 @@ func TestGenerator_AI_AllAgentsEnabled(t *testing.T) {
 	assertFile(t, out, "GEMINI.md", true)
 	assertFile(t, out, "AGENTS.md", true)
 
-	assertFile(t, out, ".github/workflows/claude-code.yml", true)
+	assertFile(t, out, ".github/workflows/claude.yml", true)
 	assertFile(t, out, ".github/workflows/codex.yml", true)
 	assertFile(t, out, ".github/workflows/gemini.yml", true)
 }
@@ -218,5 +219,133 @@ func TestGenerator_AI_NoWorkflowsWhenSCMNotGithub(t *testing.T) {
 	mustGenerate(t, manifest, out, Config{Overwrite: true, Version: "test"})
 
 	assertFile(t, out, "CLAUDE.md", true)
-	assertFile(t, out, ".github/workflows/claude-code.yml", false)
+	assertFile(t, out, ".github/workflows/claude.yml", false)
+}
+
+// readGenerated reads a generated file under outputDir, failing the test
+// if the file is missing.
+func readGenerated(t *testing.T, outputDir, rel string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(outputDir, rel))
+	if err != nil {
+		t.Fatalf("read %s: %v", rel, err)
+	}
+	return string(data)
+}
+
+// assertContains asserts that haystack contains needle, with a helpful
+// message that names what was being checked.
+func assertContains(t *testing.T, haystack, needle, what string) {
+	t.Helper()
+	if !strings.Contains(haystack, needle) {
+		t.Errorf("expected %s to contain %q", what, needle)
+	}
+}
+
+// assertNotContains is the inverse of assertContains.
+func assertNotContains(t *testing.T, haystack, needle, what string) {
+	t.Helper()
+	if strings.Contains(haystack, needle) {
+		t.Errorf("expected %s NOT to contain %q", what, needle)
+	}
+}
+
+func TestGenerator_AI_ClaudeWorkflowGoContent(t *testing.T) {
+	tmp := t.TempDir()
+	manifest := writeManifest(t, tmp, `  development:
+    ai:
+      claudecode:
+        enabled: true
+`)
+	out := filepath.Join(tmp, "out")
+
+	mustGenerate(t, manifest, out, Config{Overwrite: true, Version: "test"})
+
+	body := readGenerated(t, out, ".github/workflows/claude.yml")
+
+	// Filename invariants — the file is named claude.yml, not the
+	// old claude-code.yml. The old name lives only in the changelog
+	// note about the rename.
+	assertNotContains(t, body, "claude-code.yml", "Claude Code workflow body")
+
+	// The redundant comment block describing CLAUDE.md should be gone.
+	assertNotContains(t, body, "picks up CLAUDE.md", "Claude Code workflow body")
+
+	// YAML triggers use bullet-list form, not the inline [created] form.
+	assertContains(t, body, "issue_comment:\n    types:\n      - created", "Claude Code workflow body")
+	assertContains(t, body, "issues:\n    types:\n      - opened\n      - assigned", "Claude Code workflow body")
+	assertNotContains(t, body, "types: [created]", "Claude Code workflow body")
+
+	// New permission for the action's internal poller.
+	assertContains(t, body, "actions: read", "Claude Code workflow body")
+
+	// Go-specific setup must appear; Rust-specific setup must not.
+	assertContains(t, body, "Set up Go", "Claude Code workflow body (go)")
+	assertContains(t, body, "actions/setup-go@v6.4.0", "Claude Code workflow body (go)")
+	assertContains(t, body, "Install golangci-lint", "Claude Code workflow body (go)")
+	assertNotContains(t, body, "Set up Rust", "Claude Code workflow body (go)")
+	assertNotContains(t, body, "actions-rs/toolchain", "Claude Code workflow body (go)")
+
+	// Shared setup steps.
+	assertContains(t, body, "arduino/setup-task@v2.0.0", "Claude Code workflow body")
+	assertContains(t, body, "Install maintainer skill", "Claude Code workflow body")
+	assertContains(t, body, "raw.githubusercontent.com/inference-gateway/skills/main/skills/maintainer/SKILL.md", "Claude Code workflow body")
+
+	// New Run Claude Code step shape.
+	assertContains(t, body, "anthropics/claude-code-action@v1.0.131", "Claude Code workflow body")
+	assertContains(t, body, "claude_code_oauth_token:", "Claude Code workflow body")
+	assertContains(t, body, "use_commit_signing: true", "Claude Code workflow body")
+	assertContains(t, body, "branch_prefix: 'claude/'", "Claude Code workflow body")
+	assertContains(t, body, "--model claude-opus-4-7", "Claude Code workflow body")
+
+	// Language-specific Bash allowlist: Go gets Bash(go:*), not Bash(cargo:*).
+	assertContains(t, body, "Bash(go:*)", "Claude Code workflow body (go)")
+	assertNotContains(t, body, "Bash(cargo:*)", "Claude Code workflow body (go)")
+}
+
+func TestGenerator_AI_ClaudeWorkflowRustContent(t *testing.T) {
+	tmp := t.TempDir()
+	// Override the language block — Rust instead of Go.
+	manifest := filepath.Join(tmp, "agent.yaml")
+	body := `apiVersion: adl.inference-gateway.com/v1
+kind: Agent
+metadata:
+  name: ai-toggle-agent
+  description: Agent used to exercise the per-agent AI toggles.
+  version: 1.0.0
+spec:
+  capabilities:
+    streaming: true
+  server:
+    port: 8080
+  language:
+    rust:
+      packageName: ai-toggle-agent
+      version: "1.94.1"
+      edition: "2024"
+  development:
+    ai:
+      claudecode:
+        enabled: true
+`
+	if err := os.WriteFile(manifest, []byte(body), 0644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	out := filepath.Join(tmp, "out")
+
+	mustGenerate(t, manifest, out, Config{Overwrite: true, Version: "test"})
+
+	wf := readGenerated(t, out, ".github/workflows/claude.yml")
+
+	// Rust-specific setup must appear; Go-specific setup must not.
+	assertContains(t, wf, "Set up Rust", "Claude Code workflow body (rust)")
+	assertContains(t, wf, "actions-rs/toolchain@v1", "Claude Code workflow body (rust)")
+	assertContains(t, wf, "1.94.1", "Claude Code workflow body (rust)")
+	assertNotContains(t, wf, "Set up Go", "Claude Code workflow body (rust)")
+	assertNotContains(t, wf, "actions/setup-go", "Claude Code workflow body (rust)")
+	assertNotContains(t, wf, "Install golangci-lint", "Claude Code workflow body (rust)")
+
+	// Language-specific Bash allowlist: Rust gets Bash(cargo:*), not Bash(go:*).
+	assertContains(t, wf, "Bash(cargo:*)", "Claude Code workflow body (rust)")
+	assertNotContains(t, wf, "Bash(go:*)", "Claude Code workflow body (rust)")
 }

--- a/internal/generator/ai_test.go
+++ b/internal/generator/ai_test.go
@@ -279,8 +279,8 @@ func TestGenerator_AI_ClaudeWorkflowGoContent(t *testing.T) {
 	assertNotContains(t, body, "actions-rs/toolchain", "Claude Code workflow body (go)")
 
 	assertContains(t, body, "arduino/setup-task@v2.0.0", "Claude Code workflow body")
-	assertContains(t, body, "Install maintainer skill", "Claude Code workflow body")
-	assertContains(t, body, "raw.githubusercontent.com/inference-gateway/skills/main/skills/maintainer/SKILL.md", "Claude Code workflow body")
+	assertContains(t, body, "Install ADL skill", "Claude Code workflow body")
+	assertContains(t, body, "raw.githubusercontent.com/inference-gateway/skills/main/skills/adl/SKILL.md", "Claude Code workflow body")
 
 	assertContains(t, body, "anthropics/claude-code-action@v1.0.131", "Claude Code workflow body")
 	assertContains(t, body, "claude_code_oauth_token:", "Claude Code workflow body")

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -598,7 +598,7 @@ func (g *Generator) generateAIWorkflows(adl *schema.ADL, ctx templates.Context, 
 		{
 			enabled: g.config.AIToggles.ClaudeCode && schema.AIHasOfficialAction("claudecode"),
 			key:     "github/workflows/ai-claude-code.yaml",
-			path:    ".github/workflows/claude-code.yml",
+			path:    ".github/workflows/claude.yml",
 			label:   "Claude Code",
 		},
 		{

--- a/internal/schema/validator.go
+++ b/internal/schema/validator.go
@@ -129,7 +129,7 @@ func checkLegacySpecFields(yamlData any) error {
 	if dev, ok := spec["development"].(map[string]any); ok {
 		if ai, ok := dev["ai"].(map[string]any); ok {
 			if _, exists := ai["enabled"]; exists {
-				return fmt.Errorf("manifest uses the pre-v0.8.0 single-flag AI shape `spec.development.ai.enabled`; this field was removed in ADL v0.8.0. Move it to a per-agent toggle under spec.development.ai, e.g.:\n\n  spec:\n    development:\n      ai:\n        claudecode:\n          enabled: true   # generates CLAUDE.md + .github/workflows/claude-code.yml\n        # codex / gemini / opencode / infer are independent toggles\n\nSee https://github.com/inference-gateway/adl/releases/tag/v0.8.0 for the full per-agent matrix")
+				return fmt.Errorf("manifest uses the pre-v0.8.0 single-flag AI shape `spec.development.ai.enabled`; this field was removed in ADL v0.8.0. Move it to a per-agent toggle under spec.development.ai, e.g.:\n\n  spec:\n    development:\n      ai:\n        claudecode:\n          enabled: true   # generates CLAUDE.md + .github/workflows/claude.yml\n        # codex / gemini / opencode / infer are independent toggles\n\nSee https://github.com/inference-gateway/adl/releases/tag/v0.8.0 for the full per-agent matrix")
 			}
 		}
 	}

--- a/internal/templates/common/config/gitattributes.tmpl
+++ b/internal/templates/common/config/gitattributes.tmpl
@@ -57,7 +57,7 @@ GEMINI.md linguist-generated=true
 AGENTS.md linguist-generated=true
 {{- end }}
 {{- if .AIToggles.ClaudeCode }}
-.github/workflows/claude-code.yml linguist-generated=true
+.github/workflows/claude.yml linguist-generated=true
 {{- end }}
 {{- if .AIToggles.Codex }}
 .github/workflows/codex.yml linguist-generated=true

--- a/internal/templates/common/github/workflows/ai-claude-code.yaml.tmpl
+++ b/internal/templates/common/github/workflows/ai-claude-code.yaml.tmpl
@@ -71,12 +71,12 @@ jobs:
           version: 3.48.0
           repo-token: ${{`{{ secrets.GITHUB_TOKEN }}`}}
 
-      - name: Install maintainer skill
+      - name: Install ADL skill
         run: |
-          mkdir -p ~/.claude/skills/maintainer
+          mkdir -p ~/.claude/skills/adl
           curl -fsSL \
-            https://raw.githubusercontent.com/inference-gateway/skills/main/skills/maintainer/SKILL.md \
-            -o ~/.claude/skills/maintainer/SKILL.md
+            https://raw.githubusercontent.com/inference-gateway/skills/main/skills/adl/SKILL.md \
+            -o ~/.claude/skills/adl/SKILL.md
 
       - name: Run Claude Code
         id: claude

--- a/internal/templates/common/github/workflows/ai-claude-code.yaml.tmpl
+++ b/internal/templates/common/github/workflows/ai-claude-code.yaml.tmpl
@@ -1,19 +1,20 @@
 ---
 name: Claude Code
 
-# Runs Anthropic's Claude Code coding agent on issues, pull requests,
-# and review comments that mention @claude. The agent picks up CLAUDE.md
-# from the repo root for project-specific instructions.
-
 on:
   issue_comment:
-    types: [created]
+    types:
+      - created
   pull_request_review_comment:
-    types: [created]
+    types:
+      - created
   issues:
-    types: [opened, assigned]
+    types:
+      - opened
+      - assigned
   pull_request_review:
-    types: [submitted]
+    types:
+      - submitted
 
 jobs:
   claude:
@@ -28,14 +29,67 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 1
+{{- if eq .Language "go" }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v6.4.0
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Install golangci-lint
+        uses: golangci/golangci-lint-action@v9.2.0
+        with:
+          version: v2.12.2
+          args: --help
+{{- else if eq .Language "rust" }}
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: {{ if and .ADL.Spec.Language.Rust .ADL.Spec.Language.Rust.Version }}{{ .ADL.Spec.Language.Rust.Version }}{{ else }}stable{{ end }}
+          override: true
+          components: rustfmt, clippy
+{{- else if eq .Language "typescript" }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: {{ if and .ADL.Spec.Language.TypeScript .ADL.Spec.Language.TypeScript.NodeVersion }}{{ .ADL.Spec.Language.TypeScript.NodeVersion }}{{ else }}18{{ end }}
+          cache: 'npm'
+{{- end }}
+
+      - name: Install task
+        uses: arduino/setup-task@v2.0.0
+        with:
+          version: 3.48.0
+          repo-token: ${{`{{ secrets.GITHUB_TOKEN }}`}}
+
+      - name: Install maintainer skill
+        run: |
+          mkdir -p ~/.claude/skills/maintainer
+          curl -fsSL \
+            https://raw.githubusercontent.com/inference-gateway/skills/main/skills/maintainer/SKILL.md \
+            -o ~/.claude/skills/maintainer/SKILL.md
 
       - name: Run Claude Code
-        uses: anthropics/claude-code-action@v1
+        id: claude
+        uses: anthropics/claude-code-action@v1.0.131
         with:
-          anthropic_api_key: ${{`{{ secrets.ANTHROPIC_API_KEY }}`}}
-          github_token: ${{`{{ secrets.GITHUB_TOKEN }}`}}
+          claude_code_oauth_token: ${{`{{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}`}}
+          display_report: true
+          additional_permissions: |
+            actions: read
+          use_commit_signing: true
+          base_branch: main
+          branch_prefix: 'claude/'
+          claude_args: |
+            --model claude-opus-4-7
+            --system-prompt "You must NEVER push directly to the main branch. Always create a new feature branch (claude/feature-name), make changes there, and open a pull request to main. Use conventional commits with a capital description, e.g. 'feat(client): Add retry mechanism for streaming requests' or 'fix(auth): Resolve token validation issue'. Follow the development workflow specified in the coding instructions."
+            --allowedTools "Bash(task:*),Bash(gh:*),Bash(git:*){{- if eq .Language "go" }},Bash(go:*){{- else if eq .Language "rust" }},Bash(cargo:*){{- else if eq .Language "typescript" }},Bash(npm:*),Bash(node:*){{- end }}"


### PR DESCRIPTION
Reworks the generated `.github/workflows/claude.yml` (renamed from `claude-code.yml`) per #144.

## Changes

- Rename generated workflow file to `claude.yml` (generator path, `.gitattributes` linguist tag, README references, pre-v0.8.0 validator migration hint).
- Drop the redundant "picks up CLAUDE.md from the repo root" comment block.
- Switch trigger blocks to bullet-list YAML (`types:\n  - created`).
- Add `actions: read` permission.
- Add language-conditional setup (Go / Rust / TypeScript).
- Add `arduino/setup-task@v2.0.0`.
- Add `Install maintainer skill` step that pulls `inference-gateway/skills` `SKILL.md` into `~/.claude/skills/maintainer/`.
- Update `Run Claude Code` step to `anthropics/claude-code-action@v1.0.131` with OAuth token, commit signing, `branch_prefix: 'claude/'`, and the requested `claude_args` (model + system prompt).
- `--allowedTools` allowlist switches on `.Language`: Go → `Bash(go:*)`, Rust → `Bash(cargo:*)`, TS → `Bash(npm:*),Bash(node:*)`.

## Tests

- Renamed all `claude-code.yml` path assertions to `claude.yml`.
- Added `TestGenerator_AI_ClaudeWorkflowGoContent` and `TestGenerator_AI_ClaudeWorkflowRustContent` to cover the rendered body for each language.

`task ci` passes (fmt, lint, test, build, verify-schema).

Fixes #144

Generated with [Claude Code](https://claude.ai/code)