### PR TITLE
feat(templates): create PRs from the Claude Code workflow and make GitHub App secret names configurable

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -6,7 +6,7 @@ vars:
   VERSION: 0.49.0
   BUILD_DIR: bin
   DIST_DIR: dist
-  ADL_SCHEMA_VERSION: v0.20.1
+  ADL_SCHEMA_VERSION: v0.21.0
   ADL_SCHEMA_URL: https://raw.githubusercontent.com/inference-gateway/adl/{{.ADL_SCHEMA_VERSION}}/schema/v1/schema.json
   ADL_SCHEMA_PATH: internal/schema/schema.json
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -218,11 +218,20 @@ type orchestratorToggle struct {
 // orchestratorsBlock mirrors spec.development.ai.orchestrators: each
 // coding agent is toggled independently and defaults to disabled.
 type orchestratorsBlock struct {
-	Claudecode *orchestratorToggle `yaml:"claudecode,omitempty"`
-	Codex      *orchestratorToggle `yaml:"codex,omitempty"`
-	Gemini     *orchestratorToggle `yaml:"gemini,omitempty"`
-	Opencode   *orchestratorToggle `yaml:"opencode,omitempty"`
-	Infer      *orchestratorToggle `yaml:"infer,omitempty"`
+	Claudecode *appOrchestratorToggle `yaml:"claudecode,omitempty"`
+	Codex      *orchestratorToggle    `yaml:"codex,omitempty"`
+	Gemini     *orchestratorToggle    `yaml:"gemini,omitempty"`
+	Opencode   *orchestratorToggle    `yaml:"opencode,omitempty"`
+	Infer      *appOrchestratorToggle `yaml:"infer,omitempty"`
+}
+
+// appOrchestratorToggle is an orchestrator switch that additionally carries
+// the GitHub App secret names used by its generated workflow (claudecode,
+// infer). Empty values are omitted and the schema defaults apply.
+type appOrchestratorToggle struct {
+	Enabled             bool   `yaml:"enabled"`
+	AppIDSecret         string `yaml:"appIdSecret,omitempty"`
+	AppPrivateKeySecret string `yaml:"appPrivateKeySecret,omitempty"`
 }
 
 // aiBlock mirrors spec.development.ai: coding-agent orchestrators nested
@@ -337,9 +346,9 @@ type adlData struct {
 		} `yaml:"deployment,omitempty"`
 		Documentation *struct {
 			Pages []struct {
-					Title       string `yaml:"title"`
-					Path        string `yaml:"path"`
-					Description string `yaml:"description,omitempty"`
+				Title       string `yaml:"title"`
+				Path        string `yaml:"path"`
+				Description string `yaml:"description,omitempty"`
 			} `yaml:"pages,omitempty"`
 		} `yaml:"documentation,omitempty"`
 		Examples []struct {
@@ -456,6 +465,14 @@ type answers struct {
 	Gemini     bool
 	Opencode   bool
 	Infer      bool
+
+	// GitHub App secret names for the claudecode / infer workflows. Empty
+	// means the schema default (CLAUDE_APP_ID / INFER_APP_ID etc.) and the
+	// field is omitted from the manifest.
+	ClaudecodeAppIDSecret         string
+	ClaudecodeAppPrivateKeySecret string
+	InferAppIDSecret              string
+	InferAppPrivateKeySecret      string
 }
 
 // defaultToolSchema returns the placeholder JSON schema generated for a freshly
@@ -785,11 +802,19 @@ func buildADL(ans answers) *adlData {
 	ensureDevelopment(adl)
 	adl.Spec.Development.AI = &aiBlock{
 		Orchestrators: &orchestratorsBlock{
-			Claudecode: &orchestratorToggle{Enabled: ans.Claudecode},
-			Codex:      &orchestratorToggle{Enabled: ans.Codex},
-			Gemini:     &orchestratorToggle{Enabled: ans.Gemini},
-			Opencode:   &orchestratorToggle{Enabled: ans.Opencode},
-			Infer:      &orchestratorToggle{Enabled: ans.Infer},
+			Claudecode: &appOrchestratorToggle{
+				Enabled:             ans.Claudecode,
+				AppIDSecret:         ans.ClaudecodeAppIDSecret,
+				AppPrivateKeySecret: ans.ClaudecodeAppPrivateKeySecret,
+			},
+			Codex:    &orchestratorToggle{Enabled: ans.Codex},
+			Gemini:   &orchestratorToggle{Enabled: ans.Gemini},
+			Opencode: &orchestratorToggle{Enabled: ans.Opencode},
+			Infer: &appOrchestratorToggle{
+				Enabled:             ans.Infer,
+				AppIDSecret:         ans.InferAppIDSecret,
+				AppPrivateKeySecret: ans.InferAppPrivateKeySecret,
+			},
 		},
 	}
 
@@ -1135,8 +1160,24 @@ func collectAnswersNonInteractive(projectName string, useDefaults bool) answers 
 
 	tui.Println(tui.Header("AI Assistant Documentation"))
 	ans.Claudecode = promptBoolWithConfig("ai", useDefaults, "Enable Claude Code (CLAUDE.md + claude-code in sandboxes)", false)
+	if ans.Claudecode {
+		ans.ClaudecodeAppIDSecret = nonDefault(
+			conditionalPrompt(useDefaults, "GitHub App client ID secret name for Claude Code", "CLAUDE_APP_ID"), "CLAUDE_APP_ID")
+		ans.ClaudecodeAppPrivateKeySecret = nonDefault(
+			conditionalPrompt(useDefaults, "GitHub App private key secret name for Claude Code", "CLAUDE_APP_PRIVATE_KEY"), "CLAUDE_APP_PRIVATE_KEY")
+	}
 
 	return ans
+}
+
+// nonDefault returns v unless it equals the schema default, in which case it
+// returns "" so the field is omitted from the manifest and the default keeps
+// applying.
+func nonDefault(v, def string) string {
+	if v == def {
+		return ""
+	}
+	return v
 }
 
 // ensureDevelopment lazily initialises adl.Spec.Development so that callers

--- a/cmd/init_wizard.go
+++ b/cmd/init_wizard.go
@@ -585,6 +585,31 @@ func collectDeploymentSCM(ans *answers) {
 	ans.Gemini = slices.Contains(orchestrators, "gemini")
 	ans.Opencode = slices.Contains(orchestrators, "opencode")
 	ans.Infer = slices.Contains(orchestrators, "infer")
+
+	// claudecode and infer generate workflows that authenticate with a
+	// GitHub App; let the user override the repository secret names.
+	secretFields := []huh.Field{}
+	claudeAppID, claudeAppKey := "CLAUDE_APP_ID", "CLAUDE_APP_PRIVATE_KEY"
+	inferAppID, inferAppKey := "INFER_APP_ID", "INFER_APP_PRIVATE_KEY"
+	if ans.Claudecode {
+		secretFields = append(secretFields,
+			huh.NewInput().Title("Claude Code GitHub App client ID secret name").Value(&claudeAppID),
+			huh.NewInput().Title("Claude Code GitHub App private key secret name").Value(&claudeAppKey),
+		)
+	}
+	if ans.Infer {
+		secretFields = append(secretFields,
+			huh.NewInput().Title("Infer GitHub App client ID secret name").Value(&inferAppID),
+			huh.NewInput().Title("Infer GitHub App private key secret name").Value(&inferAppKey),
+		)
+	}
+	if len(secretFields) > 0 {
+		runFields(secretFields)
+	}
+	ans.ClaudecodeAppIDSecret = nonDefault(claudeAppID, "CLAUDE_APP_ID")
+	ans.ClaudecodeAppPrivateKeySecret = nonDefault(claudeAppKey, "CLAUDE_APP_PRIVATE_KEY")
+	ans.InferAppIDSecret = nonDefault(inferAppID, "INFER_APP_ID")
+	ans.InferAppPrivateKeySecret = nonDefault(inferAppKey, "INFER_APP_PRIVATE_KEY")
 }
 
 // wizardServices runs the "add another service" loop.

--- a/cmd/init_wizard.go
+++ b/cmd/init_wizard.go
@@ -586,8 +586,6 @@ func collectDeploymentSCM(ans *answers) {
 	ans.Opencode = slices.Contains(orchestrators, "opencode")
 	ans.Infer = slices.Contains(orchestrators, "infer")
 
-	// claudecode and infer generate workflows that authenticate with a
-	// GitHub App; let the user override the repository secret names.
 	secretFields := []huh.Field{}
 	claudeAppID, claudeAppKey := "CLAUDE_APP_ID", "CLAUDE_APP_PRIVATE_KEY"
 	inferAppID, inferAppKey := "INFER_APP_ID", "INFER_APP_PRIVATE_KEY"

--- a/internal/schema/schema.json
+++ b/internal/schema/schema.json
@@ -604,7 +604,17 @@
       "description": "Provision Anthropic's Claude Code coding agent inside the sandbox.",
       "required": ["enabled"],
       "properties": {
-        "enabled": { "type": "boolean" }
+        "enabled": { "type": "boolean" },
+        "appIdSecret": {
+          "type": "string",
+          "description": "Name of the repository secret holding the GitHub App client ID used by the generated Claude Code workflow.",
+          "default": "CLAUDE_APP_ID"
+        },
+        "appPrivateKeySecret": {
+          "type": "string",
+          "description": "Name of the repository secret holding the GitHub App private key used by the generated Claude Code workflow.",
+          "default": "CLAUDE_APP_PRIVATE_KEY"
+        }
       }
     },
     "CodexConfig": {
@@ -636,7 +646,17 @@
       "description": "Provision the Inference Gateway 'infer' coding agent inside the sandbox.",
       "required": ["enabled"],
       "properties": {
-        "enabled": { "type": "boolean" }
+        "enabled": { "type": "boolean" },
+        "appIdSecret": {
+          "type": "string",
+          "description": "Name of the repository secret holding the GitHub App client ID used by the generated infer workflow.",
+          "default": "INFER_APP_ID"
+        },
+        "appPrivateKeySecret": {
+          "type": "string",
+          "description": "Name of the repository secret holding the GitHub App private key used by the generated infer workflow.",
+          "default": "INFER_APP_PRIVATE_KEY"
+        }
       }
     },
     "FloxConfig": {

--- a/internal/schema/types.go
+++ b/internal/schema/types.go
@@ -114,6 +114,14 @@ type Card struct {
 
 // Provision Anthropic's Claude Code coding agent inside the sandbox.
 type ClaudeCodeConfig struct {
+	// Name of the repository secret holding the GitHub App client ID used by the
+	// generated Claude Code workflow.
+	AppIDSecret string `json:"appIdSecret,omitempty,omitzero" yaml:"appIdSecret,omitempty" mapstructure:"appIdSecret,omitempty"`
+
+	// Name of the repository secret holding the GitHub App private key used by the
+	// generated Claude Code workflow.
+	AppPrivateKeySecret string `json:"appPrivateKeySecret,omitempty,omitzero" yaml:"appPrivateKeySecret,omitempty" mapstructure:"appPrivateKeySecret,omitempty"`
+
 	// Enabled corresponds to the JSON schema field "enabled".
 	Enabled bool `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
 }
@@ -330,6 +338,14 @@ type ImageConfig struct {
 
 // Provision the Inference Gateway 'infer' coding agent inside the sandbox.
 type InferConfig struct {
+	// Name of the repository secret holding the GitHub App client ID used by the
+	// generated infer workflow.
+	AppIDSecret string `json:"appIdSecret,omitempty,omitzero" yaml:"appIdSecret,omitempty" mapstructure:"appIdSecret,omitempty"`
+
+	// Name of the repository secret holding the GitHub App private key used by the
+	// generated infer workflow.
+	AppPrivateKeySecret string `json:"appPrivateKeySecret,omitempty,omitzero" yaml:"appPrivateKeySecret,omitempty" mapstructure:"appPrivateKeySecret,omitempty"`
+
 	// Enabled corresponds to the JSON schema field "enabled".
 	Enabled bool `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
 }

--- a/internal/templates/common/github/workflows/ai-claude-code.yaml.tmpl
+++ b/internal/templates/common/github/workflows/ai-claude-code.yaml.tmpl
@@ -1,4 +1,13 @@
 ---
+# Runs Anthropic's Claude Code agent on issues and pull requests that
+# mention @claude, and opens a pull request with its changes.
+#
+# Requires a GitHub App installed on this repository with contents,
+# pull-requests and issues write permissions. Store its client ID and
+# private key as the {{ .ADL.Spec.Development.AI.Orchestrators.Claudecode.AppIDSecret | default "CLAUDE_APP_ID" }} and {{ .ADL.Spec.Development.AI.Orchestrators.Claudecode.AppPrivateKeySecret | default "CLAUDE_APP_PRIVATE_KEY" }} repository
+# secrets (names configurable via spec.development.ai.orchestrators.claudecode
+# appIdSecret / appPrivateKeySecret). The App token is used to create pull
+# requests so CI still triggers on them.
 name: Claude Code
 
 on:
@@ -124,9 +133,18 @@ jobs:
             echo "EOF" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3.2.0
+        with:
+          client-id: ${{`{{ secrets.`}}{{ .ADL.Spec.Development.AI.Orchestrators.Claudecode.AppIDSecret | default "CLAUDE_APP_ID" }}{{` }}`}}
+          private-key: ${{`{{ secrets.`}}{{ .ADL.Spec.Development.AI.Orchestrators.Claudecode.AppPrivateKeySecret | default "CLAUDE_APP_PRIVATE_KEY" }}{{` }}`}}
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1.0.174
+        env:
+          GH_TOKEN: ${{`{{ steps.app-token.outputs.token }}`}}
         with:
           claude_code_oauth_token: ${{`{{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}`}}
           display_report: true
@@ -139,5 +157,6 @@ jobs:
             --effort max
             --model claude-opus-4-8
             --allowedTools "Bash(task:*),Bash(gh:*),Bash(git:*),Bash(adl:*){{- if eq .Language "go" }},Bash(go:*){{- else if eq .Language "rust" }},Bash(cargo:*){{- else if eq .Language "typescript" }},Bash(npm:*),Bash(node:*){{- end }}"
+            --append-system-prompt "After pushing commits to a new branch (issue-triggered runs), open the pull request yourself with 'gh pr create' against main, titled with a conventional commit prefix and linking the triggering issue via 'Closes #<number>' in the body. GH_TOKEN is already set for gh. Do not just post a link to a PR creation page. When working on an existing pull request branch, do not create a new pull request."
           prompt: ${{`{{ steps.set-prompt.outputs.value }}`}}
           track_progress: ${{`{{ github.event_name != 'workflow_dispatch' }}`}}

--- a/internal/templates/common/github/workflows/ai-infer.yaml.tmpl
+++ b/internal/templates/common/github/workflows/ai-infer.yaml.tmpl
@@ -8,7 +8,9 @@ name: Infer
 #
 # Requires a GitHub App installed on this repository with contents,
 # pull-requests and issues write permissions. Store its client ID and
-# private key as the APP_ID and APP_PRIVATE_KEY repository secrets.
+# private key as the {{ .ADL.Spec.Development.AI.Orchestrators.Infer.AppIDSecret | default "INFER_APP_ID" }} and {{ .ADL.Spec.Development.AI.Orchestrators.Infer.AppPrivateKeySecret | default "INFER_APP_PRIVATE_KEY" }} repository secrets
+# (names configurable via spec.development.ai.orchestrators.infer
+# appIdSecret / appPrivateKeySecret).
 #
 # The model / provider below is a starting point - swap it (and the matching
 # provider API key secret) for whichever model you prefer. A `/model
@@ -65,8 +67,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3.2.0
         with:
-          client-id: ${{`{{ secrets.APP_ID }}`}}
-          private-key: ${{`{{ secrets.APP_PRIVATE_KEY }}`}}
+          client-id: ${{`{{ secrets.`}}{{ .ADL.Spec.Development.AI.Orchestrators.Infer.AppIDSecret | default "INFER_APP_ID" }}{{` }}`}}
+          private-key: ${{`{{ secrets.`}}{{ .ADL.Spec.Development.AI.Orchestrators.Infer.AppPrivateKeySecret | default "INFER_APP_PRIVATE_KEY" }}{{` }}`}}
 
       - name: Get GitHub App User ID
         id: get-user-id


### PR DESCRIPTION
Closes #296

## What

- Bumps `ADL_SCHEMA_VERSION` to v0.21.0 (inference-gateway/adl#112) and regenerates types.
- The generated Claude Code workflow now mints a GitHub App token (`actions/create-github-app-token`) and passes it as `GH_TOKEN`, and an appended system prompt instructs Claude to open the pull request itself with `gh pr create` on issue-triggered runs instead of posting a link to a PR creation page. Using an App token means CI still triggers on the PRs Claude opens. No fallback: the workflow fails if the App secrets are missing.
- `ai-claude-code` and `ai-infer` templates read the App secret names from `spec.development.ai.orchestrators.{claudecode,infer}.appIdSecret` / `appPrivateKeySecret`, defaulting to `CLAUDE_APP_ID`/`CLAUDE_APP_PRIVATE_KEY` and `INFER_APP_ID`/`INFER_APP_PRIVATE_KEY`.
- `adl init` (wizard and `--defaults`/non-interactive flow) prompts for the secret names when claudecode/infer are enabled; values equal to the schema default are omitted from the manifest.

## Breaking note

The infer workflow default secret names changed from `APP_ID`/`APP_PRIVATE_KEY` to `INFER_APP_ID`/`INFER_APP_PRIVATE_KEY`. Existing projects can keep their current secrets by setting `appIdSecret: APP_ID` and `appPrivateKeySecret: APP_PRIVATE_KEY` in the manifest.

## Verification

- `task ci` passes (fmt, lint, test, build, verify-schema against v0.21.0)
- `task examples:generate` passes
- Generated `examples/go-agent-ai.yaml` and inspected the claude workflow: App token step, `GH_TOKEN` env, and the gh pr create instruction render correctly
- Generated a manifest with custom `appIdSecret: MY_APP_ID`: rendered secrets follow the override
- `adl init --defaults --ai` echoes the default secret names and omits them from `agent.yaml`

## Impacted repos

- inference-gateway/adl: schema fields landed in v0.21.0 (#112)
- inference-gateway/docs: docs follow-up below

