### PR TITLE
fix(generator): Stop leaking declarative flags into generated Taskfile

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -726,6 +726,13 @@ func (g *Generator) getVersion() string {
 // generated Taskfile. Paths are always the in-project canonical values
 // (agent.yaml at the project root) so the task works after `cd` into the
 // generated project, regardless of how `adl generate` was originally invoked.
+//
+// Only flags that are NOT declarative in the manifest are emitted here.
+// CI/CD, deployment type, and sandbox toggles (flox/devcontainer) all live in
+// the ADL itself (spec.scm.ci, spec.scm.cd, spec.deployment.type,
+// spec.development.sandbox.flox.enabled, spec.development.sandbox.devContainer.enabled)
+// so re-emitting them as CLI flags would duplicate state and silently rewrite
+// the Taskfile on every regeneration (see issue #146).
 func (g *Generator) buildGenerateCommand() string {
 	var parts []string
 
@@ -737,26 +744,6 @@ func (g *Generator) buildGenerateCommand() string {
 
 	if g.config.Overwrite {
 		parts = append(parts, "--overwrite")
-	}
-
-	if g.config.GenerateCI {
-		parts = append(parts, "--ci")
-	}
-
-	if g.config.GenerateCD {
-		parts = append(parts, "--cd")
-	}
-
-	if g.config.DeploymentType != "" {
-		parts = append(parts, "--deployment", g.config.DeploymentType)
-	}
-
-	if g.config.EnableFlox {
-		parts = append(parts, "--flox")
-	}
-
-	if g.config.EnableDevContainer {
-		parts = append(parts, "--devcontainer")
 	}
 
 	return strings.Join(parts, " ")

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -97,12 +97,6 @@ func TestGenerator_validateADL(t *testing.T) {
 			},
 			wantErr: false,
 		},
-		// "missing capabilities" / "missing language" test cases were removed
-		// when types.go switched to schema-generated types. Capabilities and
-		// Language are required by the JSON Schema and are non-pointer struct
-		// fields after generation, so a missing-field test case is no longer
-		// expressible at the Go type level. The JSON Schema validator
-		// (internal/schema/validator.go) covers the case at parse time.
 		{
 			name: "missing Go module",
 			adl: &schema.ADL{
@@ -748,9 +742,6 @@ func TestGenerator_buildGenerateCommand(t *testing.T) {
 				EnableFlox:         true,
 				EnableDevContainer: true,
 			},
-			// Only --template and --overwrite leak into the embedded Taskfile
-			// command. Everything else is declarative in the manifest and would
-			// duplicate state if re-emitted as a flag (see issue #146).
 			expectedCmd: "adl generate --file agent.yaml --output . --template custom --overwrite",
 		},
 		{

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -748,10 +748,13 @@ func TestGenerator_buildGenerateCommand(t *testing.T) {
 				EnableFlox:         true,
 				EnableDevContainer: true,
 			},
-			expectedCmd: "adl generate --file agent.yaml --output . --template custom --overwrite --ci --cd --deployment kubernetes --flox --devcontainer",
+			// Only --template and --overwrite leak into the embedded Taskfile
+			// command. Everything else is declarative in the manifest and would
+			// duplicate state if re-emitted as a flag (see issue #146).
+			expectedCmd: "adl generate --file agent.yaml --output . --template custom --overwrite",
 		},
 		{
-			name: "config reproducing the issue scenario",
+			name: "config reproducing the issue scenario (#146): legacy CI/CD/sandbox flags must not leak into the Taskfile",
 			config: Config{
 				ADLFile:    "agent.yaml",
 				OutputDir:  ".",
@@ -760,7 +763,7 @@ func TestGenerator_buildGenerateCommand(t *testing.T) {
 				GenerateCD: true,
 				EnableFlox: true,
 			},
-			expectedCmd: "adl generate --file agent.yaml --output . --overwrite --ci --cd --flox",
+			expectedCmd: "adl generate --file agent.yaml --output . --overwrite",
 		},
 		{
 			name: "config with default template (should not include template flag)",


### PR DESCRIPTION
## Summary
- Drop the legacy `--ci` / `--cd` / `--deployment` / `--flox` / `--devcontainer` appends from `buildGenerateCommand` so the generated Taskfile's `task generate` command stops being rewritten on every run.
- Those settings are already declarative in the ADL (`spec.scm.ci`, `spec.scm.cd`, `spec.deployment.type`, `spec.development.sandbox.flox.enabled`, `spec.development.sandbox.devContainer.enabled`) - re-emitting them as CLI flags duplicated state and silently mutated the Taskfile.
- Updated the `TestGenerator_buildGenerateCommand` table to match the new shape and pin the regression against #146.

## Test plan
- [x] `go test ./internal/generator -run TestGenerator_buildGenerateCommand`
- [x] `task ci`

Closes #146

Generated with [Claude Code](https://claude.ai/code)