### PR TITLE
fix(init): always emit orchestrator GitHub App secret defaults

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1175,10 +1175,14 @@ func collectAnswersNonInteractive(projectName string, useDefaults bool) answers 
 
 	tui.Println(tui.Header("AI Assistant Documentation"))
 	ans.Claudecode = promptBoolWithConfig("ai", useDefaults, "Enable Claude Code (CLAUDE.md + claude-code in sandboxes)", false)
+	ans.ClaudecodeAppIDSecret = "CLAUDE_APP_ID"
+	ans.ClaudecodeAppPrivateKeySecret = "CLAUDE_APP_PRIVATE_KEY"
 	if ans.Claudecode {
 		ans.ClaudecodeAppIDSecret = conditionalPrompt(useDefaults, "GitHub App client ID secret name for Claude Code", "CLAUDE_APP_ID")
 		ans.ClaudecodeAppPrivateKeySecret = conditionalPrompt(useDefaults, "GitHub App private key secret name for Claude Code", "CLAUDE_APP_PRIVATE_KEY")
 	}
+	ans.InferAppIDSecret = "INFER_APP_ID"
+	ans.InferAppPrivateKeySecret = "INFER_APP_PRIVATE_KEY"
 
 	return ans
 }

--- a/cmd/init_wizard.go
+++ b/cmd/init_wizard.go
@@ -614,14 +614,10 @@ func collectDeploymentSCM(ans *answers) {
 	if len(secretFields) > 0 {
 		runFields(secretFields)
 	}
-	if ans.Claudecode {
-		ans.ClaudecodeAppIDSecret = claudeAppID
-		ans.ClaudecodeAppPrivateKeySecret = claudeAppKey
-	}
-	if ans.Infer {
-		ans.InferAppIDSecret = inferAppID
-		ans.InferAppPrivateKeySecret = inferAppKey
-	}
+	ans.ClaudecodeAppIDSecret = claudeAppID
+	ans.ClaudecodeAppPrivateKeySecret = claudeAppKey
+	ans.InferAppIDSecret = inferAppID
+	ans.InferAppPrivateKeySecret = inferAppKey
 }
 
 // wizardServices runs the "add another service" loop.


### PR DESCRIPTION
## What

Writes `appIdSecret`/`appPrivateKeySecret` defaults for the claudecode and infer orchestrators unconditionally in both the non-interactive flow and the wizard, instead of only when the orchestrator is enabled.

## Why

The manifest refresh workflow runs `adl init --defaults` (claudecode/infer disabled), so the fresh scaffold carried no secret keys under `spec.development.ai.orchestrators` and the additive yq merge had nothing to add - agents with claudecode/infer enabled never received `CLAUDE_APP_ID`/`INFER_APP_ID` etc. (seen in refresh run 29452066330 after v0.50.1).

## Verification

- `task ci` green
- `adl init --defaults` now emits the secret fields under both orchestrators even when disabled
- Replayed the refresh merge against google-calendar-agent's agent.yaml: `enabled: true` preserved, both secret-name pairs added