### PR TITLE
fix(init): Emit vendor and sandbox deps as empty lists in defaults

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -303,11 +303,6 @@ type adlData struct {
 					Enabled bool `yaml:"enabled"`
 				} `yaml:"infer,omitempty"`
 			} `yaml:"ai,omitempty"`
-			// Deps is rendered without omitempty so an empty list still
-			// appears in the scaffolded manifest. That makes the cross-cutting
-			// sandbox-deps extension point discoverable to first-time users
-			// — they can drop tools like `kubectl@1.31.0` or `deno@2.1.4`
-			// here without having to read the schema first.
 			Deps []string `yaml:"deps"`
 		} `yaml:"development,omitempty"`
 		Deployment *struct {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -177,6 +177,17 @@ func runInit(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// vendorBlock mirrors spec.language.<lang>.vendor in the ADL schema. The
+// `deps` and `devdeps` keys are intentionally rendered without `omitempty`
+// so the scaffolded manifest shows them as empty lists — that's the only
+// way first-time users discover where to drop `<package>@<version>`
+// entries without consulting the schema. The matching language-specific
+// generator (go.mod / Cargo.toml) treats nil and empty equivalently.
+type vendorBlock struct {
+	Deps    []string `yaml:"deps"`
+	Devdeps []string `yaml:"devdeps"`
+}
+
 type adlData struct {
 	APIVersion string `yaml:"apiVersion"`
 	Kind       string `yaml:"kind"`
@@ -238,17 +249,20 @@ type adlData struct {
 		} `yaml:"server"`
 		Language *struct {
 			Go *struct {
-				Module  string `yaml:"module"`
-				Version string `yaml:"version"`
+				Module  string       `yaml:"module"`
+				Version string       `yaml:"version"`
+				Vendor  *vendorBlock `yaml:"vendor,omitempty"`
 			} `yaml:"go,omitempty"`
 			TypeScript *struct {
-				PackageName string `yaml:"packageName"`
-				NodeVersion string `yaml:"nodeVersion"`
+				PackageName string       `yaml:"packageName"`
+				NodeVersion string       `yaml:"nodeVersion"`
+				Vendor      *vendorBlock `yaml:"vendor,omitempty"`
 			} `yaml:"typescript,omitempty"`
 			Rust *struct {
-				PackageName string `yaml:"packageName"`
-				Version     string `yaml:"version"`
-				Edition     string `yaml:"edition"`
+				PackageName string       `yaml:"packageName"`
+				Version     string       `yaml:"version"`
+				Edition     string       `yaml:"edition"`
+				Vendor      *vendorBlock `yaml:"vendor,omitempty"`
 			} `yaml:"rust,omitempty"`
 		} `yaml:"language,omitempty"`
 		SCM *struct {
@@ -289,6 +303,12 @@ type adlData struct {
 					Enabled bool `yaml:"enabled"`
 				} `yaml:"infer,omitempty"`
 			} `yaml:"ai,omitempty"`
+			// Deps is rendered without omitempty so an empty list still
+			// appears in the scaffolded manifest. That makes the cross-cutting
+			// sandbox-deps extension point discoverable to first-time users
+			// — they can drop tools like `kubectl@1.31.0` or `deno@2.1.4`
+			// here without having to read the schema first.
+			Deps []string `yaml:"deps"`
 		} `yaml:"development,omitempty"`
 		Deployment *struct {
 			Type string `yaml:"type,omitempty"`
@@ -639,56 +659,67 @@ func collectADLInfo(cmd *cobra.Command, projectName string, useDefaults bool) *a
 
 	adl.Spec.Language = &struct {
 		Go *struct {
-			Module  string `yaml:"module"`
-			Version string `yaml:"version"`
+			Module  string       `yaml:"module"`
+			Version string       `yaml:"version"`
+			Vendor  *vendorBlock `yaml:"vendor,omitempty"`
 		} `yaml:"go,omitempty"`
 		TypeScript *struct {
-			PackageName string `yaml:"packageName"`
-			NodeVersion string `yaml:"nodeVersion"`
+			PackageName string       `yaml:"packageName"`
+			NodeVersion string       `yaml:"nodeVersion"`
+			Vendor      *vendorBlock `yaml:"vendor,omitempty"`
 		} `yaml:"typescript,omitempty"`
 		Rust *struct {
-			PackageName string `yaml:"packageName"`
-			Version     string `yaml:"version"`
-			Edition     string `yaml:"edition"`
+			PackageName string       `yaml:"packageName"`
+			Version     string       `yaml:"version"`
+			Edition     string       `yaml:"edition"`
+			Vendor      *vendorBlock `yaml:"vendor,omitempty"`
 		} `yaml:"rust,omitempty"`
 	}{}
 
 	switch language {
 	case "go":
 		adl.Spec.Language.Go = &struct {
-			Module  string `yaml:"module"`
-			Version string `yaml:"version"`
+			Module  string       `yaml:"module"`
+			Version string       `yaml:"version"`
+			Vendor  *vendorBlock `yaml:"vendor,omitempty"`
 		}{}
 		defaultModule := getDefaultGoModule(adl.Metadata.Name)
 		adl.Spec.Language.Go.Module = promptWithConfig("go-module", useDefaults, "Go module", defaultModule)
 		adl.Spec.Language.Go.Version = promptWithConfig("go-version", useDefaults, "Go version", "1.26.2")
+		adl.Spec.Language.Go.Vendor = &vendorBlock{Deps: []string{}, Devdeps: []string{}}
 
 	case "rust":
 		adl.Spec.Language.Rust = &struct {
-			PackageName string `yaml:"packageName"`
-			Version     string `yaml:"version"`
-			Edition     string `yaml:"edition"`
+			PackageName string       `yaml:"packageName"`
+			Version     string       `yaml:"version"`
+			Edition     string       `yaml:"edition"`
+			Vendor      *vendorBlock `yaml:"vendor,omitempty"`
 		}{}
 		adl.Spec.Language.Rust.PackageName = promptWithConfig("rust-package-name", useDefaults, "Rust package name", adl.Metadata.Name)
 		adl.Spec.Language.Rust.Version = promptWithConfig("rust-version", useDefaults, "Rust version", "1.89.0")
 		adl.Spec.Language.Rust.Edition = promptWithConfig("rust-edition", useDefaults, "Rust edition", "2024")
+		adl.Spec.Language.Rust.Vendor = &vendorBlock{Deps: []string{}, Devdeps: []string{}}
 
 	case "typescript":
 		adl.Spec.Language.TypeScript = &struct {
-			PackageName string `yaml:"packageName"`
-			NodeVersion string `yaml:"nodeVersion"`
+			PackageName string       `yaml:"packageName"`
+			NodeVersion string       `yaml:"nodeVersion"`
+			Vendor      *vendorBlock `yaml:"vendor,omitempty"`
 		}{}
 		adl.Spec.Language.TypeScript.PackageName = promptWithConfig("typescript-name", useDefaults, "TypeScript package name", adl.Metadata.Name)
 		adl.Spec.Language.TypeScript.NodeVersion = "24"
+		adl.Spec.Language.TypeScript.Vendor = &vendorBlock{Deps: []string{}, Devdeps: []string{}}
 
 	default:
 		adl.Spec.Language.Go = &struct {
-			Module  string `yaml:"module"`
-			Version string `yaml:"version"`
+			Module  string       `yaml:"module"`
+			Version string       `yaml:"version"`
+			Vendor  *vendorBlock `yaml:"vendor,omitempty"`
 		}{}
 		defaultModule := getDefaultGoModule(adl.Metadata.Name)
 		adl.Spec.Language.Go.Module = promptWithConfig("go-module", useDefaults, "Go module", defaultModule)
 		adl.Spec.Language.Go.Version = promptWithConfig("go-version", useDefaults, "Go version", "1.26.2")
+		adl.Spec.Language.Go.Vendor = &vendorBlock{Deps: []string{}, Devdeps: []string{}}
 	}
 
 	fmt.Println("\n🏗️ Sandbox Configuration")
@@ -832,8 +863,16 @@ func collectADLInfo(cmd *cobra.Command, projectName string, useDefaults bool) *a
 // ensureDevelopment lazily initialises adl.Spec.Development so that callers
 // can populate adl.Spec.Development.Sandbox / adl.Spec.Development.AI without
 // repeating the nil check at every assignment site.
+//
+// Deps is seeded as an empty (but non-nil) slice so the YAML encoder emits
+// `deps: []` rather than omitting the key — first-time users need that
+// breadcrumb to discover where to drop cross-cutting sandbox tools (e.g.
+// `kubectl@1.31.0`, `terraform@1.9.5`).
 func ensureDevelopment(adl *adlData) {
 	if adl.Spec.Development != nil {
+		if adl.Spec.Development.Deps == nil {
+			adl.Spec.Development.Deps = []string{}
+		}
 		return
 	}
 	adl.Spec.Development = &struct {
@@ -865,7 +904,10 @@ func ensureDevelopment(adl *adlData) {
 				Enabled bool `yaml:"enabled"`
 			} `yaml:"infer,omitempty"`
 		} `yaml:"ai,omitempty"`
-	}{}
+		Deps []string `yaml:"deps"`
+	}{
+		Deps: []string{},
+	}
 }
 
 func parseGitRemote() (owner, repo string) {

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -380,6 +380,12 @@ func TestInitDevelopmentDefaultsEmitted(t *testing.T) {
 		"gemini:",
 		"opencode:",
 		"infer:",
+		// Empty-list extension points must be rendered explicitly so
+		// first-time users see where to drop additional dependencies
+		// without consulting the schema.
+		"vendor:",
+		"deps: []",
+		"devdeps: []",
 	} {
 		if !strings.Contains(contentStr, want) {
 			t.Errorf("ADL file should contain %q, got:\n%s", want, contentStr)
@@ -387,6 +393,84 @@ func TestInitDevelopmentDefaultsEmitted(t *testing.T) {
 	}
 
 	t.Logf("Generated ADL content:\n%s", contentStr)
+}
+
+// TestInitDefaultsEmitsVendorAndSandboxDeps asserts that `adl init --defaults`
+// writes the three list-shaped extension points (`spec.language.go.vendor.deps`,
+// `spec.language.go.vendor.devdeps`, `spec.development.deps`) as explicit empty
+// lists. These keys are how users discover where to add extra Go modules /
+// dev tools / cross-cutting sandbox packages; omitting them on init forces
+// users to consult the schema. See issue #156.
+func TestInitDefaultsEmitsVendorAndSandboxDeps(t *testing.T) {
+	tempDir := t.TempDir()
+	outputPath := filepath.Join(tempDir, "test-output")
+
+	cmd := initCmd
+	if err := cmd.Flags().Set("defaults", "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("path", outputPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("language", "go"); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = cmd.Flags().Set("language", "") }()
+
+	if err := runInit(cmd, []string{"test-agent"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	adlPath := filepath.Join(outputPath, "agent.yaml")
+	content, err := os.ReadFile(adlPath)
+	if err != nil {
+		t.Fatalf("failed to read ADL file: %v", err)
+	}
+
+	var adl adlData
+	if err := yaml.Unmarshal(content, &adl); err != nil {
+		t.Fatalf("failed to parse ADL YAML: %v", err)
+	}
+
+	if adl.Spec.Language == nil || adl.Spec.Language.Go == nil {
+		t.Fatalf("expected spec.language.go to be present")
+	}
+	if adl.Spec.Language.Go.Vendor == nil {
+		t.Fatalf("expected spec.language.go.vendor to be present by default")
+	}
+	if adl.Spec.Language.Go.Vendor.Deps == nil {
+		t.Errorf("expected spec.language.go.vendor.deps to be an empty list (not nil)")
+	}
+	if len(adl.Spec.Language.Go.Vendor.Deps) != 0 {
+		t.Errorf("expected spec.language.go.vendor.deps to be empty, got %v", adl.Spec.Language.Go.Vendor.Deps)
+	}
+	if adl.Spec.Language.Go.Vendor.Devdeps == nil {
+		t.Errorf("expected spec.language.go.vendor.devdeps to be an empty list (not nil)")
+	}
+	if len(adl.Spec.Language.Go.Vendor.Devdeps) != 0 {
+		t.Errorf("expected spec.language.go.vendor.devdeps to be empty, got %v", adl.Spec.Language.Go.Vendor.Devdeps)
+	}
+
+	if adl.Spec.Development == nil {
+		t.Fatalf("expected spec.development to be present by default")
+	}
+	if adl.Spec.Development.Deps == nil {
+		t.Errorf("expected spec.development.deps to be an empty list (not nil)")
+	}
+	if len(adl.Spec.Development.Deps) != 0 {
+		t.Errorf("expected spec.development.deps to be empty, got %v", adl.Spec.Development.Deps)
+	}
+
+	contentStr := string(content)
+	for _, want := range []string{
+		"vendor:",
+		"deps: []",
+		"devdeps: []",
+	} {
+		if !strings.Contains(contentStr, want) {
+			t.Errorf("ADL file should contain %q, got:\n%s", want, contentStr)
+		}
+	}
 }
 
 // TestInitDockerComposeFlag verifies that the --docker-compose flag at init

--- a/internal/templates/common/docs/README.md.tmpl
+++ b/internal/templates/common/docs/README.md.tmpl
@@ -234,6 +234,32 @@ task lint
 task fmt
 ```
 
+### Adding Dependencies
+
+The generator owns the baseline toolchain pins (SDK, server framework,
+logging, CLI, sandbox utilities). To extend the project without forking
+the templates, declare extras in `agent.yaml` — every empty list below
+is rendered by `adl init --defaults` precisely so it's discoverable:
+
+| Where | Purpose | Example entry | Rendered into |
+|-------|---------|---------------|---------------|
+{{- if eq .Language "go" }}
+| `spec.language.go.vendor.deps` | Runtime Go modules | `github.com/stretchr/testify@v1.10.0` | `go.mod` `require` block |
+| `spec.language.go.vendor.devdeps` | Executable dev tools (Go 1.24 `tool` directive) | `golang.org/x/tools/cmd/stringer@v0.20.0` | `go.mod` `tool` directive |
+{{- else if eq .Language "rust" }}
+| `spec.language.rust.vendor.deps` | Runtime crates | `tokio@1.36.0` | `Cargo.toml` `[dependencies]` |
+| `spec.language.rust.vendor.devdeps` | Test / dev-only crates | `mockall@0.12.0` | `Cargo.toml` `[dev-dependencies]` |
+{{- else if eq .Language "typescript" }}
+| `spec.language.typescript.vendor.deps` | Runtime npm packages | `zod@3.23.0` | `package.json` `dependencies` |
+| `spec.language.typescript.vendor.devdeps` | Test / dev-only packages | `vitest@1.6.0` | `package.json` `devDependencies` |
+{{- end }}
+| `spec.development.deps` | Cross-cutting sandbox tools (not tied to one language) | `kubectl@1.31.0`, `terraform@1.9.5`, `deno@2.1.4` | Flox `manifest.toml` / devcontainer feature |
+
+Entries use the `<package>@<version>` form. Built-in pins always win on
+conflict; the generator prints a warning and skips the user entry when
+shadowing is attempted. After editing `agent.yaml`, re-run `task generate`
+to refresh the manifests.
+
 ### Debugging
 
 Use the [A2A Debugger](https://github.com/inference-gateway/a2a-debugger) to test and debug your A2A agent during development. It provides a web interface for sending requests to your agent and inspecting responses, making it easier to troubleshoot issues and validate your implementation.


### PR DESCRIPTION
## Summary

`adl init --defaults` now emits `spec.language.<lang>.vendor.deps`, `vendor.devdeps`, and `spec.development.deps` as explicit empty lists so first-time users discover where to add extra dependencies without consulting the schema. The generated README.md also documents these extension points in a new "Adding Dependencies" subsection under Development.

Resolves #156

## Test plan

- [x] `task ci` passes (fmt, lint, test, build, verify-schema)
- [x] New `TestInitDefaultsEmitsVendorAndSandboxDeps` covers the typed shape
- [x] `TestInitDevelopmentDefaultsEmitted` updated to assert `vendor:` / `deps: []` / `devdeps: []` appear in the YAML
- [x] Manually ran `adl init --defaults --language go` and verified the three empty lists appear
- [x] Manually ran `adl generate` on `examples/go-agent.yaml` and verified the new README section renders

Generated with [Claude Code](https://claude.ai/code)