### PR TITLE
docs: document spec.telemetry OpenTelemetry generation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,10 @@ Template files live as `.tmpl` under three roots that map to embed globs in `reg
 
 There are also five **reserved tool IDs** (`read`/`bash`/`write`/`edit`/`fetch`) — see `internal/schema/builtin_config.go`. They render from `languages/<lang>/builtin/*.tmpl` and are configured under the reserved `spec.config.tools.<id>` namespace, which is intentionally skipped when generating the `Config` struct.
 
+### Telemetry (`spec.telemetry.enabled`)
+
+A manifest-only boolean (no CLI flag) that turns on OpenTelemetry instrumentation. Go gets a generated `tools/telemetry.go` (from `languages/go/telemetry.go.tmpl`, per-tool-call spans, OTel deps added to `go.mod`, `A2A_TELEMETRY_*` vars in `.env.example`); TypeScript gets `createTelemetryProvider` wiring in `index.ts.tmpl` (`TELEMETRY_ENABLE` + `OTEL_*` vars). Rust is not supported — the toggle is ignored there. Regression coverage: `examples/{go,typescript}-agent-telemetry.yaml`.
+
 ### `.adl-ignore` protects user code on re-generate
 
 The generator creates a `.adl-ignore` (gitignore-style globs) listing files containing TODO placeholders — tool implementations, custom services, bare skill directories. On subsequent `adl generate` runs (even with `--overwrite`), matched paths are skipped. `internal/generator/ignore.go` handles matching. When adding new "user-owned" files, decide whether they should be in `.adl-ignore` by default.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ _A command-line interface for generating enterprise-ready A2A (Agent-to-Agent) s
 - [Sandbox Environments](#sandbox-environments)
 - [Enterprise Features](#enterprise-features)
 - [Artifacts Support](#artifacts-support)
+- [Telemetry](#telemetry)
 - [GitHub Issue Templates](#github-issue-templates)
 - [Examples](#examples)
 - [Template System & Architecture](#template-system--architecture)
@@ -64,6 +65,7 @@ The ADL CLI helps you build enterprise-ready A2A agents quickly by generating co
 - 🎣 **Post-Generation Hooks** - Customize build, format, and test commands after generation
 - 🤖 **Multi-Provider AI** - OpenAI, Anthropic, Google, Groq, Mistral, DeepSeek, Cohere, Cloudflare, Moonshot, Ollama, Ollama Cloud, and Nvidia support
 - 📁 **Artifacts Support** - Integrated filesystem and MinIO object storage for artifact management
+- 📡 **OpenTelemetry Instrumentation** - Opt-in tracing and metrics via `spec.telemetry.enabled` (Go and TypeScript)
 
 ## Installation
 
@@ -504,6 +506,7 @@ The complete ADL schema includes:
 - **scm**: Source control management configuration (GitHub, GitLab)
 - **sandbox**: Development environment configuration (Flox, DevContainer)
 - **deployment**: Platform-specific deployment configuration (Kubernetes, Cloud Run)
+- **telemetry**: OpenTelemetry instrumentation toggle (see [Telemetry](#telemetry))
 
 ### Complete ADL Example
 
@@ -1814,6 +1817,28 @@ Configure storage via environment variables (see generated README for A2A*ARTIFA
 
 - `examples/go-agent-artifacts-filesystem.yaml` - Filesystem storage example
 - `examples/go-agent-artifacts-minio.yaml` - MinIO storage example
+
+## Telemetry
+
+Enable OpenTelemetry instrumentation for the generated agent:
+
+```yaml
+spec:
+  telemetry:
+    enabled: true
+```
+
+The manifest field is a single on/off switch - exporter endpoints, ports, and sampling stay runtime concerns configured via environment variables in the generated `.env.example`:
+
+- **Go**: pulls the OpenTelemetry runtime dependencies into `go.mod`, generates `tools/telemetry.go` (each built-in tool call becomes its own span with `infer.tool.call.id`/`infer.session.id` attributes), and surfaces `A2A_TELEMETRY_ENABLE`, `A2A_TELEMETRY_METRICS_PORT`/`_HOST`, `A2A_TELEMETRY_TRACE_ENABLE`/`_ENDPOINT`/`_HEADERS` in `.env.example`.
+- **TypeScript**: wires the ADK's `createTelemetryProvider` into `src/index.ts` (no extra npm dependencies) and surfaces `TELEMETRY_ENABLE` plus the standard `OTEL_EXPORTER_OTLP_*` / `OTEL_SERVICE_*` variables in `.env.example`.
+
+> **Note:** Telemetry generation currently supports Go and TypeScript only; Rust agents ignore `spec.telemetry`.
+
+**Examples:**
+
+- `examples/go-agent-telemetry.yaml` - Go agent with metrics server, OTLP traces, and per-tool-call spans
+- `examples/typescript-agent-telemetry.yaml` - TypeScript agent with ADK-provided OTel wiring
 
 ## GitHub Issue Templates
 


### PR DESCRIPTION
## Summary

PR #259 added OpenTelemetry instrumentation generation (`spec.telemetry.enabled`) but shipped without prose documentation. This fills the gaps:

- **README.md**: Key Features bullet, `telemetry` entry in the ADL Schema field list, TOC entry, and a new *Telemetry* section covering the manifest toggle, Go behavior (`tools/telemetry.go`, per-tool-call spans, `A2A_TELEMETRY_*` env vars) and TypeScript behavior (`createTelemetryProvider`, `OTEL_EXPORTER_OTLP_*`), plus a note that Rust is unsupported.
- **CLAUDE.md**: architecture note on the telemetry templates for contributors.

`examples/README.md` already lists both telemetry examples on main, so it is untouched.

## Cross-repo impact

Docs-only, this repo only. A companion `[DOCS]` issue for `inference-gateway/docs` (covering the ADL reference/observability pages) is drafted but not yet filed.

## Verification

- `task lint:md` passes