### PR TITLE
fix(templates): Render README title via toTitleCase helper that honors acronyms

### DIFF
--- a/internal/templates/common/docs/README.md.tmpl
+++ b/internal/templates/common/docs/README.md.tmpl
@@ -1,6 +1,6 @@
 <div align="center">
 
-# {{ .ADL.Metadata.Name | title }}
+# {{ toTitleCase .ADL.Metadata.Name .ADL.Spec.Acronyms }}
 
 {{ if .GenerateCI -}}
 {{ if and .ADL.Spec.SCM (eq .ADL.Spec.SCM.Provider "github") .ADL.Spec.SCM.URL -}}

--- a/internal/templates/engine.go
+++ b/internal/templates/engine.go
@@ -57,7 +57,11 @@ func getDefaultAcronyms() map[string]string {
 	}
 }
 
-// buildAcronymsMap builds the acronyms map from default + custom acronyms
+// buildAcronymsMap builds the acronyms map from default + custom acronyms.
+// Values are uppercased so they slot cleanly into PascalCase / camelCase /
+// UPPER_SNAKE_CASE identifiers. For human-readable title rendering that
+// preserves brand casing (e.g. "n8n", "iPhone"), see toTitleCaseWithAcronyms,
+// which consumes the raw user list directly.
 func buildAcronymsMap(customAcronyms []string) map[string]string {
 	acronyms := getDefaultAcronyms()
 
@@ -161,6 +165,40 @@ func toUpperSnakeCase(s string) string {
 	s = strings.ReplaceAll(s, "-", "_")
 
 	return strings.ToUpper(s)
+}
+
+// toTitleCaseWithAcronyms converts a dash-/snake-case identifier into a human
+// readable Title Case string with whitespace separation, preserving the casing
+// of any user-supplied acronyms. Used for display-only contexts such as the
+// generated README title, where brand names like "n8n", "iPhone", or
+// "PostgreSQL" must render with their canonical casing rather than being
+// force-uppercased like code identifiers.
+func toTitleCaseWithAcronyms(s string, acronyms []string) string {
+	if s == "" {
+		return s
+	}
+
+	preserved := make(map[string]string, len(acronyms))
+	for _, a := range acronyms {
+		preserved[strings.ToLower(a)] = a
+	}
+
+	s = strings.ReplaceAll(s, "-", " ")
+	s = strings.ReplaceAll(s, "_", " ")
+	words := strings.Fields(s)
+	for i, w := range words {
+		if orig, ok := preserved[strings.ToLower(w)]; ok {
+			words[i] = orig
+			continue
+		}
+		runes := []rune(w)
+		runes[0] = unicode.ToUpper(runes[0])
+		for j := 1; j < len(runes); j++ {
+			runes[j] = unicode.ToLower(runes[j])
+		}
+		words[i] = string(runes)
+	}
+	return strings.Join(words, " ")
 }
 
 // toUpperSnakeCaseWithAcronyms converts camelCase, dash-case, or snake_case to UPPER_SNAKE_CASE with acronym support
@@ -326,6 +364,7 @@ func customFuncMap() template.FuncMap {
 	funcMap["toSnakeCase"] = toSnakeCase
 	funcMap["toUpperCase"] = strings.ToUpper
 	funcMap["toUpperSnakeCase"] = toUpperSnakeCase
+	funcMap["toTitleCase"] = toTitleCaseWithAcronyms
 	funcMap["toJson"] = toJson
 	funcMap["toGoMap"] = toGoMap
 	funcMap["findDependencyByID"] = findDependencyByID
@@ -356,6 +395,7 @@ func customFuncMapWithAcronyms(acronyms map[string]string) template.FuncMap {
 	funcMap["toUpperSnakeCase"] = func(s string) string {
 		return toUpperSnakeCaseWithAcronyms(s, acronyms)
 	}
+	funcMap["toTitleCase"] = toTitleCaseWithAcronyms
 	funcMap["toJson"] = toJson
 	funcMap["toGoMap"] = toGoMap
 	funcMap["findDependencyByID"] = findDependencyByID

--- a/internal/templates/engine_test.go
+++ b/internal/templates/engine_test.go
@@ -332,6 +332,144 @@ func TestEngine_Execute_WithCustomAcronyms(t *testing.T) {
 	}
 }
 
+func TestToTitleCaseWithAcronyms(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		acronyms []string
+		expected string
+	}{
+		{
+			name:     "lowercase brand acronym preserved",
+			input:    "n8n-agent",
+			acronyms: []string{"n8n"},
+			expected: "n8n Agent",
+		},
+		{
+			name:     "uppercase acronym preserved",
+			input:    "api-server",
+			acronyms: []string{"API"},
+			expected: "API Server",
+		},
+		{
+			name:     "mixed-case brand acronym preserved",
+			input:    "postgresql-driver",
+			acronyms: []string{"PostgreSQL"},
+			expected: "PostgreSQL Driver",
+		},
+		{
+			name:     "multiple acronyms in one name",
+			input:    "n8n-graphql-bridge",
+			acronyms: []string{"n8n", "GraphQL"},
+			expected: "n8n GraphQL Bridge",
+		},
+		{
+			name:     "snake_case input",
+			input:    "weather_agent",
+			acronyms: nil,
+			expected: "Weather Agent",
+		},
+		{
+			name:     "no acronyms",
+			input:    "weather-agent",
+			acronyms: nil,
+			expected: "Weather Agent",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			acronyms: []string{"n8n"},
+			expected: "",
+		},
+		{
+			name:     "single word non-acronym",
+			input:    "agent",
+			acronyms: []string{"n8n"},
+			expected: "Agent",
+		},
+		{
+			name:     "acronym match is case-insensitive against input",
+			input:    "N8N-agent",
+			acronyms: []string{"n8n"},
+			expected: "n8n Agent",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toTitleCaseWithAcronyms(tt.input, tt.acronyms)
+			if got != tt.expected {
+				t.Errorf("toTitleCaseWithAcronyms(%q, %v) = %q, want %q", tt.input, tt.acronyms, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestREADMETemplate_TitleIsHumanized(t *testing.T) {
+	registry, err := NewRegistry("go")
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	engine := NewWithRegistry("minimal", registry)
+
+	tests := []struct {
+		name      string
+		metadata  schema.Metadata
+		acronyms  []string
+		wantTitle string
+	}{
+		{
+			name:      "lowercase brand acronym preserved in title",
+			metadata:  schema.Metadata{Name: "n8n-agent", Version: "0.1.0"},
+			acronyms:  []string{"n8n"},
+			wantTitle: "# n8n Agent",
+		},
+		{
+			name:      "no acronyms renders standard title case",
+			metadata:  schema.Metadata{Name: "weather-agent", Version: "0.1.0"},
+			wantTitle: "# Weather Agent",
+		},
+		{
+			name:      "mixed-case brand acronym preserved",
+			metadata:  schema.Metadata{Name: "postgresql-driver", Version: "0.1.0"},
+			acronyms:  []string{"PostgreSQL"},
+			wantTitle: "# PostgreSQL Driver",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adl := &schema.ADL{
+				Metadata: tt.metadata,
+				Spec: schema.Spec{
+					Acronyms: tt.acronyms,
+					Language: schema.Language{
+						Go: &schema.GoConfig{Module: "example.com/x", Version: "1.26.2"},
+					},
+				},
+			}
+			ctx := Context{ADL: adl, Language: "go"}
+
+			out, err := engine.ExecuteTemplate("docs/README.md", ctx)
+			if err != nil {
+				t.Fatalf("ExecuteTemplate(README.md): %v", err)
+			}
+
+			lines := strings.Split(out, "\n")
+			var got string
+			for _, line := range lines {
+				if strings.HasPrefix(line, "# ") {
+					got = line
+					break
+				}
+			}
+			if got != tt.wantTitle {
+				t.Errorf("README title = %q, want %q", got, tt.wantTitle)
+			}
+		})
+	}
+}
+
 func TestGetDefaultAcronyms(t *testing.T) {
 	acronyms := getDefaultAcronyms()
 


### PR DESCRIPTION
## Summary

- The generated README used Sprig's `| title` filter, which produced `# N8n-Agent` for `metadata.name: n8n-agent` regardless of what was in `spec.acronyms`.
- Add a `toTitleCaseWithAcronyms` helper (registered as the template func `toTitleCase`) that splits the name on `-`/`_`, title-cases each word, and substitutes the user-supplied casing whenever a word matches an entry in the acronyms list.
- The helper takes the raw acronyms slice directly, so display rendering is decoupled from `buildAcronymsMap`. Code-identifier paths (`toPascalCase` / `toCamelCase` / `toUpperSnakeCase`) keep their existing force-uppercase behavior, so generators still produce `SearchN8NDocsTool` regardless of whether the user wrote `[n8n]` or `[N8N]`.

### Before / after

| `agent.yaml` | README title before | README title after |
| --- | --- | --- |
| `name: n8n-agent`, `acronyms: [n8n]` | `# N8n-Agent` | `# n8n Agent` |
| `name: n8n-agent`, `acronyms: [N8N]` | `# N8n-Agent` | `# N8N Agent` |
| `name: postgresql-driver`, `acronyms: [PostgreSQL]` | `# Postgresql-Driver` | `# PostgreSQL Driver` |
| `name: weather-agent`, no acronyms | `# Weather-Agent` | `# Weather Agent` |

## Test plan

- [x] `go test ./...` passes (new `TestToTitleCaseWithAcronyms` + `TestREADMETemplate_TitleIsHumanized`, existing acronym tests unchanged)
- [x] `go build ./...` clean
- [x] Regenerated `n8n-agent` with the local binary: README title is `# n8n Agent`, `main.go` still references `tools.NewSearchN8NDocsTool` (matches the existing `.adl-ignore`d tool implementations), `go build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)