### PR TITLE
feat(sandbox): Honor spec.development.deps when generating sandbox configs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,13 +198,13 @@ Merge policy is **additive**: the template's built-in toolchain
 and user `deps` are appended on top. If a user entry's package name
 collides with one of these built-ins (e.g. `git@2.53.0`), the
 generator prints a `⚠️  spec.development.deps … collides with a Flox
-built-in …` warning to stderr but still renders the user entry — the
+built-in …` warning to stderr but still renders the user entry - the
 maintainer's pin wins on version conflict. The conflict-detection
 map lives in `internal/sandbox/deps.go` (`floxBuiltinPackages` /
 `devcontainerBuiltinPackages`); keep them in sync if you add new
 packages to the sandbox templates.
 
-`dockerCompose` is out of scope for now — the docker-compose dev image
+`dockerCompose` is out of scope for now - the docker-compose dev image
 doesn't consume `spec.development.deps`. Tracked in issue #154.
 
 ## Adding a New Language

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,8 @@ main.go                       # Entry point, sets version
     │   ├── frontmatter.go   # YAML frontmatter parser for skill markdown
     │   ├── installer.go     # GitHub-source skill installer (trees API + raw.githubusercontent.com)
     │   └── resolver.go      # Coordinates fetch/cache/scaffold for skills
+    ├── sandbox/             # Resolver for spec.development.deps (sandbox-level extras)
+    │   └── deps.go          # Parse/dedupe/sort `<pkg>@<ver>` entries, flag flox/devcontainer conflicts
     ├── schema/              # ADL schema definitions
     │   ├── types.go         # All ADL type definitions (ADL, Spec, Tool, Skill, etc.)
     │   └── validator.go     # JSON Schema validation
@@ -78,7 +80,7 @@ main.go                       # Entry point, sets version
 
 - `ADL` - Root structure with `apiVersion`, `kind`, `metadata`, `spec`
 - `Spec` - Contains `capabilities`, `agent`, `tools`, `skills`, `services`, `server`, `language`, `deployment`, `development`
-- `DevelopmentConfig` - Local development experience under `spec.development`: `sandbox` (flox/devcontainer/dockerCompose) and `ai` (CLAUDE.md/AGENTS.md generation). Introduced in ADL v0.6.0 - previously these sat directly under `spec`.
+- `DevelopmentConfig` - Local development experience under `spec.development`: `sandbox` (flox/devcontainer/dockerCompose), `ai` (CLAUDE.md/AGENTS.md generation), and `deps` (cross-cutting sandbox-level extras like `deno`, `kubectl`, `terraform`). Introduced in ADL v0.6.0 (sandbox+ai); `deps` added in ADL v0.10.0.
 - `Tool` - Function-call entrypoint with `id` (only `id` is required since v0.4.0). User-defined tools also set `name`, `description`, `tags`, `schema`, optional `inject`. Reserved IDs (`read`, `bash`, `write`, `edit`) take `id` alone - the generator owns metadata. See `internal/schema/builtin_config.go` for the reserved-ID set.
 - `Skill` - Markdown playbook with `id` plus optional `version`/`source`/`bare`/`name`/`description`/`tags`/`license`. Generated as `skills/<id>/SKILL.md`. **At runtime, only the frontmatter is consumed** - the body lives on disk and the model reads it on demand via the `Read` built-in. `license` accepts the SPDX identifiers enumerated in the schema (`MIT`, `Apache-2.0`, `BSD-2-Clause`, `BSD-3-Clause`, `GPL-2.0`, `GPL-3.0`, `LGPL-2.1`, `LGPL-3.0`, `MPL-2.0`, `ISC`, `CC0-1.0`, `CC-BY-4.0`, `CC-BY-SA-4.0`, `Unlicense`) plus `Proprietary` for closed-source skills. The resolver mirrors it into the generated `SKILL.md` frontmatter so the licence travels with the playbook; when both the ADL entry and the fetched frontmatter set `license`, the ADL value wins.
 - `Service` - Injectable service with `interface`, `factory`, `description`
@@ -174,6 +176,36 @@ go-cmp, …) belong in `vendor.deps`, not `vendor.devdeps`.
 When you update a built-in dependency in a language template, mirror the
 new pin into the matching map in `internal/vendor/vendor.go` so vendor
 conflicts continue to be caught.
+
+### Sandbox extras (`spec.development.deps`)
+
+`spec.development.deps` is the cross-cutting equivalent of
+`vendor.deps` - same `<package>@<version>` shape, but resolved into the
+sandbox manifests instead of `go.mod` / `Cargo.toml`. Entries are parsed
+by `internal/sandbox`, deduped (first wins), sorted alphabetically, and
+exposed on `templates.Context.SandboxDeps`. Two backends render from
+this view today:
+
+- **flox** - each entry appends `<pkg>.pkg-path = "<pkg>"` /
+  `<pkg>.version = "<version>"` lines under `[install]` in
+  `.flox/env/manifest.toml`. Resolved against Nixpkgs.
+- **devcontainer** - all entries are joined into a single
+  `ghcr.io/devcontainers-extra/features/apt-packages:1` feature entry
+  with a comma-separated `<pkg>=<version>` list.
+
+Merge policy is **additive**: the template's built-in toolchain
+(`go`/`cargo`/`nodejs`, `git`, `docker`, `go-task`) is always emitted,
+and user `deps` are appended on top. If a user entry's package name
+collides with one of these built-ins (e.g. `git@2.53.0`), the
+generator prints a `⚠️  spec.development.deps … collides with a Flox
+built-in …` warning to stderr but still renders the user entry — the
+maintainer's pin wins on version conflict. The conflict-detection
+map lives in `internal/sandbox/deps.go` (`floxBuiltinPackages` /
+`devcontainerBuiltinPackages`); keep them in sync if you add new
+packages to the sandbox templates.
+
+`dockerCompose` is out of scope for now — the docker-compose dev image
+doesn't consume `spec.development.deps`. Tracked in issue #154.
 
 ## Adding a New Language
 

--- a/README.md
+++ b/README.md
@@ -717,7 +717,7 @@ stay stable on re-run. Duplicate package names inside `deps` are deduped
 (first occurrence wins on version). When a `deps` entry's package name
 collides with one of the template's built-ins (e.g. `git@2.53.0`), the
 generator prints a `⚠️  spec.development.deps … collides with a Flox
-built-in …` warning to stderr but still renders the user entry — the
+built-in …` warning to stderr but still renders the user entry - the
 maintainer's pin wins on version conflict.
 
 **Output mapping per backend:**
