### PR TITLE
fix(init): write GitHub App secret names explicitly instead of omitting defaults

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1150,10 +1150,8 @@ func collectAnswersNonInteractive(projectName string, useDefaults bool) answers 
 			ans.ScmURL = conditionalPrompt(useDefaults, "Repository URL", defaultURL)
 			ans.GithubApp = conditionalPromptBool(useDefaults, "Enable GitHub App integration", true)
 			if ans.GithubApp {
-				ans.ScmAppIDSecret = nonDefault(
-					conditionalPrompt(useDefaults, "GitHub App client ID secret name for releases", "RELEASER_APP_ID"), "RELEASER_APP_ID")
-				ans.ScmAppPrivateKeySecret = nonDefault(
-					conditionalPrompt(useDefaults, "GitHub App private key secret name for releases", "RELEASER_APP_PRIVATE_KEY"), "RELEASER_APP_PRIVATE_KEY")
+				ans.ScmAppIDSecret = conditionalPrompt(useDefaults, "GitHub App client ID secret name for releases", "RELEASER_APP_ID")
+				ans.ScmAppPrivateKeySecret = conditionalPrompt(useDefaults, "GitHub App private key secret name for releases", "RELEASER_APP_PRIVATE_KEY")
 			}
 
 			if useDefaults {
@@ -1178,23 +1176,11 @@ func collectAnswersNonInteractive(projectName string, useDefaults bool) answers 
 	tui.Println(tui.Header("AI Assistant Documentation"))
 	ans.Claudecode = promptBoolWithConfig("ai", useDefaults, "Enable Claude Code (CLAUDE.md + claude-code in sandboxes)", false)
 	if ans.Claudecode {
-		ans.ClaudecodeAppIDSecret = nonDefault(
-			conditionalPrompt(useDefaults, "GitHub App client ID secret name for Claude Code", "CLAUDE_APP_ID"), "CLAUDE_APP_ID")
-		ans.ClaudecodeAppPrivateKeySecret = nonDefault(
-			conditionalPrompt(useDefaults, "GitHub App private key secret name for Claude Code", "CLAUDE_APP_PRIVATE_KEY"), "CLAUDE_APP_PRIVATE_KEY")
+		ans.ClaudecodeAppIDSecret = conditionalPrompt(useDefaults, "GitHub App client ID secret name for Claude Code", "CLAUDE_APP_ID")
+		ans.ClaudecodeAppPrivateKeySecret = conditionalPrompt(useDefaults, "GitHub App private key secret name for Claude Code", "CLAUDE_APP_PRIVATE_KEY")
 	}
 
 	return ans
-}
-
-// nonDefault returns v unless it equals the schema default, in which case it
-// returns "" so the field is omitted from the manifest and the default keeps
-// applying.
-func nonDefault(v, def string) string {
-	if v == def {
-		return ""
-	}
-	return v
 }
 
 // ensureDevelopment lazily initialises adl.Spec.Development so that callers

--- a/cmd/init_wizard.go
+++ b/cmd/init_wizard.go
@@ -548,8 +548,8 @@ func collectDeploymentSCM(ans *answers) {
 				huh.NewInput().Title("Release GitHub App client ID secret name").Value(&releaserAppID),
 				huh.NewInput().Title("Release GitHub App private key secret name").Value(&releaserAppKey),
 			})
-			ans.ScmAppIDSecret = nonDefault(releaserAppID, "RELEASER_APP_ID")
-			ans.ScmAppPrivateKeySecret = nonDefault(releaserAppKey, "RELEASER_APP_PRIVATE_KEY")
+			ans.ScmAppIDSecret = releaserAppID
+			ans.ScmAppPrivateKeySecret = releaserAppKey
 		}
 	}
 
@@ -614,10 +614,14 @@ func collectDeploymentSCM(ans *answers) {
 	if len(secretFields) > 0 {
 		runFields(secretFields)
 	}
-	ans.ClaudecodeAppIDSecret = nonDefault(claudeAppID, "CLAUDE_APP_ID")
-	ans.ClaudecodeAppPrivateKeySecret = nonDefault(claudeAppKey, "CLAUDE_APP_PRIVATE_KEY")
-	ans.InferAppIDSecret = nonDefault(inferAppID, "INFER_APP_ID")
-	ans.InferAppPrivateKeySecret = nonDefault(inferAppKey, "INFER_APP_PRIVATE_KEY")
+	if ans.Claudecode {
+		ans.ClaudecodeAppIDSecret = claudeAppID
+		ans.ClaudecodeAppPrivateKeySecret = claudeAppKey
+	}
+	if ans.Infer {
+		ans.InferAppIDSecret = inferAppID
+		ans.InferAppPrivateKeySecret = inferAppKey
+	}
 }
 
 // wizardServices runs the "add another service" loop.


### PR DESCRIPTION
## What

Removes the `nonDefault` helper: `adl init` (wizard and `--defaults`) now writes `appIdSecret`/`appPrivateKeySecret` (claudecode, infer) and `spec.scm.app_id_secret`/`app_private_key_secret` into the manifest even when they equal the schema defaults.

## Why

Omitting default-valued fields made them invisible: users could not discover the secret names from their own `agent.yaml`, and the org-wide `refresh-agent-manifest.yml` additive merge had nothing to add (the fresh scaffold carried no new keys), so the new fields never reached existing agents.

## Verification

- `task ci` green
- `adl init --defaults --ai` now emits `app_id_secret: RELEASER_APP_ID`, `app_private_key_secret: RELEASER_APP_PRIVATE_KEY` under `spec.scm` and `appIdSecret: CLAUDE_APP_ID`, `appPrivateKeySecret: CLAUDE_APP_PRIVATE_KEY` under the claudecode orchestrator