### PR TITLE
feat(templates): make release workflow GitHub App secret names configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1809,8 +1809,11 @@ spec:
 
 **Required GitHub Secrets:**
 
-- `BOT_GH_APP_ID` - Your GitHub App ID
-- `BOT_GH_APP_PRIVATE_KEY` - Your GitHub App private key
+- `RELEASER_APP_ID` - Your GitHub App ID
+- `RELEASER_APP_PRIVATE_KEY` - Your GitHub App private key
+
+The secret names are configurable via `spec.scm.app_id_secret` and
+`spec.scm.app_private_key_secret` if your organization uses different names.
 
 When `github_app: true` is set, the generated CD pipeline will use GitHub App authentication instead of the default `GITHUB_TOKEN`, providing better security isolation for release management.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -6,7 +6,7 @@ vars:
   VERSION: 0.49.0
   BUILD_DIR: bin
   DIST_DIR: dist
-  ADL_SCHEMA_VERSION: v0.21.0
+  ADL_SCHEMA_VERSION: v0.22.0
   ADL_SCHEMA_URL: https://raw.githubusercontent.com/inference-gateway/adl/{{.ADL_SCHEMA_VERSION}}/schema/v1/schema.json
   ADL_SCHEMA_PATH: internal/schema/schema.json
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -318,13 +318,15 @@ type adlData struct {
 			} `yaml:"rust,omitempty"`
 		} `yaml:"language,omitempty"`
 		SCM *struct {
-			Provider       string `yaml:"provider"`
-			URL            string `yaml:"url,omitempty"`
-			GithubApp      bool   `yaml:"github_app,omitempty"`
-			IssueTemplates bool   `yaml:"issue_templates"`
-			Dependabot     bool   `yaml:"dependabot"`
-			CI             bool   `yaml:"ci"`
-			CD             bool   `yaml:"cd"`
+			Provider            string `yaml:"provider"`
+			URL                 string `yaml:"url,omitempty"`
+			GithubApp           bool   `yaml:"github_app,omitempty"`
+			AppIDSecret         string `yaml:"app_id_secret,omitempty"`
+			AppPrivateKeySecret string `yaml:"app_private_key_secret,omitempty"`
+			IssueTemplates      bool   `yaml:"issue_templates"`
+			Dependabot          bool   `yaml:"dependabot"`
+			CI                  bool   `yaml:"ci"`
+			CD                  bool   `yaml:"cd"`
 		} `yaml:"scm,omitempty"`
 		Development *struct {
 			Sandbox *struct {
@@ -450,13 +452,18 @@ type answers struct {
 
 	DeploymentType string
 
-	ScmProvider    string
-	ScmURL         string
-	GithubApp      bool
-	IssueTemplates bool
-	Dependabot     bool
-	CI             bool
-	CD             bool
+	ScmProvider string
+	ScmURL      string
+	GithubApp   bool
+	// GitHub App secret names for the release (CD) workflow. Empty means the
+	// schema defaults (RELEASER_APP_ID / RELEASER_APP_PRIVATE_KEY) and the
+	// fields are omitted from the manifest.
+	ScmAppIDSecret         string
+	ScmAppPrivateKeySecret string
+	IssueTemplates         bool
+	Dependabot             bool
+	CI                     bool
+	CD                     bool
 
 	// Coding-agent orchestrators (spec.development.ai.orchestrators). Only
 	// claudecode has a CLI flag (--ai); the rest are wizard/manifest-only.
@@ -777,13 +784,15 @@ func buildADL(ans answers) *adlData {
 
 	if ans.ScmProvider != "" {
 		adl.Spec.SCM = &struct {
-			Provider       string `yaml:"provider"`
-			URL            string `yaml:"url,omitempty"`
-			GithubApp      bool   `yaml:"github_app,omitempty"`
-			IssueTemplates bool   `yaml:"issue_templates"`
-			Dependabot     bool   `yaml:"dependabot"`
-			CI             bool   `yaml:"ci"`
-			CD             bool   `yaml:"cd"`
+			Provider            string `yaml:"provider"`
+			URL                 string `yaml:"url,omitempty"`
+			GithubApp           bool   `yaml:"github_app,omitempty"`
+			AppIDSecret         string `yaml:"app_id_secret,omitempty"`
+			AppPrivateKeySecret string `yaml:"app_private_key_secret,omitempty"`
+			IssueTemplates      bool   `yaml:"issue_templates"`
+			Dependabot          bool   `yaml:"dependabot"`
+			CI                  bool   `yaml:"ci"`
+			CD                  bool   `yaml:"cd"`
 		}{
 			Provider: ans.ScmProvider,
 		}
@@ -791,6 +800,8 @@ func buildADL(ans answers) *adlData {
 		if ans.ScmProvider == "github" {
 			adl.Spec.SCM.URL = ans.ScmURL
 			adl.Spec.SCM.GithubApp = ans.GithubApp
+			adl.Spec.SCM.AppIDSecret = ans.ScmAppIDSecret
+			adl.Spec.SCM.AppPrivateKeySecret = ans.ScmAppPrivateKeySecret
 			adl.Spec.SCM.IssueTemplates = ans.IssueTemplates
 			adl.Spec.SCM.Dependabot = ans.Dependabot
 		}
@@ -1138,6 +1149,12 @@ func collectAnswersNonInteractive(projectName string, useDefaults bool) answers 
 
 			ans.ScmURL = conditionalPrompt(useDefaults, "Repository URL", defaultURL)
 			ans.GithubApp = conditionalPromptBool(useDefaults, "Enable GitHub App integration", true)
+			if ans.GithubApp {
+				ans.ScmAppIDSecret = nonDefault(
+					conditionalPrompt(useDefaults, "GitHub App client ID secret name for releases", "RELEASER_APP_ID"), "RELEASER_APP_ID")
+				ans.ScmAppPrivateKeySecret = nonDefault(
+					conditionalPrompt(useDefaults, "GitHub App private key secret name for releases", "RELEASER_APP_PRIVATE_KEY"), "RELEASER_APP_PRIVATE_KEY")
+			}
 
 			if useDefaults {
 				ans.IssueTemplates = false

--- a/cmd/init_wizard.go
+++ b/cmd/init_wizard.go
@@ -542,8 +542,6 @@ func collectDeploymentSCM(ans *answers) {
 		ans.IssueTemplates = issueTemplates
 		ans.Dependabot = dependabot
 
-		// The release (CD) workflow authenticates with a GitHub App; let the
-		// user override the repository secret names.
 		if githubApp {
 			releaserAppID, releaserAppKey := "RELEASER_APP_ID", "RELEASER_APP_PRIVATE_KEY"
 			runFields([]huh.Field{

--- a/cmd/init_wizard.go
+++ b/cmd/init_wizard.go
@@ -541,6 +541,18 @@ func collectDeploymentSCM(ans *answers) {
 		ans.GithubApp = githubApp
 		ans.IssueTemplates = issueTemplates
 		ans.Dependabot = dependabot
+
+		// The release (CD) workflow authenticates with a GitHub App; let the
+		// user override the repository secret names.
+		if githubApp {
+			releaserAppID, releaserAppKey := "RELEASER_APP_ID", "RELEASER_APP_PRIVATE_KEY"
+			runFields([]huh.Field{
+				huh.NewInput().Title("Release GitHub App client ID secret name").Value(&releaserAppID),
+				huh.NewInput().Title("Release GitHub App private key secret name").Value(&releaserAppKey),
+			})
+			ans.ScmAppIDSecret = nonDefault(releaserAppID, "RELEASER_APP_ID")
+			ans.ScmAppPrivateKeySecret = nonDefault(releaserAppKey, "RELEASER_APP_PRIVATE_KEY")
+		}
 	}
 
 	if provider != "" {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -569,11 +569,11 @@ func TestGenerator_generateCD(t *testing.T) {
 				if !containsSubstring(string(cdContent), "actions/create-github-app-token") {
 					t.Errorf("expected GitHub App CD workflow to contain github-app-token action")
 				}
-				if !containsSubstring(string(cdContent), "BOT_GH_APP_ID") {
-					t.Errorf("expected GitHub App CD workflow to contain BOT_GH_APP_ID secret")
+				if !containsSubstring(string(cdContent), "RELEASER_APP_ID") {
+					t.Errorf("expected GitHub App CD workflow to contain RELEASER_APP_ID secret")
 				}
-				if !containsSubstring(string(cdContent), "BOT_GH_APP_PRIVATE_KEY") {
-					t.Errorf("expected GitHub App CD workflow to contain BOT_GH_APP_PRIVATE_KEY secret")
+				if !containsSubstring(string(cdContent), "RELEASER_APP_PRIVATE_KEY") {
+					t.Errorf("expected GitHub App CD workflow to contain RELEASER_APP_PRIVATE_KEY secret")
 				}
 				if !containsSubstring(string(cdContent), "Get GitHub App User ID") {
 					t.Errorf("expected GitHub App CD workflow to contain user ID step")

--- a/internal/schema/schema.json
+++ b/internal/schema/schema.json
@@ -550,6 +550,16 @@
         },
         "url": { "type": "string" },
         "github_app": { "type": "boolean" },
+        "app_id_secret": {
+          "type": "string",
+          "description": "Name of the repository secret holding the GitHub App client ID used by the generated release (CD) workflow when github_app is enabled.",
+          "default": "RELEASER_APP_ID"
+        },
+        "app_private_key_secret": {
+          "type": "string",
+          "description": "Name of the repository secret holding the GitHub App private key used by the generated release (CD) workflow when github_app is enabled.",
+          "default": "RELEASER_APP_PRIVATE_KEY"
+        },
         "issue_templates": { "type": "boolean" },
         "dependabot": { "type": "boolean" },
         "ci": { "type": "boolean" },

--- a/internal/schema/types.go
+++ b/internal/schema/types.go
@@ -522,6 +522,14 @@ type RustConfig struct {
 }
 
 type SCM struct {
+	// Name of the repository secret holding the GitHub App client ID used by the
+	// generated release (CD) workflow when github_app is enabled.
+	AppIDSecret string `json:"app_id_secret,omitempty,omitzero" yaml:"app_id_secret,omitempty" mapstructure:"app_id_secret,omitempty"`
+
+	// Name of the repository secret holding the GitHub App private key used by the
+	// generated release (CD) workflow when github_app is enabled.
+	AppPrivateKeySecret string `json:"app_private_key_secret,omitempty,omitzero" yaml:"app_private_key_secret,omitempty" mapstructure:"app_private_key_secret,omitempty"`
+
 	// CD corresponds to the JSON schema field "cd".
 	CD bool `json:"cd,omitempty,omitzero" yaml:"cd,omitempty" mapstructure:"cd,omitempty"`
 

--- a/internal/templates/common/github/workflows/cd.yaml.tmpl
+++ b/internal/templates/common/github/workflows/cd.yaml.tmpl
@@ -24,8 +24,8 @@ jobs:
       - uses: actions/create-github-app-token@v3.2.0
         id: app-token
         with:
-          client-id: ${{`{{ secrets.BOT_GH_APP_ID }}`}}
-          private-key: ${{`{{ secrets.BOT_GH_APP_PRIVATE_KEY }}`}}
+          client-id: ${{`{{ secrets.`}}{{ .ADL.Spec.SCM.AppIDSecret | default "RELEASER_APP_ID" }}{{` }}`}}
+          private-key: ${{`{{ secrets.`}}{{ .ADL.Spec.SCM.AppPrivateKeySecret | default "RELEASER_APP_PRIVATE_KEY" }}{{` }}`}}
           owner: ${{`{{ github.repository_owner }}`}}
           repositories: |
             ${{`{{ github.event.repository.name }}`}}


### PR DESCRIPTION
## What

- Bumps `ADL_SCHEMA_VERSION` to v0.22.0 (inference-gateway/adl#113) and regenerates types.
- `cd.yaml` reads the release GitHub App secret names from `spec.scm.app_id_secret` / `app_private_key_secret`, defaulting to `RELEASER_APP_ID` / `RELEASER_APP_PRIVATE_KEY` (previously hardcoded `BOT_GH_APP_ID` / `BOT_GH_APP_PRIVATE_KEY`).
- `adl init` (wizard and `--defaults`/non-interactive flow) prompts for the secret names when GitHub App integration is enabled; values equal to the schema defaults are omitted from the manifest.
- README updated.

## Breaking note

The default release secret names changed from `BOT_GH_APP_ID` / `BOT_GH_APP_PRIVATE_KEY`. Existing projects can keep their current secrets by setting `spec.scm.app_id_secret: BOT_GH_APP_ID` and `spec.scm.app_private_key_secret: BOT_GH_APP_PRIVATE_KEY`.

## Verification

- `task ci` passes (fmt, lint, test, build, verify-schema against v0.22.0)
- `task examples:generate` passes
- Generated `cd.yml` with defaults renders `RELEASER_APP_ID`/`RELEASER_APP_PRIVATE_KEY`; with manifest overrides it renders the custom names
- `adl init --defaults` echoes the default secret names and omits them from `agent.yaml`