@@ -731,7 +731,7 @@ maintainer's pin wins on version conflict.
 If a package isn't published under its short attribute path in Nixpkgs,
 or isn't available as an apt package on the devcontainer base image,
 add the file to your project's `.adl-ignore` and hand-author the
-override — this is the same escape hatch we use for any sandbox file
+override - this is the same escape hatch we use for any sandbox file
 the template can't infer.
 
 Worked example per backend:

--- a/README.md
+++ b/README.md
@@ -685,6 +685,86 @@ spec:
           - vitest@1.6.0
 ```
 
+### Extra sandbox dependencies (`spec.development.deps`)
+
+`spec.development.deps` is the cross-cutting equivalent of the per-language
+`vendor.deps` block above: it lets you install tools into the development
+sandbox (Flox, devcontainer) that don't belong to any single language's
+package manager. Use it for things like `deno`, `kubectl`, `terraform`,
+`awscli`, or any other CLI you want available inside the dev shell. Each
+entry follows the `<package>@<version>` shape, validated up front by the
+schema (`^\S+@\S+$`).
+
+```yaml
+spec:
+  development:
+    sandbox:
+      flox:
+        enabled: true
+      devcontainer:
+        enabled: true
+    deps:
+      - deno@2.1.4
+      - kubectl@1.31.0
+      - terraform@1.9.5
+```
+
+**Merge semantics:** additive. The per-language toolchain that each
+sandbox template already installs (`go`/`cargo`/`nodejs`, plus `git`,
+`docker`, `go-task`) is always emitted; `spec.development.deps` entries
+are appended on top, sorted alphabetically so the generated file diffs
+stay stable on re-run. Duplicate package names inside `deps` are deduped
+(first occurrence wins on version). When a `deps` entry's package name
+collides with one of the template's built-ins (e.g. `git@2.53.0`), the
+generator prints a `⚠️  spec.development.deps … collides with a Flox
+built-in …` warning to stderr but still renders the user entry — the
+maintainer's pin wins on version conflict.
+
+**Output mapping per backend:**
+
+| Backend         | Generated file                  | Per-entry rendering                                                                                                                                                            |
+| --------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `flox`          | `.flox/env/manifest.toml`       | A pair of TOML lines under `[install]`: `<pkg>.pkg-path = "<pkg>"` / `<pkg>.version = "<version>"`. Resolved against Nixpkgs at activation time.                               |
+| `devcontainer`  | `.devcontainer/devcontainer.json` | Added to the `features` block as `ghcr.io/devcontainers-extra/features/apt-packages:1` with the comma-joined `<pkg>=<version>` list. Resolution is best-effort against apt.    |
+| `dockerCompose` | _(out of scope for this release; see issue #154)_ | n/a                                                                                                                                                                            |
+
+If a package isn't published under its short attribute path in Nixpkgs,
+or isn't available as an apt package on the devcontainer base image,
+add the file to your project's `.adl-ignore` and hand-author the
+override — this is the same escape hatch we use for any sandbox file
+the template can't infer.
+
+Worked example per backend:
+
+```yaml
+# Flox: pin deno + kubectl + terraform alongside the Go toolchain
+spec:
+  language:
+    go: { module: github.com/example/agent, version: "1.26.2" }
+  development:
+    sandbox:
+      flox:
+        enabled: true
+    deps:
+      - deno@2.1.4
+      - kubectl@1.31.0
+      - terraform@1.9.5
+```
+
+```yaml
+# Devcontainer: same deps, rendered as an apt-packages feature
+spec:
+  language:
+    go: { module: github.com/example/agent, version: "1.26.2" }
+  development:
+    sandbox:
+      devcontainer:
+        enabled: true
+    deps:
+      - deno@2.1.4
+      - kubectl@1.31.0
+```
+
 ## Skills vs. Tools
 
 The ADL spec distinguishes two complementary concepts:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -6,7 +6,7 @@ vars:
   VERSION: 0.37.0
   BUILD_DIR: bin
   DIST_DIR: dist
-  ADL_SCHEMA_VERSION: v0.9.0
+  ADL_SCHEMA_VERSION: v0.10.0
   ADL_SCHEMA_URL: https://raw.githubusercontent.com/inference-gateway/adl/{{.ADL_SCHEMA_VERSION}}/schema/v1/schema.json
   ADL_SCHEMA_PATH: internal/schema/schema.json
 

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -351,12 +351,12 @@ func (g *Generator) generateProject(templateEngine *templates.Engine, adl *schem
 	}
 	for _, c := range sandboxView.FloxConflicts {
 		fmt.Fprintf(os.Stderr,
-			"⚠️  spec.development.deps entry %s@%s collides with a Flox built-in (%s); the user entry is rendered in addition to the template default — review the generated .flox/env/manifest.toml\n",
+			"⚠️  spec.development.deps entry %s@%s collides with a Flox built-in (%s); the user entry is rendered in addition to the template default - review the generated .flox/env/manifest.toml\n",
 			c.Entry.Name, c.Entry.Version, c.Builtin)
 	}
 	for _, c := range sandboxView.DevContainerConflicts {
 		fmt.Fprintf(os.Stderr,
-			"⚠️  spec.development.deps entry %s@%s collides with a devcontainer built-in (%s); the user entry is still emitted — review the generated .devcontainer/devcontainer.json\n",
+			"⚠️  spec.development.deps entry %s@%s collides with a devcontainer built-in (%s); the user entry is still emitted - review the generated .devcontainer/devcontainer.json\n",
 			c.Entry.Name, c.Entry.Version, c.Builtin)
 	}
 

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/inference-gateway/adl-cli/internal/registry"
+	"github.com/inference-gateway/adl-cli/internal/sandbox"
 	"github.com/inference-gateway/adl-cli/internal/schema"
 	"github.com/inference-gateway/adl-cli/internal/templates"
 	"github.com/inference-gateway/adl-cli/internal/vendor"
@@ -344,6 +345,21 @@ func (g *Generator) generateProject(templateEngine *templates.Engine, adl *schem
 			c.DepGroup, c.Entry.Name, c.Entry.Version, c.Builtin)
 	}
 
+	sandboxView, err := sandbox.Resolve(adl)
+	if err != nil {
+		return fmt.Errorf("failed to resolve sandbox deps: %w", err)
+	}
+	for _, c := range sandboxView.FloxConflicts {
+		fmt.Fprintf(os.Stderr,
+			"⚠️  spec.development.deps entry %s@%s collides with a Flox built-in (%s); the user entry is rendered in addition to the template default — review the generated .flox/env/manifest.toml\n",
+			c.Entry.Name, c.Entry.Version, c.Builtin)
+	}
+	for _, c := range sandboxView.DevContainerConflicts {
+		fmt.Fprintf(os.Stderr,
+			"⚠️  spec.development.deps entry %s@%s collides with a devcontainer built-in (%s); the user entry is still emitted — review the generated .devcontainer/devcontainer.json\n",
+			c.Entry.Name, c.Entry.Version, c.Builtin)
+	}
+
 	ctx := templates.Context{
 		ADL: adl,
 		Metadata: schema.GeneratedMetadata{
@@ -360,6 +376,7 @@ func (g *Generator) generateProject(templateEngine *templates.Engine, adl *schem
 		Skills:          skillViews,
 		BuiltinConfigs:  builtinConfigs,
 		Vendor:          vendorView,
+		SandboxDeps:     sandboxView,
 	}
 
 	ignoreChecker, err := NewIgnoreChecker(outputDir)

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/inference-gateway/adl-cli/internal/schema"
 	"github.com/inference-gateway/adl-cli/internal/templates"
 	"github.com/inference-gateway/adl-cli/internal/vendor"
+	"gopkg.in/yaml.v3"
 )
 
 func TestGenerator_Generate(t *testing.T) {
@@ -1081,4 +1082,163 @@ func TestGenerator_VendorWiring(t *testing.T) {
 			t.Fatalf("expected no [dev-dependencies] section, got:\n%s", got)
 		}
 	})
+}
+
+// TestGenerator_SandboxDevelopmentDeps exercises the end-to-end pipeline
+// from a manifest with spec.development.deps through generator.Generate()
+// to the on-disk .flox/env/manifest.toml and .devcontainer/devcontainer.json.
+// This is the acceptance-criteria flox test from issue #154: "Tests cover
+// at least the flox path end-to-end (manifest -> generated manifest.toml)."
+func TestGenerator_SandboxDevelopmentDeps(t *testing.T) {
+	adl := &schema.ADL{
+		APIVersion: "adl.inference-gateway.com/v1",
+		Kind:       "Agent",
+		Metadata: schema.Metadata{
+			Name:        "deps-agent",
+			Description: "tests spec.development.deps wiring",
+			Version:     "1.0.0",
+		},
+		Spec: schema.Spec{
+			Capabilities: schema.Capabilities{},
+			Server:       schema.Server{Port: 8080},
+			Language: schema.Language{
+				Go: &schema.GoConfig{
+					Module:  "github.com/example/deps-agent",
+					Version: "1.26.2",
+				},
+			},
+			Development: &schema.DevelopmentConfig{
+				Sandbox: &schema.SandboxConfig{
+					Flox:         &schema.FloxConfig{Enabled: true},
+					DevContainer: &schema.DevContainerConfig{Enabled: true},
+				},
+				Deps: []string{
+					"deno@2.1.4",
+					"kubectl@1.31.0",
+					"terraform@1.9.5",
+				},
+			},
+		},
+	}
+
+	tmpDir, err := os.MkdirTemp("", "adl-sandbox-deps-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	adlPath := filepath.Join(tmpDir, "agent.yaml")
+	writeYAML(t, adlPath, adl)
+
+	outDir := filepath.Join(tmpDir, "out")
+	gen := New(Config{Template: "minimal", Overwrite: true, Version: "test"})
+	if err := gen.Generate(adlPath, outDir); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	manifestBytes, err := os.ReadFile(filepath.Join(outDir, ".flox", "env", "manifest.toml"))
+	if err != nil {
+		t.Fatalf("read manifest.toml: %v", err)
+	}
+	manifest := string(manifestBytes)
+	for _, frag := range []string{
+		`deno.pkg-path = "deno"`,
+		`deno.version = "2.1.4"`,
+		`kubectl.pkg-path = "kubectl"`,
+		`kubectl.version = "1.31.0"`,
+		`terraform.pkg-path = "terraform"`,
+		`terraform.version = "1.9.5"`,
+	} {
+		if !strings.Contains(manifest, frag) {
+			t.Errorf("manifest.toml missing %q\n---\n%s", frag, manifest)
+		}
+	}
+
+	devcontainerBytes, err := os.ReadFile(filepath.Join(outDir, ".devcontainer", "devcontainer.json"))
+	if err != nil {
+		t.Fatalf("read devcontainer.json: %v", err)
+	}
+	devcontainer := string(devcontainerBytes)
+	if !strings.Contains(devcontainer, "apt-packages") {
+		t.Errorf("devcontainer.json missing apt-packages feature\n---\n%s", devcontainer)
+	}
+	for _, want := range []string{"deno=2.1.4", "kubectl=1.31.0", "terraform=1.9.5"} {
+		if !strings.Contains(devcontainer, want) {
+			t.Errorf("devcontainer.json missing %q\n---\n%s", want, devcontainer)
+		}
+	}
+}
+
+// TestGenerator_SandboxDevelopmentDeps_AbsentIsNoop verifies that the
+// generated manifest.toml and devcontainer.json look identical to a
+// pre-feature build when spec.development.deps is absent. Guards the
+// "Behavior is unchanged when the field is absent or empty." AC.
+func TestGenerator_SandboxDevelopmentDeps_AbsentIsNoop(t *testing.T) {
+	adl := &schema.ADL{
+		APIVersion: "adl.inference-gateway.com/v1",
+		Kind:       "Agent",
+		Metadata: schema.Metadata{
+			Name:        "no-deps-agent",
+			Description: "no spec.development.deps",
+			Version:     "1.0.0",
+		},
+		Spec: schema.Spec{
+			Capabilities: schema.Capabilities{},
+			Server:       schema.Server{Port: 8080},
+			Language: schema.Language{
+				Go: &schema.GoConfig{Module: "github.com/example/x", Version: "1.26.2"},
+			},
+			Development: &schema.DevelopmentConfig{
+				Sandbox: &schema.SandboxConfig{
+					Flox:         &schema.FloxConfig{Enabled: true},
+					DevContainer: &schema.DevContainerConfig{Enabled: true},
+				},
+			},
+		},
+	}
+
+	tmpDir, err := os.MkdirTemp("", "adl-sandbox-deps-absent-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	adlPath := filepath.Join(tmpDir, "agent.yaml")
+	writeYAML(t, adlPath, adl)
+
+	outDir := filepath.Join(tmpDir, "out")
+	gen := New(Config{Template: "minimal", Overwrite: true, Version: "test"})
+	if err := gen.Generate(adlPath, outDir); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	manifestBytes, err := os.ReadFile(filepath.Join(outDir, ".flox", "env", "manifest.toml"))
+	if err != nil {
+		t.Fatalf("read manifest.toml: %v", err)
+	}
+	if strings.Contains(string(manifestBytes), "spec.development.deps") {
+		t.Fatalf("manifest.toml leaked spec.development.deps banner when no deps declared\n---\n%s", manifestBytes)
+	}
+
+	devcontainerBytes, err := os.ReadFile(filepath.Join(outDir, ".devcontainer", "devcontainer.json"))
+	if err != nil {
+		t.Fatalf("read devcontainer.json: %v", err)
+	}
+	if strings.Contains(string(devcontainerBytes), "apt-packages") {
+		t.Fatalf("devcontainer.json leaked apt-packages feature when no deps declared\n---\n%s", devcontainerBytes)
+	}
+}
+
+// writeYAML is a tiny helper to serialise an ADL struct out to a file
+// for the end-to-end Generate() tests. We use yaml.v3 directly so we
+// don't have to depend on a separate fixtures package.
+func writeYAML(t *testing.T, path string, adl *schema.ADL) {
+	t.Helper()
+	data, err := yaml.Marshal(adl)
+	if err != nil {
+		t.Fatalf("yaml.Marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
 }

--- a/internal/sandbox/deps.go
+++ b/internal/sandbox/deps.go
@@ -1,0 +1,183 @@
+// Package sandbox resolves the optional `spec.development.deps` field on
+// an ADL manifest into a deterministic, deduped list of sandbox-level
+// extra packages that the templates can render directly.
+//
+// `spec.development.deps` is the cross-cutting equivalent of
+// `spec.language.<lang>.vendor.deps`: each entry is a `<package>@<version>`
+// literal (validated by the JSON schema as `^\S+@\S+$`) that the user
+// wants installed inside whichever sandbox backend they've enabled
+// (Flox, devcontainer, or docker-compose dev image - the last is out of
+// scope for now). Unlike the language-vendor blocks, the generator has
+// no built-ins for the sandbox layer beyond the per-language toolchain
+// already baked into each template (Go/Cargo/Node + git + docker +
+// go-task), so the merge policy is straightforward additive: built-in
+// template entries always render; user `deps` are appended on top.
+// Duplicates inside the user list are kept once (first occurrence
+// wins); collisions with the built-in template list are flagged via
+// the Conflicts slice so the caller can surface a warning, but the
+// user entry is still rendered (the template lays the built-in down at
+// a fixed version, and the user-pinned entry replaces nothing - they
+// would coexist in the manifest and Flox/devcontainer would resolve the
+// later definition).
+//
+// We deliberately reuse the per-language `<package>@<version>` shape
+// rather than inventing a backend-specific syntax (e.g. Nix attribute
+// paths for Flox) because the schema is shared across consumers and
+// each backend can translate the literal in its own template. Flox
+// turns `<pkg>@<ver>` into `pkg.pkg-path = "pkg"` / `pkg.version = "ver"`;
+// devcontainer renders `pkg=ver` apt-style entries.
+package sandbox
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/inference-gateway/adl-cli/internal/schema"
+)
+
+// Entry is a parsed `<package>@<version>` tuple for a sandbox-level
+// extra dependency.
+type Entry struct {
+	Name    string
+	Version string
+}
+
+// Conflict describes a user `deps` entry whose package name collides
+// with one of the generator's built-in sandbox packages (the toolchain
+// the per-language template always installs - `go`, `cargo`, `git`,
+// `docker`, `go-task`, ...). The conflict is reported so the caller
+// can warn, but the user entry is NOT dropped: the user explicitly
+// asked for a specific version, and we honour that.
+type Conflict struct {
+	Entry   Entry
+	Builtin string // the built-in package name the conflict was against
+}
+
+// Parse splits a `<package>@<version>` literal into an Entry. The schema
+// validates the pattern up front, but we still defend against malformed
+// input here for callers that bypass the validator (e.g. generator
+// tests that construct an ADL by hand).
+func Parse(raw string) (Entry, error) {
+	idx := strings.LastIndex(raw, "@")
+	if idx <= 0 || idx == len(raw)-1 {
+		return Entry{}, fmt.Errorf("invalid sandbox dep %q: expected '<package>@<version>'", raw)
+	}
+	name := strings.TrimSpace(raw[:idx])
+	version := strings.TrimSpace(raw[idx+1:])
+	if name == "" || version == "" {
+		return Entry{}, fmt.Errorf("invalid sandbox dep %q: package and version must be non-empty", raw)
+	}
+	if strings.ContainsAny(name, " \t") || strings.ContainsAny(version, " \t") {
+		return Entry{}, fmt.Errorf("invalid sandbox dep %q: name and version must not contain whitespace", raw)
+	}
+	return Entry{Name: name, Version: version}, nil
+}
+
+// floxBuiltinPackages enumerates the packages that the Flox manifest
+// template always installs (see
+// `internal/templates/sandbox/flox/manifest.toml.tmpl`). Used to flag -
+// but not drop - collisions with user `spec.development.deps`.
+//
+// Keep this in sync with the manifest template. The order doesn't
+// matter; it's only used for membership lookup.
+var floxBuiltinPackages = map[string]struct{}{
+	"go":            {},
+	"golangci-lint": {},
+	"cargo":         {},
+	"rustc":         {},
+	"clippy":        {},
+	"rustfmt":       {},
+	"rust-analyzer": {},
+	"nodejs_24":     {},
+	"go-task":       {},
+	"git":           {},
+	"docker":        {},
+	"claude-code":   {},
+	"adl":           {},
+}
+
+// devcontainerBuiltinPackages enumerates the well-known features the
+// devcontainer template always provisions. The Devcontainer Features
+// model is feature-id-keyed (not package-name-keyed), so collisions are
+// rare; we only flag the most common shorthand matches here so users
+// who type `git@2.53.0` get a helpful warning that git is already
+// installed by the base image.
+//
+// Keep this in sync with `internal/templates/sandbox/devcontainer/devcontainer.json.tmpl`.
+var devcontainerBuiltinPackages = map[string]struct{}{
+	"git":              {},
+	"docker":           {},
+	"docker-in-docker": {},
+}
+
+// View is the resolved sandbox deps data injected into the template
+// Context. The slice is deduped (first occurrence wins) and sorted by
+// Name so output is deterministic across runs.
+type View struct {
+	// Deps holds the user-declared extra sandbox packages, parsed and
+	// sorted. Always non-nil for the templates' `range` clause; empty
+	// when `spec.development.deps` is absent.
+	Deps []Entry
+
+	// FloxConflicts collects entries whose package name collides with
+	// the Flox manifest template's built-in package list. Each entry
+	// is still rendered (user entries win on version conflict); the
+	// generator surfaces a warning so the user knows the template
+	// pin and the user pin will both appear in the generated
+	// manifest.toml.
+	FloxConflicts []Conflict
+
+	// DevContainerConflicts mirrors FloxConflicts for the devcontainer
+	// backend. Only the most common shorthand collisions (git, docker)
+	// are flagged - the Devcontainer Features model is feature-id-keyed
+	// so most user entries won't clash.
+	DevContainerConflicts []Conflict
+}
+
+// HasDeps reports whether the view carries any user-declared deps.
+// Templates use this to decide whether to render the optional block.
+func (v View) HasDeps() bool {
+	return len(v.Deps) > 0
+}
+
+// Resolve walks `adl.Spec.Development.Deps`, parses each entry,
+// dedupes by package name (first wins), sorts the result, and flags
+// collisions with the per-backend built-in package lists. Returns an
+// empty View (no error) when the ADL or its development block is nil
+// or when `deps` is empty.
+func Resolve(adl *schema.ADL) (View, error) {
+	view := View{}
+	if adl == nil || adl.Spec.Development == nil || len(adl.Spec.Development.Deps) == 0 {
+		return view, nil
+	}
+
+	var kept []Entry
+	seen := make(map[string]struct{}, len(adl.Spec.Development.Deps))
+
+	for _, raw := range adl.Spec.Development.Deps {
+		entry, err := Parse(raw)
+		if err != nil {
+			return View{}, fmt.Errorf("spec.development.deps: %w", err)
+		}
+		if _, dup := seen[entry.Name]; dup {
+			continue
+		}
+		seen[entry.Name] = struct{}{}
+		kept = append(kept, entry)
+	}
+
+	sort.Slice(kept, func(i, j int) bool { return kept[i].Name < kept[j].Name })
+	view.Deps = kept
+
+	for _, e := range kept {
+		if _, clash := floxBuiltinPackages[e.Name]; clash {
+			view.FloxConflicts = append(view.FloxConflicts, Conflict{Entry: e, Builtin: e.Name})
+		}
+		if _, clash := devcontainerBuiltinPackages[e.Name]; clash {
+			view.DevContainerConflicts = append(view.DevContainerConflicts, Conflict{Entry: e, Builtin: e.Name})
+		}
+	}
+
+	return view, nil
+}

--- a/internal/sandbox/deps_test.go
+++ b/internal/sandbox/deps_test.go
@@ -1,0 +1,209 @@
+package sandbox
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/inference-gateway/adl-cli/internal/schema"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    Entry
+		wantErr bool
+	}{
+		{
+			name: "simple",
+			raw:  "deno@2.1.4",
+			want: Entry{Name: "deno", Version: "2.1.4"},
+		},
+		{
+			name: "kubectl with x.y.z",
+			raw:  "kubectl@1.31.0",
+			want: Entry{Name: "kubectl", Version: "1.31.0"},
+		},
+		{
+			name:    "missing version",
+			raw:     "deno@",
+			wantErr: true,
+		},
+		{
+			name:    "missing name",
+			raw:     "@1.0.0",
+			wantErr: true,
+		},
+		{
+			name:    "no at sign",
+			raw:     "deno-2.1.4",
+			wantErr: true,
+		},
+		{
+			name:    "embedded whitespace in name",
+			raw:     "foo bar@2.1.4",
+			wantErr: true,
+		},
+		{
+			name:    "embedded whitespace in version",
+			raw:     "foo@2.1 4",
+			wantErr: true,
+		},
+		{
+			name: "version with at sign uses last",
+			raw:  "@org/pkg@1.0.0",
+			want: Entry{Name: "@org/pkg", Version: "1.0.0"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Parse(tc.raw)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("Parse(%q) err=%v wantErr=%v", tc.raw, err, tc.wantErr)
+			}
+			if tc.wantErr {
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("Parse(%q) = %#v, want %#v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolve_NilOrEmpty(t *testing.T) {
+	cases := []struct {
+		name string
+		adl  *schema.ADL
+	}{
+		{name: "nil adl", adl: nil},
+		{name: "no development", adl: &schema.ADL{}},
+		{
+			name: "development without deps",
+			adl: &schema.ADL{
+				Spec: schema.Spec{Development: &schema.DevelopmentConfig{}},
+			},
+		},
+		{
+			name: "empty deps slice",
+			adl: &schema.ADL{
+				Spec: schema.Spec{Development: &schema.DevelopmentConfig{Deps: []string{}}},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := Resolve(tc.adl)
+			if err != nil {
+				t.Fatalf("Resolve: %v", err)
+			}
+			if v.HasDeps() {
+				t.Fatalf("expected empty deps, got %#v", v.Deps)
+			}
+			if len(v.FloxConflicts) != 0 || len(v.DevContainerConflicts) != 0 {
+				t.Fatalf("expected no conflicts, got flox=%v devcontainer=%v", v.FloxConflicts, v.DevContainerConflicts)
+			}
+		})
+	}
+}
+
+func TestResolve_DedupesAndSorts(t *testing.T) {
+	adl := &schema.ADL{
+		Spec: schema.Spec{
+			Development: &schema.DevelopmentConfig{
+				Deps: []string{
+					"terraform@1.9.5",
+					"deno@2.1.4",
+					"kubectl@1.31.0",
+					"deno@2.0.0", // duplicate package name - first wins
+				},
+			},
+		},
+	}
+
+	v, err := Resolve(adl)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	want := []Entry{
+		{Name: "deno", Version: "2.1.4"},
+		{Name: "kubectl", Version: "1.31.0"},
+		{Name: "terraform", Version: "1.9.5"},
+	}
+	if !reflect.DeepEqual(v.Deps, want) {
+		t.Fatalf("Resolve deps = %#v, want %#v", v.Deps, want)
+	}
+}
+
+func TestResolve_FloxConflict(t *testing.T) {
+	adl := &schema.ADL{
+		Spec: schema.Spec{
+			Development: &schema.DevelopmentConfig{
+				Deps: []string{
+					"git@2.53.0",   // clashes with built-in
+					"deno@2.1.4",   // safe
+					"go-task@3.50", // clashes with built-in
+				},
+			},
+		},
+	}
+
+	v, err := Resolve(adl)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	if len(v.Deps) != 3 {
+		t.Fatalf("expected all 3 deps preserved (conflicts warn but don't drop), got %d", len(v.Deps))
+	}
+
+	conflictNames := make(map[string]bool, len(v.FloxConflicts))
+	for _, c := range v.FloxConflicts {
+		conflictNames[c.Entry.Name] = true
+	}
+	if !conflictNames["git"] || !conflictNames["go-task"] {
+		t.Fatalf("expected git and go-task to flag flox conflicts, got %v", conflictNames)
+	}
+	if conflictNames["deno"] {
+		t.Fatalf("did not expect deno to flag a flox conflict")
+	}
+}
+
+func TestResolve_DevContainerConflict(t *testing.T) {
+	adl := &schema.ADL{
+		Spec: schema.Spec{
+			Development: &schema.DevelopmentConfig{
+				Deps: []string{"git@2.53.0", "kubectl@1.31.0"},
+			},
+		},
+	}
+
+	v, err := Resolve(adl)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	if len(v.DevContainerConflicts) != 1 {
+		t.Fatalf("expected exactly one devcontainer conflict (git), got %d", len(v.DevContainerConflicts))
+	}
+	if v.DevContainerConflicts[0].Entry.Name != "git" {
+		t.Fatalf("expected git devcontainer conflict, got %q", v.DevContainerConflicts[0].Entry.Name)
+	}
+}
+
+func TestResolve_MalformedEntry(t *testing.T) {
+	adl := &schema.ADL{
+		Spec: schema.Spec{
+			Development: &schema.DevelopmentConfig{
+				Deps: []string{"valid@1.0", "broken-without-at"},
+			},
+		},
+	}
+
+	if _, err := Resolve(adl); err == nil {
+		t.Fatalf("expected error for malformed entry, got nil")
+	}
+}

--- a/internal/sandbox/deps_test.go
+++ b/internal/sandbox/deps_test.go
@@ -117,7 +117,7 @@ func TestResolve_DedupesAndSorts(t *testing.T) {
 					"terraform@1.9.5",
 					"deno@2.1.4",
 					"kubectl@1.31.0",
-					"deno@2.0.0", // duplicate package name - first wins
+					"deno@2.0.0",
 				},
 			},
 		},
@@ -143,9 +143,9 @@ func TestResolve_FloxConflict(t *testing.T) {
 		Spec: schema.Spec{
 			Development: &schema.DevelopmentConfig{
 				Deps: []string{
-					"git@2.53.0",   // clashes with built-in
-					"deno@2.1.4",   // safe
-					"go-task@3.50", // clashes with built-in
+					"git@2.53.0",
+					"deno@2.1.4",
+					"go-task@3.50",
 				},
 			},
 		},

--- a/internal/schema/schema.json
+++ b/internal/schema/schema.json
@@ -327,10 +327,18 @@
     },
     "DevelopmentConfig": {
       "type": "object",
-      "description": "Local development experience for the agent: sandboxed dev environments (flox, devcontainer, dockerCompose) and AI-assistant integration (CLAUDE.md/AGENTS.md generation, claude-code provisioning).",
+      "description": "Local development experience for the agent: sandboxed dev environments (flox, devcontainer, dockerCompose), AI-assistant integration (CLAUDE.md/AGENTS.md generation, claude-code provisioning), and extra sandbox-level dependencies (deps) for tools that don't belong to any single language's package manager (e.g. deno, kubectl, terraform).",
       "properties": {
         "sandbox": { "$ref": "#/definitions/SandboxConfig" },
-        "ai": { "$ref": "#/definitions/AIConfig" }
+        "ai": { "$ref": "#/definitions/AIConfig" },
+        "deps": {
+          "type": "array",
+          "description": "Extra packages to install into the development sandbox (flox, devcontainer, dockerCompose) on top of whatever the generator pulls in by default. Use this for cross-cutting tools that aren't tied to one of the project's languages — e.g. 'deno@2.1.4', 'kubectl@1.31.0', 'terraform@1.9.5'. Each entry follows the '<package>@<version>' form; consumers are responsible for resolving the package against the sandbox's native package source (Nixpkgs for flox, apt/apk/feature for devcontainer, image layers for dockerCompose).",
+          "items": {
+            "type": "string",
+            "pattern": "^\\S+@\\S+$"
+          }
+        }
       }
     },
     "SandboxConfig": {

--- a/internal/schema/types.go
+++ b/internal/schema/types.go
@@ -165,11 +165,22 @@ type DevContainerConfig struct {
 }
 
 // Local development experience for the agent: sandboxed dev environments (flox,
-// devcontainer, dockerCompose) and AI-assistant integration (CLAUDE.md/AGENTS.md
-// generation, claude-code provisioning).
+// devcontainer, dockerCompose), AI-assistant integration (CLAUDE.md/AGENTS.md
+// generation, claude-code provisioning), and extra sandbox-level dependencies
+// (deps) for tools that don't belong to any single language's package manager
+// (e.g. deno, kubectl, terraform).
 type DevelopmentConfig struct {
 	// AI corresponds to the JSON schema field "ai".
 	AI *AIConfig `json:"ai,omitempty,omitzero" yaml:"ai,omitempty" mapstructure:"ai,omitempty"`
+
+	// Extra packages to install into the development sandbox (flox, devcontainer,
+	// dockerCompose) on top of whatever the generator pulls in by default. Use this
+	// for cross-cutting tools that aren't tied to one of the project's languages —
+	// e.g. 'deno@2.1.4', 'kubectl@1.31.0', 'terraform@1.9.5'. Each entry follows the
+	// '<package>@<version>' form; consumers are responsible for resolving the package
+	// against the sandbox's native package source (Nixpkgs for flox, apt/apk/feature
+	// for devcontainer, image layers for dockerCompose).
+	Deps []string `json:"deps,omitempty,omitzero" yaml:"deps,omitempty" mapstructure:"deps,omitempty"`
 
 	// Sandbox corresponds to the JSON schema field "sandbox".
 	Sandbox *SandboxConfig `json:"sandbox,omitempty,omitzero" yaml:"sandbox,omitempty" mapstructure:"sandbox,omitempty"`

--- a/internal/templates/engine.go
+++ b/internal/templates/engine.go
@@ -11,6 +11,7 @@ import (
 	"unicode"
 
 	"github.com/Masterminds/sprig/v3"
+	"github.com/inference-gateway/adl-cli/internal/sandbox"
 	"github.com/inference-gateway/adl-cli/internal/schema"
 	"github.com/inference-gateway/adl-cli/internal/vendor"
 )
@@ -213,7 +214,12 @@ type Context struct {
 	// entries: parsed, deduped against the generator's built-in dependency
 	// set, and sorted. Templates render directly from this view (see
 	// go.mod.tmpl / Cargo.toml.tmpl).
-	Vendor         vendor.View
+	Vendor vendor.View
+	// SandboxDeps holds the resolved spec.development.deps entries:
+	// parsed, deduped, and sorted. Templates render from this view to
+	// extend the sandbox manifests (Flox `manifest.toml`, devcontainer
+	// features) on top of whatever the generator installs by default.
+	SandboxDeps    sandbox.View
 	customAcronyms map[string]string
 }
 

--- a/internal/templates/engine.go
+++ b/internal/templates/engine.go
@@ -210,15 +210,7 @@ type Context struct {
 	GenerateCommand string
 	Skills          []SkillView
 	BuiltinConfigs  schema.ResolvedBuiltinConfigs
-	// Vendor holds the resolved spec.language.<lang>.vendor.{deps,devdeps}
-	// entries: parsed, deduped against the generator's built-in dependency
-	// set, and sorted. Templates render directly from this view (see
-	// go.mod.tmpl / Cargo.toml.tmpl).
 	Vendor vendor.View
-	// SandboxDeps holds the resolved spec.development.deps entries:
-	// parsed, deduped, and sorted. Templates render from this view to
-	// extend the sandbox manifests (Flox `manifest.toml`, devcontainer
-	// features) on top of whatever the generator installs by default.
 	SandboxDeps    sandbox.View
 	customAcronyms map[string]string
 }

--- a/internal/templates/registry_sandbox_deps_test.go
+++ b/internal/templates/registry_sandbox_deps_test.go
@@ -1,0 +1,193 @@
+package templates
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/inference-gateway/adl-cli/internal/sandbox"
+	schema "github.com/inference-gateway/adl-cli/internal/schema"
+)
+
+// TestFloxManifest_DevelopmentDeps verifies the full pipeline from
+// `spec.development.deps` to the generated `.flox/env/manifest.toml`.
+// This is the acceptance-criteria flox test from issue #154: a manifest
+// with three deps must end up with three additional [install] entries
+// (deno/kubectl/terraform) in the rendered file, sorted alphabetically
+// to keep diffs stable, and the per-package version pin must match the
+// literal supplied in the ADL.
+func TestFloxManifest_DevelopmentDeps(t *testing.T) {
+	registry, err := NewRegistry("go")
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	engine := NewWithRegistry("minimal", registry)
+
+	adl := minimalGoADL()
+	adl.Spec.Development = &schema.DevelopmentConfig{
+		Sandbox: &schema.SandboxConfig{Flox: &schema.FloxConfig{Enabled: true}},
+		Deps:    []string{"terraform@1.9.5", "deno@2.1.4", "kubectl@1.31.0"},
+	}
+
+	view, err := sandbox.Resolve(adl)
+	if err != nil {
+		t.Fatalf("sandbox.Resolve: %v", err)
+	}
+
+	out, err := engine.ExecuteTemplate("flox/manifest.toml", Context{
+		ADL:         adl,
+		Language:    "go",
+		SandboxDeps: view,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteTemplate: %v", err)
+	}
+
+	wantFragments := []string{
+		`deno.pkg-path = "deno"`,
+		`deno.version = "2.1.4"`,
+		`kubectl.pkg-path = "kubectl"`,
+		`kubectl.version = "1.31.0"`,
+		`terraform.pkg-path = "terraform"`,
+		`terraform.version = "1.9.5"`,
+	}
+	for _, frag := range wantFragments {
+		if !strings.Contains(out, frag) {
+			t.Errorf("flox manifest missing %q\n---\n%s", frag, out)
+		}
+	}
+
+	// Ordering must be deterministic (alphabetical) so re-generation
+	// doesn't churn diffs.
+	denoIdx := strings.Index(out, "deno.pkg-path")
+	kubectlIdx := strings.Index(out, "kubectl.pkg-path")
+	terraformIdx := strings.Index(out, "terraform.pkg-path")
+	if denoIdx >= kubectlIdx || kubectlIdx >= terraformIdx {
+		t.Fatalf("expected sorted order deno < kubectl < terraform; got positions %d/%d/%d\n---\n%s",
+			denoIdx, kubectlIdx, terraformIdx, out)
+	}
+
+	// Built-in entries must still be present - deps are additive.
+	for _, builtin := range []string{
+		`go.pkg-path = "go"`,
+		`go-task.pkg-path = "go-task"`,
+		`git.pkg-path = "git"`,
+		`docker.pkg-path = "docker"`,
+	} {
+		if !strings.Contains(out, builtin) {
+			t.Errorf("flox manifest dropped built-in %q\n---\n%s", builtin, out)
+		}
+	}
+}
+
+// TestFloxManifest_NoDevelopmentDeps asserts that the generated
+// manifest.toml is byte-identical (modulo the trailing newline) to the
+// pre-feature output when spec.development.deps is absent. This guards
+// the AC "Behavior is unchanged when the field is absent or empty."
+func TestFloxManifest_NoDevelopmentDeps(t *testing.T) {
+	registry, err := NewRegistry("go")
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	engine := NewWithRegistry("minimal", registry)
+
+	adl := minimalGoADL()
+	adl.Spec.Development = &schema.DevelopmentConfig{
+		Sandbox: &schema.SandboxConfig{Flox: &schema.FloxConfig{Enabled: true}},
+	}
+
+	view, err := sandbox.Resolve(adl)
+	if err != nil {
+		t.Fatalf("sandbox.Resolve: %v", err)
+	}
+	if view.HasDeps() {
+		t.Fatalf("sandbox.Resolve returned non-empty deps for an ADL without deps")
+	}
+
+	out, err := engine.ExecuteTemplate("flox/manifest.toml", Context{
+		ADL:         adl,
+		Language:    "go",
+		SandboxDeps: view,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteTemplate: %v", err)
+	}
+
+	// The user-deps comment must NOT appear when no deps are declared,
+	// otherwise we'd leak the section header into every generated file.
+	if strings.Contains(out, "spec.development.deps") {
+		t.Fatalf("manifest unexpectedly mentions spec.development.deps when no deps are set\n---\n%s", out)
+	}
+}
+
+// TestDevcontainerJSON_DevelopmentDeps confirms that the devcontainer
+// path consumes spec.development.deps and emits an apt-packages feature
+// entry. The devcontainer-extras feature is the closest equivalent to
+// "an arbitrary list of `<pkg>=<ver>` pins" that the official features
+// catalog ships today.
+func TestDevcontainerJSON_DevelopmentDeps(t *testing.T) {
+	registry, err := NewRegistry("go")
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	engine := NewWithRegistry("minimal", registry)
+
+	adl := minimalGoADL()
+	adl.Spec.Development = &schema.DevelopmentConfig{
+		Sandbox: &schema.SandboxConfig{DevContainer: &schema.DevContainerConfig{Enabled: true}},
+		Deps:    []string{"deno@2.1.4", "kubectl@1.31.0"},
+	}
+
+	view, err := sandbox.Resolve(adl)
+	if err != nil {
+		t.Fatalf("sandbox.Resolve: %v", err)
+	}
+
+	out, err := engine.ExecuteTemplate("devcontainer/devcontainer.json", Context{
+		ADL:         adl,
+		Language:    "go",
+		SandboxDeps: view,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteTemplate: %v", err)
+	}
+
+	if !strings.Contains(out, `"ghcr.io/devcontainers-extra/features/apt-packages:1"`) {
+		t.Errorf("devcontainer.json missing apt-packages feature reference\n---\n%s", out)
+	}
+	if !strings.Contains(out, "deno=2.1.4") || !strings.Contains(out, "kubectl=1.31.0") {
+		t.Errorf("devcontainer.json missing deno=2.1.4 or kubectl=1.31.0 in packages list\n---\n%s", out)
+	}
+}
+
+// TestDevcontainerJSON_NoDevelopmentDeps asserts that devcontainer.json
+// does not include the apt-packages feature when no deps are declared.
+func TestDevcontainerJSON_NoDevelopmentDeps(t *testing.T) {
+	registry, err := NewRegistry("go")
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	engine := NewWithRegistry("minimal", registry)
+
+	adl := minimalGoADL()
+	adl.Spec.Development = &schema.DevelopmentConfig{
+		Sandbox: &schema.SandboxConfig{DevContainer: &schema.DevContainerConfig{Enabled: true}},
+	}
+
+	view, err := sandbox.Resolve(adl)
+	if err != nil {
+		t.Fatalf("sandbox.Resolve: %v", err)
+	}
+
+	out, err := engine.ExecuteTemplate("devcontainer/devcontainer.json", Context{
+		ADL:         adl,
+		Language:    "go",
+		SandboxDeps: view,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteTemplate: %v", err)
+	}
+
+	if strings.Contains(out, "apt-packages") {
+		t.Fatalf("devcontainer.json unexpectedly contains apt-packages feature when no deps are declared\n---\n%s", out)
+	}
+}

--- a/internal/templates/sandbox/devcontainer/devcontainer.json.tmpl
+++ b/internal/templates/sandbox/devcontainer/devcontainer.json.tmpl
@@ -9,7 +9,11 @@
   {{- end }}
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
-    "ghcr.io/devcontainers/features/git:1": {}
+    "ghcr.io/devcontainers/features/git:1": {}{{- if .SandboxDeps.HasDeps }},
+    "ghcr.io/devcontainers-extra/features/apt-packages:1": {
+      "packages": "{{- range $i, $e := .SandboxDeps.Deps }}{{ if $i }},{{ end }}{{ $e.Name }}={{ $e.Version }}{{- end }}"
+    }
+    {{- end }}
   },
   "customizations": {
     "vscode": {

--- a/internal/templates/sandbox/flox/manifest.toml.tmpl
+++ b/internal/templates/sandbox/flox/manifest.toml.tmpl
@@ -56,6 +56,18 @@ claude-code.pkg-path = "claude-code"
 claude-code.version = "^2.1.145"
 claude-code.pkg-group = "common"
 {{- end }}
+{{- if .SandboxDeps.HasDeps }}
+
+# Extra packages declared in spec.development.deps. Each entry is rendered
+# as a Flox install line resolved against Nixpkgs. The package name from
+# the ADL ('<package>@<version>') becomes the Nixpkgs attribute path; if a
+# package is exposed under a different attribute path in Nixpkgs you may
+# need to add it under .adl-ignore and hand-author the override.
+{{- range .SandboxDeps.Deps }}
+{{ .Name }}.pkg-path = "{{ .Name }}"
+{{ .Name }}.version = "{{ .Version }}"
+{{- end }}
+{{- end }}
 
 [hook]
 on-activate = '''


### PR DESCRIPTION
Closes #154

## Summary

Wires the new `spec.development.deps` ADL field (added in inference-gateway/adl#17, releasing as v0.10.0) into the Flox and devcontainer sandbox templates. Users can now install cross-cutting CLI tools (deno, kubectl, terraform, ...) into the generated dev sandbox without hand-editing the artifacts after every regeneration.

- Bump `ADL_SCHEMA_VERSION` to `v0.10.0` and refresh the embedded schema + regenerated types so `DevelopmentConfig.Deps` is available.
- Add `internal/sandbox.Resolve` which parses each `<pkg>@<ver>` entry, dedupes (first wins), sorts alphabetically, and flags collisions with the per-backend built-in package lists.
- Thread the resolved view through `templates.Context.SandboxDeps` and surface stderr warnings for conflicts from `generator.Generate`.
- Render entries into `.flox/env/manifest.toml` as `<pkg>.pkg-path` / `<pkg>.version` install lines, and into `.devcontainer/devcontainer.json` as a `ghcr.io/devcontainers-extra/features/apt-packages:1` feature with a comma-separated `<pkg>=<ver>` list. `dockerCompose` is intentionally out of scope per the issue.
- Document the field in README (new "Extra sandbox dependencies" section with one worked example per backend) and CLAUDE.md.

## Merge policy

Additive, user wins on version conflict. Built-in template entries (`go`, `git`, `docker`, `go-task`, ...) always render; user `deps` are appended on top, sorted alphabetically so re-generation produces stable diffs. Conflicts emit a ⚠️ warning to stderr but still render the user entry.

## Test plan

- [x] `task fmt` / `task lint` / `task test` / `task build` / `task examples:test` all pass.
- [ ] `task verify-schema` will pass once `inference-gateway/adl` v0.10.0 is released (the schema change already landed on main via PR #17).
- [x] Unit tests: `internal/sandbox/deps_test.go`.
- [x] Template-level tests: `internal/templates/registry_sandbox_deps_test.go`.
- [x] End-to-end generator tests asserting the on-disk `.flox/env/manifest.toml` / `.devcontainer/devcontainer.json` (`TestGenerator_SandboxDevelopmentDeps` / `_AbsentIsNoop`).

Generated with [Claude Code](https://claude.ai/code)