### PR TITLE
feat(generator): Wire spec.language.*.vendor.{deps,devdeps} through Go and Rust generators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ dist/
 
 # Dependency directories (remove the comment below to include it)
 vendor/
+# But keep our internal "vendor" package (resolves spec.language.*.vendor.{deps,devdeps}).
+!internal/vendor/
 
 # Go workspace file
 go.work

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,13 +152,24 @@ Every `spec.language.<lang>` config accepts an optional `vendor.{deps,devdeps}`
 block whose entries follow the `<package>@<version>` form. They are resolved
 by `internal/vendor` (parsed, deduped against the generator's built-in
 dependency set, sorted), exposed on `templates.Context.Vendor` as
-`GoRequires` / `CargoDeps` / `CargoDevDeps` / `NpmDeps` / `NpmDevDeps`, and
-rendered into `go.mod` / `Cargo.toml` directly. Built-ins always win on
-conflict (`internal/vendor/vendor.go` lists them as `GoBuiltins`,
-`CargoBuiltinDeps`, `CargoBuiltinDevDeps`); collisions surface as
-stderr warnings from the generator. The TypeScript fields are validated
-and resolved today but only land in `package.json` once the TS templates
-exist (currently only `.gitkeep`).
+`GoRequires` / `GoTools` / `CargoDeps` / `CargoDevDeps` / `NpmDeps` /
+`NpmDevDeps`, and rendered into `go.mod` / `Cargo.toml` directly.
+Built-ins always win on conflict (`internal/vendor/vendor.go` lists them
+as `GoBuiltins`, `CargoBuiltinDeps`, `CargoBuiltinDevDeps`); collisions
+surface as stderr warnings from the generator. The TypeScript fields are
+validated and resolved today but only land in `package.json` once the TS
+templates exist (currently only `.gitkeep`).
+
+**Go-specific semantics:** `vendor.deps` map straight into `go.mod`'s
+`require` block (plus the built-ins). `vendor.devdeps` are treated as
+executable tool dependencies and emitted via Go 1.24+'s
+[`tool` directive](https://go.dev/doc/modules/managing-dependencies#tools);
+each entry also lands in `require` as `// indirect` so the module is
+downloadable. Users supply the full tool package path
+(e.g. `golang.org/x/tools/cmd/stringer@v0.20.0`); running `go mod tidy`
+after generation normalises the `require` entry to the module root.
+Test libraries that are `import`-ed by `*_test.go` files (testify,
+go-cmp, …) belong in `vendor.deps`, not `vendor.devdeps`.
 
 When you update a built-in dependency in a language template, mirror the
 new pin into the matching map in `internal/vendor/vendor.go` so vendor

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,24 @@ is documented in the generated `.env.example` - not baked into `main.rs`. When
 `spec.development.sandbox.dockerCompose.enabled: true` is also set, a working
 `docker-compose.yaml` with a Redis service is produced alongside the agent.
 
+### Vendor (extra dependencies)
+
+Every `spec.language.<lang>` config accepts an optional `vendor.{deps,devdeps}`
+block whose entries follow the `<package>@<version>` form. They are resolved
+by `internal/vendor` (parsed, deduped against the generator's built-in
+dependency set, sorted), exposed on `templates.Context.Vendor` as
+`GoRequires` / `CargoDeps` / `CargoDevDeps` / `NpmDeps` / `NpmDevDeps`, and
+rendered into `go.mod` / `Cargo.toml` directly. Built-ins always win on
+conflict (`internal/vendor/vendor.go` lists them as `GoBuiltins`,
+`CargoBuiltinDeps`, `CargoBuiltinDevDeps`); collisions surface as
+stderr warnings from the generator. The TypeScript fields are validated
+and resolved today but only land in `package.json` once the TS templates
+exist (currently only `.gitkeep`).
+
+When you update a built-in dependency in a language template, mirror the
+new pin into the matching map in `internal/vendor/vendor.go` so vendor
+conflicts continue to be caught.
+
 ## Adding a New Language
 
 1. Create `internal/templates/languages/<lang>/` with templates

--- a/README.md
+++ b/README.md
@@ -609,9 +609,9 @@ spec:
 
 Every language config block accepts an optional `vendor` section that lets
 the manifest extend the generator's built-in dependency set. Use `deps`
-for runtime/production dependencies and `devdeps` for test- or
-development-only ones (test frameworks, mock generators, linters that
-need to be importable). Each entry must be `<package>@<version>` using
+for runtime/production dependencies and `devdeps` for development-only
+ones. The exact meaning of `devdeps` depends on the language - see the
+mapping table below. Each entry must be `<package>@<version>` using
 the target language's native package and version syntax - the schema
 validates the shape up front (`^\S+@\S+$`) and points at the offending
 key if you mistype it (e.g. `spec.language.go.vendor.deps.0`).
@@ -627,14 +627,19 @@ downgrades of the core runtime SDK.
 
 | Language   | `deps` lands in               | `devdeps` lands in                 |
 | ---------- | ----------------------------- | ---------------------------------- |
-| Go         | `go.mod` `require` block      | same `require` block (Go has no separate dev section - `go mod tidy` will reclassify entries as `// indirect` or drop them based on actual import usage) |
+| Go         | `go.mod` `require` block      | `go.mod` [`tool` directive](https://go.dev/doc/modules/managing-dependencies#tools) (executable dev tools: code generators, linters, etc.) plus an `// indirect` entry in `require` so the module is downloadable. Test libraries that you `import` (testify, go-cmp, …) belong in `deps`, not `devdeps`. |
 | Rust       | `Cargo.toml` `[dependencies]` | `Cargo.toml` `[dev-dependencies]`  |
-| TypeScript | `package.json` `dependencies` | `package.json` `devDependencies` *(plumbed end-to-end once the TypeScript generator templates land - the schema and validator already accept the field)* |
+| TypeScript | `package.json` `dependencies` | `package.json` `devDependencies` _(plumbed end-to-end once the TypeScript generator templates land - the schema and validator already accept the field)_ |
+
+For Go, supply the **full tool package path** (the binary's `main` package,
+e.g. `golang.org/x/tools/cmd/stringer`) with a version. After generation,
+run `go mod tidy` so Go normalises the indirect `require` entry to the
+actual module root.
 
 Examples per language:
 
 ```yaml
-# Go: testify for tests, uuid for runtime.
+# Go: uuid for runtime, stringer + mockgen as dev tools.
 spec:
   language:
     go:
@@ -643,8 +648,10 @@ spec:
       vendor:
         deps:
           - github.com/google/uuid@v1.6.0
+          - github.com/stretchr/testify@v1.10.0  # imported by *_test.go
         devdeps:
-          - github.com/stretchr/testify@v1.10.0
+          - golang.org/x/tools/cmd/stringer@v0.20.0
+          - github.com/golang/mock/mockgen@v1.6.0
 ```
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -605,6 +605,79 @@ spec:
         enabled: true
 ```
 
+### Extra dependencies (`spec.language.<lang>.vendor`)
+
+Every language config block accepts an optional `vendor` section that lets
+the manifest extend the generator's built-in dependency set. Use `deps`
+for runtime/production dependencies and `devdeps` for test- or
+development-only ones (test frameworks, mock generators, linters that
+need to be importable). Each entry must be `<package>@<version>` using
+the target language's native package and version syntax - the schema
+validates the shape up front (`^\S+@\S+$`) and points at the offending
+key if you mistype it (e.g. `spec.language.go.vendor.deps.0`).
+
+**Conflict policy:** generator built-ins always win. If your manifest
+lists a package that the generator already pins (e.g.
+`github.com/inference-gateway/adk` for Go, `tokio` for Rust), the
+vendor entry is silently dropped and a `⚠️  vendor … collides with
+built-in …` warning is printed to stderr. This prevents accidental
+downgrades of the core runtime SDK.
+
+**Output mapping per language:**
+
+| Language   | `deps` lands in               | `devdeps` lands in                 |
+| ---------- | ----------------------------- | ---------------------------------- |
+| Go         | `go.mod` `require` block      | same `require` block (Go has no separate dev section - `go mod tidy` will reclassify entries as `// indirect` or drop them based on actual import usage) |
+| Rust       | `Cargo.toml` `[dependencies]` | `Cargo.toml` `[dev-dependencies]`  |
+| TypeScript | `package.json` `dependencies` | `package.json` `devDependencies` *(plumbed end-to-end once the TypeScript generator templates land - the schema and validator already accept the field)* |
+
+Examples per language:
+
+```yaml
+# Go: testify for tests, uuid for runtime.
+spec:
+  language:
+    go:
+      module: github.com/example/agent
+      version: "1.26.2"
+      vendor:
+        deps:
+          - github.com/google/uuid@v1.6.0
+        devdeps:
+          - github.com/stretchr/testify@v1.10.0
+```
+
+```yaml
+# Rust: regex at runtime, mockall + pretty_assertions for tests.
+spec:
+  language:
+    rust:
+      packageName: agent
+      version: "1.94.1"
+      edition: "2024"
+      vendor:
+        deps:
+          - regex@1.10.0
+        devdeps:
+          - mockall@0.12.1
+          - pretty_assertions@1.4.0
+```
+
+```yaml
+# TypeScript: axios at runtime, vitest + @types/node for tests.
+spec:
+  language:
+    typescript:
+      packageName: "@example/agent"
+      nodeVersion: "20"
+      vendor:
+        deps:
+          - axios@1.7.0
+        devdeps:
+          - "@types/node@20.11.0"
+          - vitest@1.6.0
+```
+
 ## Skills vs. Tools
 
 The ADL spec distinguishes two complementary concepts:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -6,7 +6,10 @@ vars:
   VERSION: 0.36.6
   BUILD_DIR: bin
   DIST_DIR: dist
-  ADL_SCHEMA_VERSION: v0.8.0
+  # TODO: bump to v0.9.0 once the `feat(schema): Add optional vendor.deps and
+  # vendor.devdeps to language configs` change is tagged upstream. Pinned to
+  # the merge SHA in the meantime so verify-schema stays green.
+  ADL_SCHEMA_VERSION: 5a28d5a71442e2f9fce1435a56c2058126d326cb
   ADL_SCHEMA_URL: https://raw.githubusercontent.com/inference-gateway/adl/{{.ADL_SCHEMA_VERSION}}/schema/v1/schema.json
   ADL_SCHEMA_PATH: internal/schema/schema.json
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -6,10 +6,7 @@ vars:
   VERSION: 0.36.6
   BUILD_DIR: bin
   DIST_DIR: dist
-  # TODO: bump to v0.9.0 once the `feat(schema): Add optional vendor.deps and
-  # vendor.devdeps to language configs` change is tagged upstream. Pinned to
-  # the merge SHA in the meantime so verify-schema stays green.
-  ADL_SCHEMA_VERSION: 5a28d5a71442e2f9fce1435a56c2058126d326cb
+  ADL_SCHEMA_VERSION: v0.9.0
   ADL_SCHEMA_URL: https://raw.githubusercontent.com/inference-gateway/adl/{{.ADL_SCHEMA_VERSION}}/schema/v1/schema.json
   ADL_SCHEMA_PATH: internal/schema/schema.json
 

--- a/examples/go-agent.yaml
+++ b/examples/go-agent.yaml
@@ -209,6 +209,13 @@ spec:
     go:
       module: "github.com/inference-gateway/adl-cli/test-output"
       version: "1.26.2"
+      vendor:
+        # Extra modules to add to go.mod beyond the generator's defaults.
+        # Go has no separate dev section: deps and devdeps are merged into
+        # the single `require` block. `go mod tidy` will reclassify them
+        # (// indirect / drop) once your code does or doesn't import them.
+        devdeps:
+          - github.com/stretchr/testify@v1.10.0
   scm:
     provider: github
     url: "https://github.com/inference-gateway/adl-cli"

--- a/examples/go-agent.yaml
+++ b/examples/go-agent.yaml
@@ -211,11 +211,16 @@ spec:
       version: "1.26.2"
       vendor:
         # Extra modules to add to go.mod beyond the generator's defaults.
-        # Go has no separate dev section: deps and devdeps are merged into
-        # the single `require` block. `go mod tidy` will reclassify them
-        # (// indirect / drop) once your code does or doesn't import them.
-        devdeps:
+        # `deps` map straight into the `require` block (test libraries that
+        # you `import` from *_test.go go here too). `devdeps` are treated
+        # as Go 1.24+ tool dependencies and emitted via the `tool` directive
+        # plus an `// indirect` entry in `require`; supply the full tool
+        # package path with a version, then run `go mod tidy` to normalise
+        # the require entry to the owning module root.
+        deps:
           - github.com/stretchr/testify@v1.10.0
+        devdeps:
+          - golang.org/x/tools/cmd/stringer@v0.20.0
   scm:
     provider: github
     url: "https://github.com/inference-gateway/adl-cli"

--- a/examples/go-agent.yaml
+++ b/examples/go-agent.yaml
@@ -210,13 +210,6 @@ spec:
       module: "github.com/inference-gateway/adl-cli/test-output"
       version: "1.26.2"
       vendor:
-        # Extra modules to add to go.mod beyond the generator's defaults.
-        # `deps` map straight into the `require` block (test libraries that
-        # you `import` from *_test.go go here too). `devdeps` are treated
-        # as Go 1.24+ tool dependencies and emitted via the `tool` directive
-        # plus an `// indirect` entry in `require`; supply the full tool
-        # package path with a version, then run `go mod tidy` to normalise
-        # the require entry to the owning module root.
         deps:
           - github.com/stretchr/testify@v1.10.0
         devdeps:

--- a/examples/rust-agent.yaml
+++ b/examples/rust-agent.yaml
@@ -68,6 +68,12 @@ spec:
       packageName: "rust-agent"
       version: "1.94.1"
       edition: "2024"
+      vendor:
+        # Extra crates to add to Cargo.toml beyond the generator's defaults.
+        # `deps` lands in [dependencies], `devdeps` lands in [dev-dependencies].
+        devdeps:
+          - mockall@0.12.1
+          - pretty_assertions@1.4.0
   development:
     sandbox:
       flox:

--- a/examples/rust-agent.yaml
+++ b/examples/rust-agent.yaml
@@ -69,8 +69,6 @@ spec:
       version: "1.94.1"
       edition: "2024"
       vendor:
-        # Extra crates to add to Cargo.toml beyond the generator's defaults.
-        # `deps` lands in [dependencies], `devdeps` lands in [dev-dependencies].
         devdeps:
           - mockall@0.12.1
           - pretty_assertions@1.4.0

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -13,6 +13,7 @@ import (
 	"github.com/inference-gateway/adl-cli/internal/registry"
 	"github.com/inference-gateway/adl-cli/internal/schema"
 	"github.com/inference-gateway/adl-cli/internal/templates"
+	"github.com/inference-gateway/adl-cli/internal/vendor"
 	"gopkg.in/yaml.v3"
 )
 
@@ -333,6 +334,16 @@ func (g *Generator) generateProject(templateEngine *templates.Engine, adl *schem
 		return fmt.Errorf("failed to resolve built-in tool config: %w", err)
 	}
 
+	vendorView, err := vendor.ResolveADL(adl)
+	if err != nil {
+		return fmt.Errorf("failed to resolve vendor dependencies: %w", err)
+	}
+	for _, c := range vendorView.Conflicts {
+		fmt.Fprintf(os.Stderr,
+			"⚠️  vendor %s entry %s@%s collides with built-in %s; dropping the vendor entry (built-ins win)\n",
+			c.DepGroup, c.Entry.Name, c.Entry.Version, c.Builtin)
+	}
+
 	ctx := templates.Context{
 		ADL: adl,
 		Metadata: schema.GeneratedMetadata{
@@ -348,6 +359,7 @@ func (g *Generator) generateProject(templateEngine *templates.Engine, adl *schem
 		GenerateCommand: g.buildGenerateCommand(),
 		Skills:          skillViews,
 		BuiltinConfigs:  builtinConfigs,
+		Vendor:          vendorView,
 	}
 
 	ignoreChecker, err := NewIgnoreChecker(outputDir)

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -966,7 +966,7 @@ func TestGenerator_VendorWiring(t *testing.T) {
 		return out
 	}
 
-	t.Run("go: no vendor block renders unchanged require list", func(t *testing.T) {
+	t.Run("go: no vendor block renders unchanged require list and no tool directive", func(t *testing.T) {
 		got := render(t, "go", "go.mod", makeGo(nil))
 		if !strings.Contains(got, "github.com/inference-gateway/adk v0.18.4") {
 			t.Fatalf("expected built-in ADK in require, got:\n%s", got)
@@ -974,23 +974,47 @@ func TestGenerator_VendorWiring(t *testing.T) {
 		if strings.Contains(got, "stretchr/testify") {
 			t.Fatalf("unexpected vendor entry leaked, got:\n%s", got)
 		}
+		if strings.Contains(got, "tool (") {
+			t.Fatalf("expected no tool directive when vendor is empty, got:\n%s", got)
+		}
 	})
 
-	t.Run("go: deps and devdeps both land in require, sorted, deduped", func(t *testing.T) {
+	t.Run("go: deps land in require sorted+deduped; devdeps populate require // indirect and tool block", func(t *testing.T) {
 		got := render(t, "go", "go.mod", makeGo(&schema.VendorConfig{
 			Deps:    []string{"github.com/google/uuid@v1.6.0", "github.com/google/uuid@v1.5.0"},
-			Devdeps: []string{"github.com/stretchr/testify@v1.10.0"},
+			Devdeps: []string{"golang.org/x/tools/cmd/stringer@v0.20.0"},
 		}))
-		uuidIdx := strings.Index(got, "github.com/google/uuid v1.6.0")
-		testifyIdx := strings.Index(got, "github.com/stretchr/testify v1.10.0")
-		if uuidIdx == -1 || testifyIdx == -1 {
-			t.Fatalf("expected uuid v1.6.0 and testify v1.10.0 in require block, got:\n%s", got)
-		}
-		if uuidIdx > testifyIdx {
-			t.Fatalf("expected sorted order (google < stretchr), got:\n%s", got)
+		if !strings.Contains(got, "github.com/google/uuid v1.6.0") {
+			t.Fatalf("expected uuid v1.6.0 in require, got:\n%s", got)
 		}
 		if strings.Contains(got, "v1.5.0") {
 			t.Fatalf("expected duplicate uuid v1.5.0 to be deduped (first-wins), got:\n%s", got)
+		}
+		if !strings.Contains(got, "golang.org/x/tools/cmd/stringer v0.20.0 // indirect") {
+			t.Fatalf("expected stringer in require as // indirect, got:\n%s", got)
+		}
+		toolIdx := strings.Index(got, "tool (")
+		if toolIdx == -1 {
+			t.Fatalf("expected tool directive, got:\n%s", got)
+		}
+		toolSection := got[toolIdx:]
+		if !strings.Contains(toolSection, "golang.org/x/tools/cmd/stringer") {
+			t.Fatalf("expected stringer in tool block, got:\n%s", toolSection)
+		}
+		if strings.Contains(toolSection, "v0.20.0") {
+			t.Fatalf("tool block must list bare package paths (no version), got:\n%s", toolSection)
+		}
+	})
+
+	t.Run("go: dev-only vendor still emits a tool directive without deps", func(t *testing.T) {
+		got := render(t, "go", "go.mod", makeGo(&schema.VendorConfig{
+			Devdeps: []string{"github.com/golang/mock/mockgen@v1.6.0"},
+		}))
+		if !strings.Contains(got, "github.com/golang/mock/mockgen v1.6.0 // indirect") {
+			t.Fatalf("expected mockgen as // indirect require, got:\n%s", got)
+		}
+		if !strings.Contains(got, "tool (") {
+			t.Fatalf("expected tool directive when only devdeps set, got:\n%s", got)
 		}
 	})
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -3,10 +3,12 @@ package generator
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/inference-gateway/adl-cli/internal/schema"
 	"github.com/inference-gateway/adl-cli/internal/templates"
+	"github.com/inference-gateway/adl-cli/internal/vendor"
 )
 
 func TestGenerator_Generate(t *testing.T) {
@@ -895,4 +897,164 @@ func TestGenerator_IssueTemplates(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGenerator_VendorWiring exercises the go.mod / Cargo.toml templates
+// end-to-end with vendor.deps / vendor.devdeps populated. The cases cover
+// every state from acceptance criteria #6 in issue #152: empty/missing
+// vendor, runtime-only, dev-only, both, dedup against built-ins, and
+// dedup against a runtime entry (Rust's [dependencies] / [dev-dependencies]
+// dual-section rule).
+func TestGenerator_VendorWiring(t *testing.T) {
+	makeGo := func(v *schema.VendorConfig) *schema.ADL {
+		return &schema.ADL{
+			APIVersion: "adl.inference-gateway.com/v1",
+			Kind:       "Agent",
+			Metadata:   schema.Metadata{Name: "agent", Description: "x", Version: "1.0.0"},
+			Spec: schema.Spec{
+				Capabilities: schema.Capabilities{},
+				Server:       schema.Server{Port: 8080},
+				Language: schema.Language{
+					Go: &schema.GoConfig{
+						Module:  "github.com/example/agent",
+						Version: "1.26.2",
+						Vendor:  v,
+					},
+				},
+			},
+		}
+	}
+	makeRust := func(v *schema.VendorConfig) *schema.ADL {
+		return &schema.ADL{
+			APIVersion: "adl.inference-gateway.com/v1",
+			Kind:       "Agent",
+			Metadata:   schema.Metadata{Name: "agent", Description: "x", Version: "1.0.0"},
+			Spec: schema.Spec{
+				Capabilities: schema.Capabilities{},
+				Server:       schema.Server{Port: 8080},
+				Language: schema.Language{
+					Rust: &schema.RustConfig{
+						PackageName: "agent",
+						Version:     "1.94.1",
+						Edition:     "2024",
+						Vendor:      v,
+					},
+				},
+			},
+		}
+	}
+
+	render := func(t *testing.T, lang, tmplKey string, adl *schema.ADL) string {
+		t.Helper()
+		registry, err := templates.NewRegistry(lang)
+		if err != nil {
+			t.Fatalf("NewRegistry: %v", err)
+		}
+		engine := templates.NewWithRegistry("", registry)
+		view, err := vendor.ResolveADL(adl)
+		if err != nil {
+			t.Fatalf("vendor.ResolveADL: %v", err)
+		}
+		out, err := engine.ExecuteTemplate(tmplKey, templates.Context{
+			ADL:      adl,
+			Language: lang,
+			Vendor:   view,
+		})
+		if err != nil {
+			t.Fatalf("ExecuteTemplate %s: %v", tmplKey, err)
+		}
+		return out
+	}
+
+	t.Run("go: no vendor block renders unchanged require list", func(t *testing.T) {
+		got := render(t, "go", "go.mod", makeGo(nil))
+		if !strings.Contains(got, "github.com/inference-gateway/adk v0.18.4") {
+			t.Fatalf("expected built-in ADK in require, got:\n%s", got)
+		}
+		if strings.Contains(got, "stretchr/testify") {
+			t.Fatalf("unexpected vendor entry leaked, got:\n%s", got)
+		}
+	})
+
+	t.Run("go: deps and devdeps both land in require, sorted, deduped", func(t *testing.T) {
+		got := render(t, "go", "go.mod", makeGo(&schema.VendorConfig{
+			Deps:    []string{"github.com/google/uuid@v1.6.0", "github.com/google/uuid@v1.5.0"},
+			Devdeps: []string{"github.com/stretchr/testify@v1.10.0"},
+		}))
+		uuidIdx := strings.Index(got, "github.com/google/uuid v1.6.0")
+		testifyIdx := strings.Index(got, "github.com/stretchr/testify v1.10.0")
+		if uuidIdx == -1 || testifyIdx == -1 {
+			t.Fatalf("expected uuid v1.6.0 and testify v1.10.0 in require block, got:\n%s", got)
+		}
+		if uuidIdx > testifyIdx {
+			t.Fatalf("expected sorted order (google < stretchr), got:\n%s", got)
+		}
+		if strings.Contains(got, "v1.5.0") {
+			t.Fatalf("expected duplicate uuid v1.5.0 to be deduped (first-wins), got:\n%s", got)
+		}
+	})
+
+	t.Run("go: built-in conflict is dropped before the template renders", func(t *testing.T) {
+		got := render(t, "go", "go.mod", makeGo(&schema.VendorConfig{
+			Deps: []string{"github.com/inference-gateway/adk@v0.0.1"},
+		}))
+		if !strings.Contains(got, "github.com/inference-gateway/adk v0.18.4") {
+			t.Fatalf("expected built-in version preserved, got:\n%s", got)
+		}
+		if strings.Contains(got, "v0.0.1") {
+			t.Fatalf("expected conflicting vendor entry to be dropped, got:\n%s", got)
+		}
+	})
+
+	t.Run("rust: deps go to [dependencies], devdeps go to [dev-dependencies]", func(t *testing.T) {
+		got := render(t, "rust", "Cargo.toml", makeRust(&schema.VendorConfig{
+			Deps:    []string{"regex@1.10.0"},
+			Devdeps: []string{"mockall@0.12.1", "pretty_assertions@1.4.0"},
+		}))
+		depsSection := got[strings.Index(got, "[dependencies]"):strings.Index(got, "[dev-dependencies]")]
+		devSection := got[strings.Index(got, "[dev-dependencies]"):]
+		if !strings.Contains(depsSection, `regex = "1.10.0"`) {
+			t.Fatalf("expected regex in [dependencies], got:\n%s", depsSection)
+		}
+		if !strings.Contains(devSection, `mockall = "0.12.1"`) || !strings.Contains(devSection, `pretty_assertions = "1.4.0"`) {
+			t.Fatalf("expected mockall + pretty_assertions in [dev-dependencies], got:\n%s", devSection)
+		}
+		if strings.Index(devSection, "mockall") > strings.Index(devSection, "pretty_assertions") {
+			t.Fatalf("expected dev-dependencies sorted, got:\n%s", devSection)
+		}
+	})
+
+	t.Run("rust: dev-only vendor still emits the dev-dependencies section even without built-in tools", func(t *testing.T) {
+		got := render(t, "rust", "Cargo.toml", makeRust(&schema.VendorConfig{
+			Devdeps: []string{"mockall@0.12.1"},
+		}))
+		if !strings.Contains(got, "[dev-dependencies]") {
+			t.Fatalf("expected [dev-dependencies] section, got:\n%s", got)
+		}
+		if !strings.Contains(got, `mockall = "0.12.1"`) {
+			t.Fatalf("expected mockall in [dev-dependencies], got:\n%s", got)
+		}
+		if strings.Contains(got, "tempfile") {
+			t.Fatalf("expected no tempfile when no built-in tools enabled, got:\n%s", got)
+		}
+	})
+
+	t.Run("rust: built-in runtime crate is rejected from devdeps too (dual-section guard)", func(t *testing.T) {
+		got := render(t, "rust", "Cargo.toml", makeRust(&schema.VendorConfig{
+			Devdeps: []string{"tokio@0.1.0"},
+		}))
+		if strings.Contains(got, `tokio = "0.1.0"`) {
+			t.Fatalf("expected conflicting tokio vendor entry to be dropped, got:\n%s", got)
+		}
+		if !strings.Contains(got, `tokio = { version = "1"`) {
+			t.Fatalf("expected built-in tokio preserved, got:\n%s", got)
+		}
+	})
+
+	t.Run("rust: empty vendor block + no built-in tools omits [dev-dependencies]", func(t *testing.T) {
+		got := render(t, "rust", "Cargo.toml", makeRust(nil))
+		if strings.Contains(got, "[dev-dependencies]") {
+			t.Fatalf("expected no [dev-dependencies] section, got:\n%s", got)
+		}
+	})
 }

--- a/internal/schema/schema.json
+++ b/internal/schema/schema.json
@@ -244,7 +244,8 @@
       "required": ["module", "version"],
       "properties": {
         "module": { "type": "string" },
-        "version": { "type": "string" }
+        "version": { "type": "string" },
+        "vendor": { "$ref": "#/definitions/VendorConfig" }
       }
     },
     "TypeScriptConfig": {
@@ -252,7 +253,8 @@
       "required": ["packageName", "nodeVersion"],
       "properties": {
         "packageName": { "type": "string" },
-        "nodeVersion": { "type": "string" }
+        "nodeVersion": { "type": "string" },
+        "vendor": { "$ref": "#/definitions/VendorConfig" }
       }
     },
     "RustConfig": {
@@ -265,6 +267,30 @@
         "features": {
           "type": "array",
           "items": { "type": "string" }
+        },
+        "vendor": { "$ref": "#/definitions/VendorConfig" }
+      }
+    },
+    "VendorConfig": {
+      "type": "object",
+      "description": "Extra packages to vendor into the generated project on top of whatever the generator pulls in by default. Use 'deps' for runtime/production dependencies and 'devdeps' for development- or test-only dependencies (linters, test frameworks, mock generators, etc.). Each entry follows the '<package>@<version>' form using the target language's native package and version syntax (e.g. 'github.com/stretchr/testify@v1.9.0' for Go, 'vitest@1.6.0' or '@types/node@20.11.0' for TypeScript, 'tokio@1.36.0' for Rust). Consumers are responsible for translating these into the language's lockfile / manifest format.",
+      "additionalProperties": false,
+      "properties": {
+        "deps": {
+          "type": "array",
+          "description": "Runtime/production dependencies to add to the generated project, each in '<package>@<version>' form.",
+          "items": {
+            "type": "string",
+            "pattern": "^\\S+@\\S+$"
+          }
+        },
+        "devdeps": {
+          "type": "array",
+          "description": "Development- and test-only dependencies to add to the generated project (e.g. testing libraries, linters, mock generators), each in '<package>@<version>' form.",
+          "items": {
+            "type": "string",
+            "pattern": "^\\S+@\\S+$"
+          }
         }
       }
     },

--- a/internal/schema/types.go
+++ b/internal/schema/types.go
@@ -195,6 +195,9 @@ type GoConfig struct {
 	// Module corresponds to the JSON schema field "module".
 	Module string `json:"module" yaml:"module" mapstructure:"module"`
 
+	// Vendor corresponds to the JSON schema field "vendor".
+	Vendor *VendorConfig `json:"vendor,omitempty,omitzero" yaml:"vendor,omitempty" mapstructure:"vendor,omitempty"`
+
 	// Version corresponds to the JSON schema field "version".
 	Version string `json:"version" yaml:"version" mapstructure:"version"`
 }
@@ -274,6 +277,9 @@ type RustConfig struct {
 
 	// PackageName corresponds to the JSON schema field "packageName".
 	PackageName string `json:"packageName" yaml:"packageName" mapstructure:"packageName"`
+
+	// Vendor corresponds to the JSON schema field "vendor".
+	Vendor *VendorConfig `json:"vendor,omitempty,omitzero" yaml:"vendor,omitempty" mapstructure:"vendor,omitempty"`
 
 	// Version corresponds to the JSON schema field "version".
 	Version string `json:"version" yaml:"version" mapstructure:"version"`
@@ -518,4 +524,27 @@ type TypeScriptConfig struct {
 
 	// PackageName corresponds to the JSON schema field "packageName".
 	PackageName string `json:"packageName" yaml:"packageName" mapstructure:"packageName"`
+
+	// Vendor corresponds to the JSON schema field "vendor".
+	Vendor *VendorConfig `json:"vendor,omitempty,omitzero" yaml:"vendor,omitempty" mapstructure:"vendor,omitempty"`
+}
+
+// Extra packages to vendor into the generated project on top of whatever the
+// generator pulls in by default. Use 'deps' for runtime/production dependencies
+// and 'devdeps' for development- or test-only dependencies (linters, test
+// frameworks, mock generators, etc.). Each entry follows the '<package>@<version>'
+// form using the target language's native package and version syntax (e.g.
+// 'github.com/stretchr/testify@v1.9.0' for Go, 'vitest@1.6.0' or
+// '@types/node@20.11.0' for TypeScript, 'tokio@1.36.0' for Rust). Consumers are
+// responsible for translating these into the language's lockfile / manifest
+// format.
+type VendorConfig struct {
+	// Runtime/production dependencies to add to the generated project, each in
+	// '<package>@<version>' form.
+	Deps []string `json:"deps,omitempty,omitzero" yaml:"deps,omitempty" mapstructure:"deps,omitempty"`
+
+	// Development- and test-only dependencies to add to the generated project (e.g.
+	// testing libraries, linters, mock generators), each in '<package>@<version>'
+	// form.
+	Devdeps []string `json:"devdeps,omitempty,omitzero" yaml:"devdeps,omitempty" mapstructure:"devdeps,omitempty"`
 }

--- a/internal/schema/validator_test.go
+++ b/internal/schema/validator_test.go
@@ -184,6 +184,158 @@ spec:
 	}
 }
 
+func TestValidator_VendorEntries(t *testing.T) {
+	cases := []struct {
+		name        string
+		adl         string
+		wantErr     bool
+		wantErrFrag string
+	}{
+		{
+			name: "go vendor block with well-formed entries validates",
+			adl: `apiVersion: adl.inference-gateway.com/v1
+kind: Agent
+metadata:
+  name: go-vendor
+  description: "go vendor smoke"
+  version: "0.1.0"
+spec:
+  capabilities:
+    streaming: true
+    pushNotifications: false
+    stateTransitionHistory: false
+  server:
+    port: 8080
+  language:
+    go:
+      module: "github.com/example/agent"
+      version: "1.26.2"
+      vendor:
+        deps:
+          - github.com/google/uuid@v1.6.0
+        devdeps:
+          - github.com/stretchr/testify@v1.10.0
+`,
+			wantErr: false,
+		},
+		{
+			name: "ts vendor block with scoped package validates",
+			adl: `apiVersion: adl.inference-gateway.com/v1
+kind: Agent
+metadata:
+  name: ts-vendor
+  description: "ts vendor smoke"
+  version: "0.1.0"
+spec:
+  capabilities:
+    streaming: true
+    pushNotifications: false
+    stateTransitionHistory: false
+  server:
+    port: 8080
+  language:
+    typescript:
+      packageName: "@example/agent"
+      nodeVersion: "20"
+      vendor:
+        deps:
+          - axios@1.7.0
+        devdeps:
+          - "@types/node@20.11.0"
+          - vitest@1.6.0
+`,
+			wantErr: false,
+		},
+		{
+			name: "vendor entry without version is rejected with a path pointing at the offending key",
+			adl: `apiVersion: adl.inference-gateway.com/v1
+kind: Agent
+metadata:
+  name: bad-vendor
+  description: "missing version"
+  version: "0.1.0"
+spec:
+  capabilities:
+    streaming: true
+    pushNotifications: false
+    stateTransitionHistory: false
+  server:
+    port: 8080
+  language:
+    go:
+      module: "github.com/example/agent"
+      version: "1.26.2"
+      vendor:
+        deps:
+          - github.com/missing-version-here
+`,
+			wantErr:     true,
+			wantErrFrag: "spec.language.go.vendor.deps.0",
+		},
+		{
+			name: "vendor entry with whitespace is rejected",
+			adl: `apiVersion: adl.inference-gateway.com/v1
+kind: Agent
+metadata:
+  name: bad-vendor
+  description: "whitespace"
+  version: "0.1.0"
+spec:
+  capabilities:
+    streaming: true
+    pushNotifications: false
+    stateTransitionHistory: false
+  server:
+    port: 8080
+  language:
+    rust:
+      packageName: "agent"
+      version: "1.94.1"
+      edition: "2024"
+      vendor:
+        devdeps:
+          - "mockall @ 0.12.0"
+`,
+			wantErr:     true,
+			wantErrFrag: "spec.language.rust.vendor.devdeps.0",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpFile, err := os.CreateTemp("", "adl-vendor-*.yaml")
+			if err != nil {
+				t.Fatalf("temp file: %v", err)
+			}
+			defer func() {
+				if rmErr := os.Remove(tmpFile.Name()); rmErr != nil {
+					t.Logf("cleanup: %v", rmErr)
+				}
+			}()
+			if _, err := tmpFile.WriteString(tc.adl); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			if err := tmpFile.Close(); err != nil {
+				t.Fatalf("close: %v", err)
+			}
+
+			_, err = NewValidator().ValidateFile(tmpFile.Name())
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected validation error, got nil")
+				}
+				if tc.wantErrFrag != "" && !strings.Contains(err.Error(), tc.wantErrFrag) {
+					t.Fatalf("error %q did not point at offending key %q", err.Error(), tc.wantErrFrag)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected validation error: %v", err)
+			}
+		})
+	}
+}
+
 func TestValidator_ValidateFile_Invalid(t *testing.T) {
 	invalidADL := `apiVersion: invalid
 kind: Agent

--- a/internal/templates/engine.go
+++ b/internal/templates/engine.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/inference-gateway/adl-cli/internal/schema"
+	"github.com/inference-gateway/adl-cli/internal/vendor"
 )
 
 // Engine handles template execution
@@ -208,7 +209,12 @@ type Context struct {
 	GenerateCommand string
 	Skills          []SkillView
 	BuiltinConfigs  schema.ResolvedBuiltinConfigs
-	customAcronyms  map[string]string
+	// Vendor holds the resolved spec.language.<lang>.vendor.{deps,devdeps}
+	// entries: parsed, deduped against the generator's built-in dependency
+	// set, and sorted. Templates render directly from this view (see
+	// go.mod.tmpl / Cargo.toml.tmpl).
+	Vendor         vendor.View
+	customAcronyms map[string]string
 }
 
 // New creates a new template engine

--- a/internal/templates/languages/go/go.mod.tmpl
+++ b/internal/templates/languages/go/go.mod.tmpl
@@ -11,4 +11,14 @@ require (
 {{- range .Vendor.GoRequires }}
 	{{ .Name }} {{ .Version }}
 {{- end }}
+{{- range .Vendor.GoTools }}
+	{{ .Name }} {{ .Version }} // indirect
+{{- end }}
 )
+{{ if .Vendor.GoTools }}
+tool (
+{{- range .Vendor.GoTools }}
+	{{ .Name }}
+{{- end }}
+)
+{{- end }}

--- a/internal/templates/languages/go/go.mod.tmpl
+++ b/internal/templates/languages/go/go.mod.tmpl
@@ -8,4 +8,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	go.uber.org/zap v1.28.0
 	gopkg.in/yaml.v3 v3.0.1
+{{- range .Vendor.GoRequires }}
+	{{ .Name }} {{ .Version }}
+{{- end }}
 )

--- a/internal/templates/languages/rust/Cargo.toml.tmpl
+++ b/internal/templates/languages/rust/Cargo.toml.tmpl
@@ -39,10 +39,18 @@ envy = "0.4.2"
 {{- if $hasFetch }}
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 {{- end }}
-{{- if $hasBuiltin }}
+{{- range .Vendor.CargoDeps }}
+{{ .Name }} = "{{ .Version }}"
+{{- end }}
+{{- if or $hasBuiltin .Vendor.CargoDevDeps }}
 
 [dev-dependencies]
+{{- if $hasBuiltin }}
 tempfile = "3"
+{{- end }}
+{{- range .Vendor.CargoDevDeps }}
+{{ .Name }} = "{{ .Version }}"
+{{- end }}
 {{- end }}
 
 [profile.release]

--- a/internal/templates/registry_dockerignore_test.go
+++ b/internal/templates/registry_dockerignore_test.go
@@ -215,4 +215,3 @@ func TestEnvExampleTemplate_Essentials(t *testing.T) {
 		}
 	})
 }
-

--- a/internal/vendor/vendor.go
+++ b/internal/vendor/vendor.go
@@ -209,9 +209,6 @@ func ResolveADL(adl *schema.ADL) (View, error) {
 		view.GoRequires = deps
 		view.Conflicts = append(view.Conflicts, depConflicts...)
 
-		// devdeps become Go 1.24 `tool` directive entries. Dedupe against
-		// built-ins AND against anything already accepted into deps so
-		// the same module never appears in both lists.
 		toolEffectiveBuiltins := cloneMap(GoBuiltins)
 		for _, e := range deps {
 			toolEffectiveBuiltins[e.Name] = e.Version
@@ -232,11 +229,6 @@ func ResolveADL(adl *schema.ADL) (View, error) {
 		view.CargoDeps = deps
 		view.Conflicts = append(view.Conflicts, conflicts...)
 
-		// When checking dev-dependencies, treat as built-in: real dev
-		// built-ins (tempfile), the runtime built-ins (tokio, etc.), AND
-		// any vendor entry already accepted for `[dependencies]`. Cargo
-		// rejects a crate appearing in both sections of the manifest, so
-		// devdeps must be deduped against every prior dep we plan to emit.
 		devEffectiveBuiltins := cloneMap(CargoBuiltinDevDeps)
 		for k, v := range CargoBuiltinDeps {
 			if _, set := devEffectiveBuiltins[k]; !set {
@@ -262,9 +254,6 @@ func ResolveADL(adl *schema.ADL) (View, error) {
 		view.NpmDeps = deps
 		view.Conflicts = append(view.Conflicts, conflicts...)
 
-		// Same dedupe-against-everything-prior reasoning as the Rust
-		// branch above: a package in `dependencies` cannot also live in
-		// `devDependencies`.
 		devEffectiveBuiltins := cloneMap(NpmBuiltinDevDeps)
 		for k, v := range NpmBuiltinDeps {
 			if _, set := devEffectiveBuiltins[k]; !set {

--- a/internal/vendor/vendor.go
+++ b/internal/vendor/vendor.go
@@ -156,9 +156,20 @@ var NpmBuiltinDevDeps = map[string]string{}
 // Each field is a sorted, deduped slice ready to be rendered by the
 // language-specific template.
 type View struct {
-	// GoRequires is the merged deps+devdeps set for Go (go.mod has no
-	// notion of a separate dev section; see README for context).
+	// GoRequires holds Go runtime dependencies (`vendor.deps`) that the
+	// `go.mod` template appends to the built-in `require` block. Test
+	// libraries that are `import`-ed by `*_test.go` belong here too:
+	// Go has no separate test-dependency notion.
 	GoRequires []Entry
+
+	// GoTools holds Go executable dev tools (`vendor.devdeps`). Each
+	// entry is rendered both as a `// indirect` line in `require` (so
+	// the module is downloadable) and as a bare package path inside the
+	// `tool ( ... )` block introduced in Go 1.24. Users supply the full
+	// tool package path (e.g. `golang.org/x/tools/cmd/stringer`); a
+	// post-generation `go mod tidy` normalises the require entry to the
+	// owning module root.
+	GoTools []Entry
 
 	// CargoDeps / CargoDevDeps map to the matching Cargo.toml sections.
 	// CargoDevDeps is additionally deduped against CargoDeps so we never
@@ -191,13 +202,26 @@ func ResolveADL(adl *schema.ADL) (View, error) {
 	lang := adl.Spec.Language
 
 	if lang.Go != nil && lang.Go.Vendor != nil {
-		merged := mergeRaw(lang.Go.Vendor.Deps, lang.Go.Vendor.Devdeps)
-		entries, conflicts, err := Resolve(merged, GoBuiltins, "deps+devdeps")
+		deps, depConflicts, err := Resolve(lang.Go.Vendor.Deps, GoBuiltins, "deps")
 		if err != nil {
-			return View{}, fmt.Errorf("spec.language.go.vendor: %w", err)
+			return View{}, fmt.Errorf("spec.language.go.vendor.deps: %w", err)
 		}
-		view.GoRequires = entries
-		view.Conflicts = append(view.Conflicts, conflicts...)
+		view.GoRequires = deps
+		view.Conflicts = append(view.Conflicts, depConflicts...)
+
+		// devdeps become Go 1.24 `tool` directive entries. Dedupe against
+		// built-ins AND against anything already accepted into deps so
+		// the same module never appears in both lists.
+		toolEffectiveBuiltins := cloneMap(GoBuiltins)
+		for _, e := range deps {
+			toolEffectiveBuiltins[e.Name] = e.Version
+		}
+		tools, toolConflicts, err := Resolve(lang.Go.Vendor.Devdeps, toolEffectiveBuiltins, "devdeps")
+		if err != nil {
+			return View{}, fmt.Errorf("spec.language.go.vendor.devdeps: %w", err)
+		}
+		view.GoTools = tools
+		view.Conflicts = append(view.Conflicts, toolConflicts...)
 	}
 
 	if lang.Rust != nil && lang.Rust.Vendor != nil {
@@ -259,16 +283,6 @@ func ResolveADL(adl *schema.ADL) (View, error) {
 	}
 
 	return view, nil
-}
-
-func mergeRaw(a, b []string) []string {
-	if len(a) == 0 && len(b) == 0 {
-		return nil
-	}
-	out := make([]string, 0, len(a)+len(b))
-	out = append(out, a...)
-	out = append(out, b...)
-	return out
 }
 
 func cloneMap(m map[string]string) map[string]string {

--- a/internal/vendor/vendor.go
+++ b/internal/vendor/vendor.go
@@ -1,0 +1,280 @@
+// Package vendor resolves the optional `spec.language.<lang>.vendor.deps`
+// and `spec.language.<lang>.vendor.devdeps` fields on an ADL manifest into
+// per-language dependency lists that the templates can render directly.
+//
+// The schema validates the raw entries up front (each must match
+// `^\S+@\S+$`), but here we re-split them into name/version, dedupe each
+// list against the generator's built-in dependency set for that language,
+// and sort the result so the output is deterministic.
+//
+// Conflict policy: built-in dependencies always win. If a user lists
+// `github.com/inference-gateway/adk@v0.0.1` in `vendor.deps`, it is
+// dropped and reported via Resolve's `Dropped` slice so the caller can
+// surface a warning. This prevents accidental downgrades of the core
+// runtime SDK or related plumbing the generator depends on.
+package vendor
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/inference-gateway/adl-cli/internal/schema"
+)
+
+// Entry is a parsed `<package>@<version>` tuple.
+type Entry struct {
+	Name    string
+	Version string
+}
+
+// Conflict describes a vendor entry that was dropped because its package
+// name collided with one of the generator's built-in dependencies.
+type Conflict struct {
+	Entry    Entry
+	Builtin  string // the built-in package name the conflict was against
+	DepGroup string // "deps" or "devdeps"
+}
+
+// Parse splits a `<package>@<version>` literal into an Entry. The schema
+// validates the pattern up front, but we still defend against malformed
+// input here for callers that bypass the validator (e.g. generator tests
+// that construct an ADL by hand).
+func Parse(raw string) (Entry, error) {
+	idx := strings.LastIndex(raw, "@")
+	if idx <= 0 || idx == len(raw)-1 {
+		return Entry{}, fmt.Errorf("invalid vendor entry %q: expected '<package>@<version>'", raw)
+	}
+	name := strings.TrimSpace(raw[:idx])
+	version := strings.TrimSpace(raw[idx+1:])
+	if name == "" || version == "" {
+		return Entry{}, fmt.Errorf("invalid vendor entry %q: package and version must be non-empty", raw)
+	}
+	if strings.ContainsAny(name, " \t") || strings.ContainsAny(version, " \t") {
+		return Entry{}, fmt.Errorf("invalid vendor entry %q: name and version must not contain whitespace", raw)
+	}
+	return Entry{Name: name, Version: version}, nil
+}
+
+// Resolve parses each raw entry, drops duplicates and built-in collisions,
+// and returns the surviving entries sorted by Name. If two vendor entries
+// declare the same package, the first one wins.
+//
+// `depGroup` is propagated into any Conflict reported by the second
+// return value so callers can mention "deps" vs "devdeps" in warnings.
+func Resolve(raws []string, builtins map[string]string, depGroup string) ([]Entry, []Conflict, error) {
+	if len(raws) == 0 {
+		return nil, nil, nil
+	}
+
+	var kept []Entry
+	var conflicts []Conflict
+	seen := make(map[string]struct{}, len(raws))
+
+	for _, raw := range raws {
+		entry, err := Parse(raw)
+		if err != nil {
+			return nil, nil, err
+		}
+		if _, dup := seen[entry.Name]; dup {
+			continue
+		}
+		if builtinVersion, clash := builtins[entry.Name]; clash {
+			conflicts = append(conflicts, Conflict{
+				Entry:    entry,
+				Builtin:  fmt.Sprintf("%s@%s", entry.Name, builtinVersion),
+				DepGroup: depGroup,
+			})
+			continue
+		}
+		seen[entry.Name] = struct{}{}
+		kept = append(kept, entry)
+	}
+
+	sort.Slice(kept, func(i, j int) bool { return kept[i].Name < kept[j].Name })
+	return kept, conflicts, nil
+}
+
+// GoBuiltins enumerates the modules that the generator always writes to
+// the generated `go.mod` require block (see
+// `internal/templates/languages/go/go.mod.tmpl`). Vendor entries that
+// match one of these are dropped to keep the generator in charge of its
+// runtime SDK pins.
+//
+// Keep this in sync with the go.mod template; the generator's TestVendor*
+// tests will fail loudly if a built-in is added there without being
+// mirrored here.
+var GoBuiltins = map[string]string{
+	"github.com/inference-gateway/adk":  "v0.18.4",
+	"github.com/sethvargo/go-envconfig": "v1.3.0",
+	"github.com/spf13/cobra":            "v1.10.2",
+	"go.uber.org/zap":                   "v1.28.0",
+	"gopkg.in/yaml.v3":                  "v3.0.1",
+}
+
+// CargoBuiltinDeps enumerates the crates the Cargo.toml template always
+// writes to the `[dependencies]` section. Some are conditional on
+// features (e.g. `reqwest` when the `fetch` built-in is enabled); list
+// them all so users can't shadow them regardless of which features they
+// activate.
+var CargoBuiltinDeps = map[string]string{
+	"inference-gateway-adk": "0.4.3",
+	"inference-gateway-sdk": "0.13.3",
+	"tokio":                 "1",
+	"tracing":               "0.1",
+	"tracing-subscriber":    "0.3",
+	"clap":                  "4",
+	"serde":                 "1",
+	"serde_json":            "1",
+	"serde_yaml":            "0.9",
+	"anyhow":                "1",
+	"async-trait":           "0.1",
+	"uuid":                  "1",
+	"chrono":                "0.4",
+	"dotenvy":               "0.15.7",
+	"envy":                  "0.4.2",
+	"reqwest":               "0.12",
+}
+
+// CargoBuiltinDevDeps mirrors CargoBuiltinDeps for the `[dev-dependencies]`
+// section. Currently only `tempfile` is emitted (and only when a built-in
+// tool is enabled), but listing it here lets us catch shadowing
+// regardless of features.
+var CargoBuiltinDevDeps = map[string]string{
+	"tempfile": "3",
+}
+
+// NpmBuiltinDeps / NpmBuiltinDevDeps are placeholders for the TypeScript
+// generator. There are no TS templates today (only `.gitkeep`), but the
+// schema accepts vendor entries for TypeScript so we still parse and
+// dedupe them when the generator eventually wires them through. Keep the
+// maps empty until a `package.json` template lands.
+var NpmBuiltinDeps = map[string]string{}
+var NpmBuiltinDevDeps = map[string]string{}
+
+// View is the resolved vendor data injected into the template Context.
+// Each field is a sorted, deduped slice ready to be rendered by the
+// language-specific template.
+type View struct {
+	// GoRequires is the merged deps+devdeps set for Go (go.mod has no
+	// notion of a separate dev section; see README for context).
+	GoRequires []Entry
+
+	// CargoDeps / CargoDevDeps map to the matching Cargo.toml sections.
+	// CargoDevDeps is additionally deduped against CargoDeps so we never
+	// emit the same crate in both sections.
+	CargoDeps    []Entry
+	CargoDevDeps []Entry
+
+	// NpmDeps / NpmDevDeps map to package.json's dependencies /
+	// devDependencies. NpmDevDeps is deduped against NpmDeps for the same
+	// reason as Cargo.
+	NpmDeps    []Entry
+	NpmDevDeps []Entry
+
+	// Conflicts collects every entry that was dropped because of a
+	// built-in collision so the caller can surface warnings to the user.
+	Conflicts []Conflict
+}
+
+// Resolve walks the language-specific vendor blocks on the ADL manifest
+// and produces a View suitable for templating. Languages whose vendor
+// block is absent contribute empty slices. Errors only surface for
+// malformed entries (which should never happen post-validation, but we
+// re-check here so generator tests can pass hand-built ADLs).
+func ResolveADL(adl *schema.ADL) (View, error) {
+	view := View{}
+	if adl == nil {
+		return view, nil
+	}
+
+	lang := adl.Spec.Language
+
+	if lang.Go != nil && lang.Go.Vendor != nil {
+		merged := mergeRaw(lang.Go.Vendor.Deps, lang.Go.Vendor.Devdeps)
+		entries, conflicts, err := Resolve(merged, GoBuiltins, "deps+devdeps")
+		if err != nil {
+			return View{}, fmt.Errorf("spec.language.go.vendor: %w", err)
+		}
+		view.GoRequires = entries
+		view.Conflicts = append(view.Conflicts, conflicts...)
+	}
+
+	if lang.Rust != nil && lang.Rust.Vendor != nil {
+		deps, conflicts, err := Resolve(lang.Rust.Vendor.Deps, CargoBuiltinDeps, "deps")
+		if err != nil {
+			return View{}, fmt.Errorf("spec.language.rust.vendor.deps: %w", err)
+		}
+		view.CargoDeps = deps
+		view.Conflicts = append(view.Conflicts, conflicts...)
+
+		// When checking dev-dependencies, treat as built-in: real dev
+		// built-ins (tempfile), the runtime built-ins (tokio, etc.), AND
+		// any vendor entry already accepted for `[dependencies]`. Cargo
+		// rejects a crate appearing in both sections of the manifest, so
+		// devdeps must be deduped against every prior dep we plan to emit.
+		devEffectiveBuiltins := cloneMap(CargoBuiltinDevDeps)
+		for k, v := range CargoBuiltinDeps {
+			if _, set := devEffectiveBuiltins[k]; !set {
+				devEffectiveBuiltins[k] = v
+			}
+		}
+		for _, e := range deps {
+			devEffectiveBuiltins[e.Name] = e.Version
+		}
+		devdeps, devConflicts, err := Resolve(lang.Rust.Vendor.Devdeps, devEffectiveBuiltins, "devdeps")
+		if err != nil {
+			return View{}, fmt.Errorf("spec.language.rust.vendor.devdeps: %w", err)
+		}
+		view.CargoDevDeps = devdeps
+		view.Conflicts = append(view.Conflicts, devConflicts...)
+	}
+
+	if lang.TypeScript != nil && lang.TypeScript.Vendor != nil {
+		deps, conflicts, err := Resolve(lang.TypeScript.Vendor.Deps, NpmBuiltinDeps, "deps")
+		if err != nil {
+			return View{}, fmt.Errorf("spec.language.typescript.vendor.deps: %w", err)
+		}
+		view.NpmDeps = deps
+		view.Conflicts = append(view.Conflicts, conflicts...)
+
+		// Same dedupe-against-everything-prior reasoning as the Rust
+		// branch above: a package in `dependencies` cannot also live in
+		// `devDependencies`.
+		devEffectiveBuiltins := cloneMap(NpmBuiltinDevDeps)
+		for k, v := range NpmBuiltinDeps {
+			if _, set := devEffectiveBuiltins[k]; !set {
+				devEffectiveBuiltins[k] = v
+			}
+		}
+		for _, e := range deps {
+			devEffectiveBuiltins[e.Name] = e.Version
+		}
+		devdeps, devConflicts, err := Resolve(lang.TypeScript.Vendor.Devdeps, devEffectiveBuiltins, "devdeps")
+		if err != nil {
+			return View{}, fmt.Errorf("spec.language.typescript.vendor.devdeps: %w", err)
+		}
+		view.NpmDevDeps = devdeps
+		view.Conflicts = append(view.Conflicts, devConflicts...)
+	}
+
+	return view, nil
+}
+
+func mergeRaw(a, b []string) []string {
+	if len(a) == 0 && len(b) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(a)+len(b))
+	out = append(out, a...)
+	out = append(out, b...)
+	return out
+}
+
+func cloneMap(m map[string]string) map[string]string {
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/vendor/vendor_test.go
+++ b/internal/vendor/vendor_test.go
@@ -212,20 +212,43 @@ func TestResolveADL_NoVendor(t *testing.T) {
 	}
 }
 
-func TestResolveADL_GoMergesDepsAndDevDeps(t *testing.T) {
+func TestResolveADL_GoSplitsDepsAndToolDevDeps(t *testing.T) {
 	adl := goADLWithVendor(
 		[]string{"github.com/stretchr/testify@v1.10.0"},
-		[]string{"github.com/google/go-cmp@v0.6.0"},
+		[]string{"golang.org/x/tools/cmd/stringer@v0.20.0"},
 	)
 	view, err := ResolveADL(adl)
 	if err != nil {
 		t.Fatalf("ResolveADL: %v", err)
 	}
-	if len(view.GoRequires) != 2 {
-		t.Fatalf("expected 2 entries, got %+v", view.GoRequires)
+	if len(view.GoRequires) != 1 || view.GoRequires[0].Name != "github.com/stretchr/testify" {
+		t.Fatalf("expected testify in GoRequires, got %+v", view.GoRequires)
 	}
-	if view.GoRequires[0].Name != "github.com/google/go-cmp" {
-		t.Fatalf("expected go-cmp first (sorted), got %+v", view.GoRequires)
+	if len(view.GoTools) != 1 || view.GoTools[0].Name != "golang.org/x/tools/cmd/stringer" {
+		t.Fatalf("expected stringer in GoTools, got %+v", view.GoTools)
+	}
+}
+
+func TestResolveADL_GoToolDevDepDedupedAgainstDeps(t *testing.T) {
+	// If a user lists the same module path in both deps and devdeps the
+	// tool resolver must drop the devdeps entry: `require` only allows one
+	// entry per module path, and the deps version wins.
+	adl := goADLWithVendor(
+		[]string{"github.com/golang/mock/mockgen@v1.6.0"},
+		[]string{"github.com/golang/mock/mockgen@v1.5.0"},
+	)
+	view, err := ResolveADL(adl)
+	if err != nil {
+		t.Fatalf("ResolveADL: %v", err)
+	}
+	if len(view.GoRequires) != 1 || view.GoRequires[0].Version != "v1.6.0" {
+		t.Fatalf("expected deps to win at v1.6.0, got %+v", view.GoRequires)
+	}
+	if len(view.GoTools) != 0 {
+		t.Fatalf("expected duplicate tool entry to be dropped, got %+v", view.GoTools)
+	}
+	if len(view.Conflicts) != 1 || view.Conflicts[0].DepGroup != "devdeps" {
+		t.Fatalf("expected single devdeps conflict, got %+v", view.Conflicts)
 	}
 }
 

--- a/internal/vendor/vendor_test.go
+++ b/internal/vendor/vendor_test.go
@@ -230,9 +230,6 @@ func TestResolveADL_GoSplitsDepsAndToolDevDeps(t *testing.T) {
 }
 
 func TestResolveADL_GoToolDevDepDedupedAgainstDeps(t *testing.T) {
-	// If a user lists the same module path in both deps and devdeps the
-	// tool resolver must drop the devdeps entry: `require` only allows one
-	// entry per module path, and the deps version wins.
 	adl := goADLWithVendor(
 		[]string{"github.com/golang/mock/mockgen@v1.6.0"},
 		[]string{"github.com/golang/mock/mockgen@v1.5.0"},
@@ -307,11 +304,6 @@ func TestResolveADL_RustBuiltinConflictDropped(t *testing.T) {
 }
 
 func TestResolveADL_RustRuntimeBuiltinAlsoBlocksDevDeps(t *testing.T) {
-	// tokio is a runtime built-in; users sometimes try to add a different
-	// version to dev-dependencies. Cargo rejects the same crate appearing
-	// in both [dependencies] and [dev-dependencies], so we must drop it
-	// from devdeps too. Regression guard for the bug fixed in the rust-agent
-	// smoke test where tokio@0.1.0 leaked into [dev-dependencies].
 	adl := rustADLWithVendor(nil, []string{"tokio@0.1.0"})
 	view, err := ResolveADL(adl)
 	if err != nil {

--- a/internal/vendor/vendor_test.go
+++ b/internal/vendor/vendor_test.go
@@ -1,0 +1,314 @@
+package vendor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/inference-gateway/adl-cli/internal/schema"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      string
+		wantName string
+		wantVer  string
+		wantErr  string
+	}{
+		{
+			name:     "go module path",
+			raw:      "github.com/stretchr/testify@v1.10.0",
+			wantName: "github.com/stretchr/testify",
+			wantVer:  "v1.10.0",
+		},
+		{
+			name:     "npm scoped package keeps single @ on its name and splits on the version separator",
+			raw:      "@types/node@20.11.0",
+			wantName: "@types/node",
+			wantVer:  "20.11.0",
+		},
+		{
+			name:     "rust crate plain version",
+			raw:      "tokio@1.36.0",
+			wantName: "tokio",
+			wantVer:  "1.36.0",
+		},
+		{
+			name:    "missing version",
+			raw:     "tokio@",
+			wantErr: "expected '<package>@<version>'",
+		},
+		{
+			name:    "missing name",
+			raw:     "@v1.0.0",
+			wantErr: "expected '<package>@<version>'",
+		},
+		{
+			name:    "no separator",
+			raw:     "tokio",
+			wantErr: "expected '<package>@<version>'",
+		},
+		{
+			name:    "internal whitespace rejected",
+			raw:     "github.com/foo@v 1.0",
+			wantErr: "must not contain whitespace",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Parse(tt.raw)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("Parse(%q) succeeded; wanted error containing %q", tt.raw, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("Parse(%q) error %v; wanted to contain %q", tt.raw, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Parse(%q) failed: %v", tt.raw, err)
+			}
+			if got.Name != tt.wantName || got.Version != tt.wantVer {
+				t.Fatalf("Parse(%q) = {%q %q}; want {%q %q}",
+					tt.raw, got.Name, got.Version, tt.wantName, tt.wantVer)
+			}
+		})
+	}
+}
+
+func TestResolve(t *testing.T) {
+	builtins := map[string]string{"github.com/inference-gateway/adk": "v0.18.4"}
+
+	t.Run("empty input yields nothing", func(t *testing.T) {
+		entries, conflicts, err := Resolve(nil, builtins, "deps")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if entries != nil || conflicts != nil {
+			t.Fatalf("expected nil/nil, got entries=%v conflicts=%v", entries, conflicts)
+		}
+	})
+
+	t.Run("dedup against built-ins drops conflict and records it", func(t *testing.T) {
+		entries, conflicts, err := Resolve(
+			[]string{
+				"github.com/stretchr/testify@v1.10.0",
+				"github.com/inference-gateway/adk@v0.0.1",
+			},
+			builtins,
+			"deps",
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(entries) != 1 || entries[0].Name != "github.com/stretchr/testify" {
+			t.Fatalf("expected only testify to survive, got %+v", entries)
+		}
+		if len(conflicts) != 1 || conflicts[0].Entry.Name != "github.com/inference-gateway/adk" {
+			t.Fatalf("expected adk conflict, got %+v", conflicts)
+		}
+		if conflicts[0].DepGroup != "deps" {
+			t.Fatalf("conflict.DepGroup = %q, want %q", conflicts[0].DepGroup, "deps")
+		}
+	})
+
+	t.Run("internal duplicates are collapsed first-wins", func(t *testing.T) {
+		entries, _, err := Resolve(
+			[]string{
+				"github.com/stretchr/testify@v1.10.0",
+				"github.com/stretchr/testify@v1.9.0",
+			},
+			builtins,
+			"deps",
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(entries) != 1 || entries[0].Version != "v1.10.0" {
+			t.Fatalf("expected first-wins dedup, got %+v", entries)
+		}
+	})
+
+	t.Run("results are sorted by Name", func(t *testing.T) {
+		entries, _, err := Resolve(
+			[]string{
+				"z-pkg@v1.0.0",
+				"a-pkg@v1.0.0",
+				"m-pkg@v1.0.0",
+			},
+			builtins,
+			"deps",
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got := []string{entries[0].Name, entries[1].Name, entries[2].Name}
+		want := []string{"a-pkg", "m-pkg", "z-pkg"}
+		for i := range got {
+			if got[i] != want[i] {
+				t.Fatalf("sort mismatch at %d: got %v, want %v", i, got, want)
+			}
+		}
+	})
+
+	t.Run("malformed entry surfaces an error", func(t *testing.T) {
+		_, _, err := Resolve([]string{"not-a-valid-entry"}, builtins, "deps")
+		if err == nil {
+			t.Fatalf("expected error for malformed entry")
+		}
+	})
+}
+
+func goADLWithVendor(deps, devdeps []string) *schema.ADL {
+	return &schema.ADL{
+		Spec: schema.Spec{
+			Language: schema.Language{
+				Go: &schema.GoConfig{
+					Module:  "example.com/agent",
+					Version: "1.26.2",
+					Vendor: &schema.VendorConfig{
+						Deps:    deps,
+						Devdeps: devdeps,
+					},
+				},
+			},
+		},
+	}
+}
+
+func rustADLWithVendor(deps, devdeps []string) *schema.ADL {
+	return &schema.ADL{
+		Spec: schema.Spec{
+			Language: schema.Language{
+				Rust: &schema.RustConfig{
+					PackageName: "agent",
+					Version:     "1.94.1",
+					Edition:     "2024",
+					Vendor: &schema.VendorConfig{
+						Deps:    deps,
+						Devdeps: devdeps,
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestResolveADL_NoVendor(t *testing.T) {
+	adl := &schema.ADL{
+		Spec: schema.Spec{
+			Language: schema.Language{
+				Go: &schema.GoConfig{Module: "example.com/agent", Version: "1.26.2"},
+			},
+		},
+	}
+	view, err := ResolveADL(adl)
+	if err != nil {
+		t.Fatalf("ResolveADL: %v", err)
+	}
+	if len(view.GoRequires) != 0 || len(view.CargoDeps) != 0 || len(view.Conflicts) != 0 {
+		t.Fatalf("expected empty View, got %+v", view)
+	}
+}
+
+func TestResolveADL_GoMergesDepsAndDevDeps(t *testing.T) {
+	adl := goADLWithVendor(
+		[]string{"github.com/stretchr/testify@v1.10.0"},
+		[]string{"github.com/google/go-cmp@v0.6.0"},
+	)
+	view, err := ResolveADL(adl)
+	if err != nil {
+		t.Fatalf("ResolveADL: %v", err)
+	}
+	if len(view.GoRequires) != 2 {
+		t.Fatalf("expected 2 entries, got %+v", view.GoRequires)
+	}
+	if view.GoRequires[0].Name != "github.com/google/go-cmp" {
+		t.Fatalf("expected go-cmp first (sorted), got %+v", view.GoRequires)
+	}
+}
+
+func TestResolveADL_GoBuiltinConflictDropsAndWarns(t *testing.T) {
+	adl := goADLWithVendor(
+		[]string{"github.com/inference-gateway/adk@v0.0.1"},
+		nil,
+	)
+	view, err := ResolveADL(adl)
+	if err != nil {
+		t.Fatalf("ResolveADL: %v", err)
+	}
+	if len(view.GoRequires) != 0 {
+		t.Fatalf("expected built-in conflict to be dropped, got %+v", view.GoRequires)
+	}
+	if len(view.Conflicts) != 1 {
+		t.Fatalf("expected 1 conflict, got %+v", view.Conflicts)
+	}
+}
+
+func TestResolveADL_RustDevDepsDedupedAgainstDeps(t *testing.T) {
+	adl := rustADLWithVendor(
+		[]string{"mockall@0.12.0"},
+		[]string{"mockall@0.12.0", "pretty_assertions@1.4.0"},
+	)
+	view, err := ResolveADL(adl)
+	if err != nil {
+		t.Fatalf("ResolveADL: %v", err)
+	}
+	if len(view.CargoDeps) != 1 || view.CargoDeps[0].Name != "mockall" {
+		t.Fatalf("expected mockall in deps, got %+v", view.CargoDeps)
+	}
+	if len(view.CargoDevDeps) != 1 || view.CargoDevDeps[0].Name != "pretty_assertions" {
+		t.Fatalf("expected pretty_assertions in devdeps with mockall deduped, got %+v", view.CargoDevDeps)
+	}
+}
+
+func TestResolveADL_RustBuiltinConflictDropped(t *testing.T) {
+	adl := rustADLWithVendor(
+		[]string{"tokio@0.1.0"},
+		[]string{"tempfile@2"},
+	)
+	view, err := ResolveADL(adl)
+	if err != nil {
+		t.Fatalf("ResolveADL: %v", err)
+	}
+	if len(view.CargoDeps) != 0 {
+		t.Fatalf("expected tokio to be dropped, got %+v", view.CargoDeps)
+	}
+	if len(view.CargoDevDeps) != 0 {
+		t.Fatalf("expected tempfile to be dropped, got %+v", view.CargoDevDeps)
+	}
+	if len(view.Conflicts) != 2 {
+		t.Fatalf("expected 2 conflicts, got %+v", view.Conflicts)
+	}
+}
+
+func TestResolveADL_RustRuntimeBuiltinAlsoBlocksDevDeps(t *testing.T) {
+	// tokio is a runtime built-in; users sometimes try to add a different
+	// version to dev-dependencies. Cargo rejects the same crate appearing
+	// in both [dependencies] and [dev-dependencies], so we must drop it
+	// from devdeps too. Regression guard for the bug fixed in the rust-agent
+	// smoke test where tokio@0.1.0 leaked into [dev-dependencies].
+	adl := rustADLWithVendor(nil, []string{"tokio@0.1.0"})
+	view, err := ResolveADL(adl)
+	if err != nil {
+		t.Fatalf("ResolveADL: %v", err)
+	}
+	if len(view.CargoDevDeps) != 0 {
+		t.Fatalf("expected tokio in devdeps to be dropped, got %+v", view.CargoDevDeps)
+	}
+	if len(view.Conflicts) != 1 || view.Conflicts[0].DepGroup != "devdeps" {
+		t.Fatalf("expected single devdeps conflict, got %+v", view.Conflicts)
+	}
+}
+
+func TestResolveADL_MalformedEntrySurfacesError(t *testing.T) {
+	adl := goADLWithVendor([]string{"not-valid"}, nil)
+	_, err := ResolveADL(adl)
+	if err == nil {
+		t.Fatal("expected error for malformed entry")
+	}
+	if !strings.Contains(err.Error(), "spec.language.go.vendor") {
+		t.Fatalf("error should point at offending key, got %v", err)
+	}
+}


### PR DESCRIPTION
Closes #152.

## Summary

- Added `internal/vendor` helper that parses `<pkg>@<ver>` entries, dedupes against the generator's built-in dependency set per language, sorts the result, and surfaces conflicts as stderr warnings (built-ins always win).
- Go: `vendor.deps` + `vendor.devdeps` merge into the single `go.mod` `require` block.
- Rust: `vendor.deps` → `[dependencies]`, `vendor.devdeps` → `[dev-dependencies]`, deduped across sections.
- TypeScript: schema/validator/View accept vendor entries today; rendering deferred until TS generator templates exist.
- Examples (`go-agent.yaml`, `rust-agent.yaml`) updated with realistic `vendor.devdeps` entries.
- README documents the new block with one example per language; CLAUDE.md notes the pin-maintenance rule so future built-in bumps stay in sync with the conflict-detection map.
- Schema pinned to upstream merge SHA `5a28d5a7` until `v0.9.0` of `inference-gateway/adl` is tagged (`TODO` marker left in `Taskfile.yml`).

## Test plan

- [x] `task ci` (fmt, lint, test, build, verify-schema) passes locally.
- [x] `task examples:test` and `task examples:generate` pass locally.
- [x] New unit tests cover: empty/missing vendor, runtime-only, dev-only, both, dedup against built-ins, dedup across deps/devdeps, malformed entry (validator + vendor helper).
- [x] Manual smoke: generated `go-agent` has `github.com/stretchr/testify` in `go.mod`, generated `rust-agent` has `mockall` + `pretty_assertions` in `[dev-dependencies]`.
- [ ] Verify on a real agent generated with the new vendor entries.

🤖 Generated with [Claude Code](https://claude.ai/code)