### PR TITLE
fix(templates): JSON-encode metadata/skill strings to escape inner quotes

### DIFF
--- a/internal/templates/common/config/agent.json.tmpl
+++ b/internal/templates/common/config/agent.json.tmpl
@@ -1,15 +1,15 @@
 {
-	"name": "{{ .ADL.Metadata.Name }}",
-	"version": "{{ .ADL.Metadata.Version }}",
-	"description": "{{ .ADL.Metadata.Description }}",
-	"protocolVersion": "{{- if .ADL.Spec.Card }}{{- if .ADL.Spec.Card.ProtocolVersion }}{{ .ADL.Spec.Card.ProtocolVersion }}{{- else }}0.3.0{{- end }}{{- else }}0.3.0{{- end }}",
-	"url": "{{- if .ADL.Spec.Card }}{{- if .ADL.Spec.Card.URL }}{{ .ADL.Spec.Card.URL }}{{- else }}{{- end }}{{- else }}{{- end }}",
-	"preferredTransport": "{{- if .ADL.Spec.Card }}{{- if .ADL.Spec.Card.PreferredTransport }}{{ .ADL.Spec.Card.PreferredTransport }}{{- else }}JSONRPC{{- end }}{{- else }}JSONRPC{{- end }}",
+	"name": {{ .ADL.Metadata.Name | toJson }},
+	"version": {{ .ADL.Metadata.Version | toJson }},
+	"description": {{ .ADL.Metadata.Description | toJson }},
+	"protocolVersion": {{- if .ADL.Spec.Card }}{{- if .ADL.Spec.Card.ProtocolVersion }} {{ .ADL.Spec.Card.ProtocolVersion | toJson }}{{- else }} "0.3.0"{{- end }}{{- else }} "0.3.0"{{- end }},
+	"url": {{- if .ADL.Spec.Card }}{{- if .ADL.Spec.Card.URL }} {{ .ADL.Spec.Card.URL | toJson }}{{- else }} ""{{- end }}{{- else }} ""{{- end }},
+	"preferredTransport": {{- if .ADL.Spec.Card }}{{- if .ADL.Spec.Card.PreferredTransport }} {{ .ADL.Spec.Card.PreferredTransport | toJson }}{{- else }} "JSONRPC"{{- end }}{{- else }} "JSONRPC"{{- end }},
 	{{- if .ADL.Spec.Card }}{{- if .ADL.Spec.Card.DocumentationURL }}
-	"documentationUrl": "{{ .ADL.Spec.Card.DocumentationURL }}",
+	"documentationUrl": {{ .ADL.Spec.Card.DocumentationURL | toJson }},
 	{{- end }}{{- end }}
 	{{- if .ADL.Spec.Card }}{{- if .ADL.Spec.Card.IconURL }}
-	"iconUrl": "{{ .ADL.Spec.Card.IconURL }}",
+	"iconUrl": {{ .ADL.Spec.Card.IconURL | toJson }},
 	{{- end }}{{- end }}
 	"defaultInputModes": {{- if .ADL.Spec.Card }}{{- if .ADL.Spec.Card.DefaultInputModes }} {{ .ADL.Spec.Card.DefaultInputModes | toJson }}{{- else }} ["text"]{{- end }}{{- else }} ["text"]{{- end }},
 	"defaultOutputModes": {{- if .ADL.Spec.Card }}{{- if .ADL.Spec.Card.DefaultOutputModes }} {{ .ADL.Spec.Card.DefaultOutputModes | toJson }}{{- else }} ["text"]{{- end }}{{- else }} ["text"]{{- end }},
@@ -28,12 +28,12 @@
 		{{- range $index, $skill := .Skills }}
 		{{- if $index }},{{ end }}
 		{
-			"id": "{{ $skill.ID }}",
-			"name": "{{ $skill.Name }}",
-			"description": "{{ $skill.Description }}",
+			"id": {{ $skill.ID | toJson }},
+			"name": {{ $skill.Name | toJson }},
+			"description": {{ $skill.Description | toJson }},
 			"tags": {{ if $skill.Tags }}{{ $skill.Tags | toJson }}{{ else }}[]{{ end }}
 			{{- if $skill.Version }},
-			"version": "{{ $skill.Version }}"
+			"version": {{ $skill.Version | toJson }}
 			{{- end }}
 		}
 		{{- end }}

--- a/internal/templates/languages/go/main.go.tmpl
+++ b/internal/templates/languages/go/main.go.tmpl
@@ -44,9 +44,9 @@ import (
 // via `-ldflags "-X 'main.Version=...'"` (see Dockerfile). They default
 // to the values declared in the ADL.
 var (
-	Version          = "{{ .ADL.Metadata.Version }}"
-	AgentName        = "{{ .ADL.Metadata.Name }}"
-	AgentDescription = "{{ .ADL.Metadata.Description }}"
+	Version          = {{ .ADL.Metadata.Version | toJson }}
+	AgentName        = {{ .ADL.Metadata.Name | toJson }}
+	AgentDescription = {{ .ADL.Metadata.Description | toJson }}
 )
 
 // skillsDir is the directory the runtime scans for skill manifests at

--- a/internal/templates/languages/rust/main.rs.tmpl
+++ b/internal/templates/languages/rust/main.rs.tmpl
@@ -18,10 +18,10 @@ mod tools;
 /// {{ .ADL.Metadata.Description }}
 #[derive(Parser, Debug)]
 #[command(
-    name = "{{ .ADL.Metadata.Name }}",
+    name = {{ .ADL.Metadata.Name | toJson }},
     version,
-    about = "{{ .ADL.Metadata.Description }}",
-    long_about = "{{ .ADL.Metadata.Description }}\n\nThis is an A2A (Agent-to-Agent) protocol server. Use the `start` subcommand to run it.",
+    about = {{ .ADL.Metadata.Description | toJson }},
+    long_about = {{ printf "%s\n\nThis is an A2A (Agent-to-Agent) protocol server. Use the `start` subcommand to run it." .ADL.Metadata.Description | toJson }},
 )]
 struct Cli {
     #[command(subcommand)]

--- a/internal/templates/registry_agent_card_test.go
+++ b/internal/templates/registry_agent_card_test.go
@@ -215,8 +215,6 @@ func TestRustMainTemplate_EscapesQuotesInDescription(t *testing.T) {
 		t.Errorf("main.rs did not contain properly escaped about literal\nwant substring: %s\n--- rendered ---\n%s", wantAbout, rendered)
 	}
 
-	// long_about must concatenate the description with the trailing boilerplate
-	// AND keep inner quotes escaped.
 	wantLongAbout := `long_about = "Agent for \"PromQL\" and \"sum by\" queries\n\nThis is an A2A (Agent-to-Agent) protocol server. Use the ` + "`start`" + ` subcommand to run it."`
 	if !strings.Contains(rendered, wantLongAbout) {
 		t.Errorf("main.rs did not contain properly escaped long_about literal\nwant substring: %s\n--- rendered ---\n%s", wantLongAbout, rendered)

--- a/internal/templates/registry_agent_card_test.go
+++ b/internal/templates/registry_agent_card_test.go
@@ -1,0 +1,228 @@
+package templates
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	schema "github.com/inference-gateway/adl-cli/internal/schema"
+)
+
+// TestAgentCardTemplate_EscapesQuotesInDescriptions is the regression test
+// for issue #150. The previous template inlined description strings into the
+// JSON output with raw `"{{ .Description }}"`, so any inner double quote
+// (e.g. a skill description that says: Triggers on phrases like "PromQL")
+// terminated the JSON string early and produced an invalid `.well-known/agent-card.json`.
+//
+// The fix routes every string field through `toJson`, which delegates to
+// `encoding/json` and escapes `"`, `\`, and control characters per RFC 8259.
+// This test asserts the rendered output parses cleanly and the original
+// strings survive round-tripping with their inner quotes intact.
+func TestAgentCardTemplate_EscapesQuotesInDescriptions(t *testing.T) {
+	r, err := NewRegistry("go")
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	tmpl, err := r.GetTemplate("config/agent.json")
+	if err != nil {
+		t.Fatalf("GetTemplate(config/agent.json): %v", err)
+	}
+
+	adl := minimalGoADL()
+	adl.Metadata.Description = `An agent that handles "PromQL" and "sum by" queries.`
+	adl.Spec.Card = &schema.Card{
+		ProtocolVersion:    "0.3.0",
+		URL:                "https://example.com/agent",
+		PreferredTransport: "JSONRPC",
+		DocumentationURL:   "https://example.com/docs",
+		IconURL:            "https://example.com/icon.png",
+	}
+
+	promqlDesc := `Generate Prometheus query expressions. Triggers on phrases like "PromQL", "Prometheus query", and "sum by".`
+	dashboardDesc := `Author Grafana dashboards. Handles phrases such as "stat panel" and "time series".`
+
+	engine := NewWithRegistry("config/agent.json", r)
+	ctx := Context{
+		ADL:      adl,
+		Language: "go",
+		Skills: []SkillView{
+			{
+				ID:          "promql",
+				Name:        "PromQL",
+				Description: promqlDesc,
+				Tags:        []string{"prometheus", "metrics"},
+				Version:     "1.0.0",
+			},
+			{
+				ID:          "dashboarding",
+				Name:        "Dashboarding",
+				Description: dashboardDesc,
+				Tags:        []string{"grafana"},
+			},
+		},
+	}
+
+	rendered, err := engine.Execute(tmpl, ctx)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var card struct {
+		Name        string `json:"name"`
+		Version     string `json:"version"`
+		Description string `json:"description"`
+		Skills      []struct {
+			ID          string   `json:"id"`
+			Name        string   `json:"name"`
+			Description string   `json:"description"`
+			Tags        []string `json:"tags"`
+			Version     string   `json:"version,omitempty"`
+		} `json:"skills"`
+	}
+	if err := json.Unmarshal([]byte(rendered), &card); err != nil {
+		t.Fatalf("rendered agent-card.json is not valid JSON: %v\n--- rendered ---\n%s", err, rendered)
+	}
+
+	if card.Description != adl.Metadata.Description {
+		t.Errorf("metadata description was not preserved through JSON encoding\nwant: %q\ngot:  %q", adl.Metadata.Description, card.Description)
+	}
+
+	if len(card.Skills) != 2 {
+		t.Fatalf("expected 2 skills, got %d", len(card.Skills))
+	}
+	if card.Skills[0].Description != promqlDesc {
+		t.Errorf("promql skill description not preserved\nwant: %q\ngot:  %q", promqlDesc, card.Skills[0].Description)
+	}
+	if card.Skills[1].Description != dashboardDesc {
+		t.Errorf("dashboarding skill description not preserved\nwant: %q\ngot:  %q", dashboardDesc, card.Skills[1].Description)
+	}
+	if card.Skills[0].Version != "1.0.0" {
+		t.Errorf("promql skill version not preserved\nwant: %q\ngot:  %q", "1.0.0", card.Skills[0].Version)
+	}
+}
+
+// TestAgentCardTemplate_EscapesBackslashesAndControlChars covers the rest of
+// the RFC 8259 must-escape set so a careless future edit that re-introduces
+// raw interpolation gets caught.
+func TestAgentCardTemplate_EscapesBackslashesAndControlChars(t *testing.T) {
+	r, err := NewRegistry("go")
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	tmpl, err := r.GetTemplate("config/agent.json")
+	if err != nil {
+		t.Fatalf("GetTemplate(config/agent.json): %v", err)
+	}
+
+	adl := minimalGoADL()
+	adl.Metadata.Description = "line one\nline two with a \\ backslash and a \"quote\""
+
+	engine := NewWithRegistry("config/agent.json", r)
+	rendered, err := engine.Execute(tmpl, Context{ADL: adl, Language: "go"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var card struct {
+		Description string `json:"description"`
+	}
+	if err := json.Unmarshal([]byte(rendered), &card); err != nil {
+		t.Fatalf("rendered agent-card.json is not valid JSON: %v\n--- rendered ---\n%s", err, rendered)
+	}
+	if card.Description != adl.Metadata.Description {
+		t.Errorf("description not preserved\nwant: %q\ngot:  %q", adl.Metadata.Description, card.Description)
+	}
+}
+
+// TestGoMainTemplate_EscapesQuotesInDescription is the sibling regression for
+// issue #150: the Go main.go template also embeds metadata.description as a
+// raw Go string literal (the AgentDescription var). Inner double quotes used
+// to produce invalid Go that would fail `go build`. The fix routes the value
+// through `toJson`, which emits a JSON-encoded string that doubles as a valid
+// Go interpreted-string literal (same escape semantics for `"`, `\`, `\n`).
+func TestGoMainTemplate_EscapesQuotesInDescription(t *testing.T) {
+	r, err := NewRegistry("go")
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	tmpl, err := r.GetTemplate("main.go")
+	if err != nil {
+		t.Fatalf("GetTemplate(main.go): %v", err)
+	}
+
+	adl := minimalGoADL()
+	adl.Metadata.Description = `Agent for "PromQL" and "sum by" queries`
+
+	engine := NewWithRegistry("main.go", r)
+	rendered, err := engine.Execute(tmpl, Context{ADL: adl, Language: "go"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	want := `AgentDescription = "Agent for \"PromQL\" and \"sum by\" queries"`
+	if !strings.Contains(rendered, want) {
+		t.Errorf("main.go did not contain properly escaped AgentDescription literal\nwant substring: %s\n--- rendered ---\n%s", want, rendered)
+	}
+
+	if strings.Contains(rendered, `"Agent for "PromQL"`) {
+		t.Errorf("main.go still contains raw (unescaped) quotes inside the description literal\n--- rendered ---\n%s", rendered)
+	}
+}
+
+// TestRustMainTemplate_EscapesQuotesInDescription is the sibling regression
+// for issue #150 in the Rust generator. `name`, `about`, and `long_about` on
+// the #[command(...)] attribute are Rust string literals; a raw `"` in the
+// description used to break compilation.
+func TestRustMainTemplate_EscapesQuotesInDescription(t *testing.T) {
+	r, err := NewRegistry("rust")
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	tmpl, err := r.GetTemplate("main.rs")
+	if err != nil {
+		t.Fatalf("GetTemplate(main.rs): %v", err)
+	}
+
+	adl := &schema.ADL{
+		APIVersion: "adl.inference-gateway.com/v1",
+		Kind:       "Agent",
+		Metadata: schema.Metadata{
+			Name:        "rust-agent",
+			Description: `Agent for "PromQL" and "sum by" queries`,
+			Version:     "0.1.0",
+		},
+		Spec: schema.Spec{
+			Capabilities: schema.Capabilities{Streaming: true},
+			Server:       schema.Server{Port: 8080},
+			Language: schema.Language{
+				Rust: &schema.RustConfig{
+					PackageName: "rust-agent",
+					Version:     "1.94.1",
+					Edition:     "2024",
+				},
+			},
+		},
+	}
+
+	engine := NewWithRegistry("main.rs", r)
+	rendered, err := engine.Execute(tmpl, Context{ADL: adl, Language: "rust"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	wantAbout := `about = "Agent for \"PromQL\" and \"sum by\" queries"`
+	if !strings.Contains(rendered, wantAbout) {
+		t.Errorf("main.rs did not contain properly escaped about literal\nwant substring: %s\n--- rendered ---\n%s", wantAbout, rendered)
+	}
+
+	// long_about must concatenate the description with the trailing boilerplate
+	// AND keep inner quotes escaped.
+	wantLongAbout := `long_about = "Agent for \"PromQL\" and \"sum by\" queries\n\nThis is an A2A (Agent-to-Agent) protocol server. Use the ` + "`start`" + ` subcommand to run it."`
+	if !strings.Contains(rendered, wantLongAbout) {
+		t.Errorf("main.rs did not contain properly escaped long_about literal\nwant substring: %s\n--- rendered ---\n%s", wantLongAbout, rendered)
+	}
+
+	if strings.Contains(rendered, `about = "Agent for "PromQL"`) {
+		t.Errorf("main.rs still contains raw (unescaped) quotes inside the about literal\n--- rendered ---\n%s", rendered)
+	}
+}


### PR DESCRIPTION
Fixes #150

## Summary

Skill and metadata descriptions containing literal double quotes (e.g. `"PromQL"`) used to be interpolated verbatim into the generated `.well-known/agent-card.json`, breaking JSON parsing. The same raw interpolation also produced invalid Go (`AgentDescription` var) and invalid Rust (`about`/`long_about` on the clap `#[command(...)]` attribute).

Route every interpolated string field through the template engine's `toJson` helper, which delegates to `encoding/json` and escapes `"`, `\`, and control characters per RFC 8259. The output is simultaneously a valid JSON string literal, a valid Go interpreted-string literal, and a valid Rust string literal, so one change fixes all three generators.

## Files changed

- `internal/templates/common/config/agent.json.tmpl` — skill + metadata fields use `toJson`
- `internal/templates/languages/go/main.go.tmpl` — `AgentDescription` / `AgentName` / `Version` literals
- `internal/templates/languages/rust/main.rs.tmpl` — clap `name` / `about` / `long_about` attributes
- `internal/templates/registry_agent_card_test.go` — new, 4 regression tests

## Test plan

- [x] `task ci` passes (0 lint issues, all tests pass, build OK, schema OK)
- [x] Smoke-test: `jq . .well-known/agent-card.json` parses cleanly with a description containing literal `"PromQL"`
- [x] Smoke-test: generated Go `main.go` passes `go fmt`
- [x] Smoke-test: generated Rust `main.rs` contains properly escaped clap attributes

Generated with [Claude Code](https://claude.ai/code)