### PR TITLE
fix(templates): install ADL CLI in generated AI workflows

### DIFF
--- a/internal/templates/common/github/workflows/ai-claude-code.yaml.tmpl
+++ b/internal/templates/common/github/workflows/ai-claude-code.yaml.tmpl
@@ -85,7 +85,9 @@ jobs:
         env:
           VERSION: v{{ .Metadata.CLIVersion }}
         run: |
-          curl -fsSL https://raw.githubusercontent.com/inference-gateway/adl-cli/v{{ .Metadata.CLIVersion }}/install.sh | bash
+          curl -fsSL \
+            -H "Authorization: Bearer ${{`{{ secrets.GITHUB_TOKEN }}`}}" \
+            https://raw.githubusercontent.com/inference-gateway/adl-cli/v{{ .Metadata.CLIVersion }}/install.sh | bash
           adl --version
 
       - name: Install ADL skill

--- a/internal/templates/common/github/workflows/ai-claude-code.yaml.tmpl
+++ b/internal/templates/common/github/workflows/ai-claude-code.yaml.tmpl
@@ -81,6 +81,13 @@ jobs:
           version: 3.48.0
           repo-token: ${{`{{ secrets.GITHUB_TOKEN }}`}}
 
+      - name: Install ADL CLI
+        env:
+          VERSION: v{{ .Metadata.CLIVersion }}
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/inference-gateway/adl-cli/v{{ .Metadata.CLIVersion }}/install.sh | bash
+          adl --version
+
       - name: Install ADL skill
         run: |
           mkdir -p ~/.claude/skills/adl
@@ -129,6 +136,6 @@ jobs:
           claude_args: |
             --effort max
             --model claude-opus-4-8
-            --allowedTools "Bash(task:*),Bash(gh:*),Bash(git:*){{- if eq .Language "go" }},Bash(go:*){{- else if eq .Language "rust" }},Bash(cargo:*){{- else if eq .Language "typescript" }},Bash(npm:*),Bash(node:*){{- end }}"
+            --allowedTools "Bash(task:*),Bash(gh:*),Bash(git:*),Bash(adl:*){{- if eq .Language "go" }},Bash(go:*){{- else if eq .Language "rust" }},Bash(cargo:*){{- else if eq .Language "typescript" }},Bash(npm:*),Bash(node:*){{- end }}"
           prompt: ${{`{{ steps.set-prompt.outputs.value }}`}}
           track_progress: ${{`{{ github.event_name != 'workflow_dispatch' }}`}}

--- a/internal/templates/common/github/workflows/ai-infer.yaml.tmpl
+++ b/internal/templates/common/github/workflows/ai-infer.yaml.tmpl
@@ -105,6 +105,13 @@ jobs:
         with:
           version: 3.48.0
           repo-token: ${{`{{ steps.app-token.outputs.token }}`}}
+
+      - name: Install ADL CLI
+        env:
+          VERSION: v{{ .Metadata.CLIVersion }}
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/inference-gateway/adl-cli/v{{ .Metadata.CLIVersion }}/install.sh | bash
+          adl --version
 {{- if eq .Language "go" }}
 
       - name: Set up Go
@@ -157,7 +164,7 @@ jobs:
           skills: |
             adl
           bash-allow-append: >-
-            ^task( .*)?${{- if eq .Language "go" }},^go( .*)?${{- else if eq .Language "rust" }},^cargo( .*)?$,^rustup( .*)?$,^rustc( .*)?${{- else if eq .Language "typescript" }},^bun( .*)?$,^node( .*)?$,^npm( .*)?$,^npx( .*)?${{- end }}
+            ^adl( .*)?$,^task( .*)?${{- if eq .Language "go" }},^go( .*)?${{- else if eq .Language "rust" }},^cargo( .*)?$,^rustup( .*)?$,^rustc( .*)?${{- else if eq .Language "typescript" }},^bun( .*)?$,^node( .*)?$,^npm( .*)?$,^npx( .*)?${{- end }}
           anthropic-api-key: ${{`{{ secrets.ANTHROPIC_API_KEY }}`}}
           openai-api-key: ${{`{{ secrets.OPENAI_API_KEY }}`}}
           google-api-key: ${{`{{ secrets.GOOGLE_API_KEY }}`}}

--- a/internal/templates/common/github/workflows/ai-infer.yaml.tmpl
+++ b/internal/templates/common/github/workflows/ai-infer.yaml.tmpl
@@ -110,7 +110,9 @@ jobs:
         env:
           VERSION: v{{ .Metadata.CLIVersion }}
         run: |
-          curl -fsSL https://raw.githubusercontent.com/inference-gateway/adl-cli/v{{ .Metadata.CLIVersion }}/install.sh | bash
+          curl -fsSL \
+            -H "Authorization: Bearer ${{`{{ steps.app-token.outputs.token }}`}}" \
+            https://raw.githubusercontent.com/inference-gateway/adl-cli/v{{ .Metadata.CLIVersion }}/install.sh | bash
           adl --version
 {{- if eq .Language "go" }}
 


### PR DESCRIPTION
The generated `claude.yml` and `infer.yml` AI workflows install the **adl skill** but never the **adl binary**, so agent runs can't execute `adl validate`/`adl generate` and fall back to `go run` (seen in inference-gateway/mock-agent#59).

Changes:
- `ai-claude-code.yaml.tmpl`: add the same "Install ADL CLI" step `ci.go.yaml.tmpl` already uses (pinned to `.Metadata.CLIVersion`), and add `Bash(adl:*)` to `--allowedTools`.
- `ai-infer.yaml.tmpl`: same install step, and `^adl( .*)?$` added to `bash-allow-append`.

Codex/gemini templates don't load the adl skill, so they're untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)