### PR TITLE
feat: generate CONFIGURATIONS.md and unify telemetry env vars under A2A_ prefix

### DIFF
--- a/internal/templates/common/ai/claude.md.tmpl
+++ b/internal/templates/common/ai/claude.md.tmpl
@@ -25,7 +25,7 @@ The codebase is generated using ADL CLI {{ .Metadata.CLIVersion }} and follows a
   - Graceful shutdown handling
 
 - **Agent Configuration**: `.well-known/agent-card.json` - Serves agent metadata at runtime
-- **Environment Configuration**: Extensive env vars with `A2A_` prefix (see README for full list)
+- **Environment Configuration**: Extensive env vars with `A2A_` prefix (see CONFIGURATIONS.md for full list)
 
 ## Development Commands
 

--- a/internal/templates/common/ai/gemini.md.tmpl
+++ b/internal/templates/common/ai/gemini.md.tmpl
@@ -29,7 +29,7 @@ The codebase is generated using ADL CLI {{ .Metadata.CLIVersion }} and follows a
   - Graceful shutdown handling
 
 - **Agent Configuration**: `.well-known/agent-card.json` - Serves agent metadata at runtime
-- **Environment Configuration**: Extensive env vars with `A2A_` prefix (see README for full list)
+- **Environment Configuration**: Extensive env vars with `A2A_` prefix (see CONFIGURATIONS.md for full list)
 
 ## Development Commands
 

--- a/internal/templates/common/config/dockerignore.tmpl
+++ b/internal/templates/common/config/dockerignore.tmpl
@@ -32,6 +32,7 @@ Dockerfile
 
 # Docs
 README.md
+CONFIGURATIONS.md
 CLAUDE.md
 AGENTS.md
 GEMINI.md

--- a/internal/templates/common/config/env.example.tmpl
+++ b/internal/templates/common/config/env.example.tmpl
@@ -50,17 +50,17 @@ A2A_TELEMETRY_ENABLE=true
 {{- if .ADL.Spec.Language.TypeScript }}
 
 # OpenTelemetry (spec.telemetry.enabled: true)
-# The TypeScript ADK starts the OpenTelemetry Node SDK when TELEMETRY_ENABLE is
-# truthy and reads the standard OTEL_* variables directly. Each OTEL_* below maps
-# 1:1 to a spec.telemetry field. Prometheus pull is not supported by the TS ADK
-# yet - push to a collector via OTLP instead.
-TELEMETRY_ENABLE=true
+# A2A_TELEMETRY_ENABLE is the master switch. Each A2A_OTEL_* below maps 1:1 to a
+# spec.telemetry field; the generated index.ts mirrors them onto the standard
+# OTEL_* names the OpenTelemetry Node SDK reads. Prometheus pull is not supported
+# by the TS ADK yet - push to a collector via OTLP instead.
+A2A_TELEMETRY_ENABLE=true
 {{- range telemetryEnvVars .ADL }}
 {{ .Key }}={{ .Value }}
 {{- end }}
-# OTEL_EXPORTER_OTLP_HEADERS and sampling stay runtime-only.
-# OTEL_SERVICE_NAME and OTEL_SERVICE_VERSION default to the agent card values.
-# OTEL_SERVICE_NAME=
-# OTEL_SERVICE_VERSION=
+# OTLP headers and sampling stay runtime-only.
+# Service name and version default to the agent card values.
+# A2A_OTEL_SERVICE_NAME=
+# A2A_OTEL_SERVICE_VERSION=
 {{- end }}
 {{- end }}

--- a/internal/templates/common/config/gitattributes.tmpl
+++ b/internal/templates/common/config/gitattributes.tmpl
@@ -108,6 +108,7 @@ src/tools/{{ .ID }}.ts linguist-generated=true
 
 # Documentation (partially generated)
 README.md linguist-documentation=true
+CONFIGURATIONS.md linguist-documentation=true
 
 # Preserve line endings for generated files
 {{- if eq .Language "go" }}

--- a/internal/templates/common/config/releaserc.yaml.tmpl
+++ b/internal/templates/common/config/releaserc.yaml.tmpl
@@ -94,6 +94,7 @@ plugins:
         - Dockerfile
         - main.go
         - README.md
+        - CONFIGURATIONS.md
         - Taskfile.yml
         - .well-known/agent-card.json
       message: "chore(release): 🔖 ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"

--- a/internal/templates/common/docs/CONFIGURATIONS.md.tmpl
+++ b/internal/templates/common/docs/CONFIGURATIONS.md.tmpl
@@ -1,0 +1,87 @@
+# Configuration
+
+{{ toTitleCase .ADL.Metadata.Name .ADL.Spec.Acronyms }} is configured via environment variables. Defaults are
+derived from `agent.yaml`; the env vars below override them at runtime.
+{{- if .ADL.Spec.Config }}
+
+## Custom Configuration
+
+| Category | Variable | Default |
+|----------|----------|---------|
+{{- range $category, $configs := .ADL.Spec.Config }}
+{{- range $key, $value := $configs }}
+{{- if kindIs "map" $value }}
+{{- range $leaf, $leafVal := $value }}
+| **{{ $category | title }}** | `{{ $category | toUpperSnakeCase }}_{{ $key | toUpperSnakeCase }}_{{ $leaf | toUpperSnakeCase }}` | `{{ $leafVal }}` |
+{{- end }}
+{{- else }}
+| **{{ $category | title }}** | `{{ $category | toUpperSnakeCase }}_{{ $key | toUpperSnakeCase }}` | `{{ $value }}` |
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+## Environment Variables
+
+| Category | Variable | Description | Default |
+|----------|----------|-------------|---------|
+| **Server** | `A2A_PORT` | Server port | `{{ .ADL.Spec.Server.Port | default 8080 }}` |
+| **Server** | `A2A_DEBUG` | Enable debug mode | `{{ .ADL.Spec.Server.Debug | default false }}` |
+| **Server** | `A2A_AGENT_URL` | Agent URL for internal references | `{{ .ADL.Spec.Server.Scheme | default "http" }}://localhost:{{ .ADL.Spec.Server.Port | default 8080 }}` |
+| **Server** | `A2A_STREAMING_STATUS_UPDATE_INTERVAL` | Streaming status update frequency | `1s` |
+| **Server** | `A2A_SERVER_READ_TIMEOUT` | HTTP server read timeout | `120s` |
+| **Server** | `A2A_SERVER_WRITE_TIMEOUT` | HTTP server write timeout | `120s` |
+| **Server** | `A2A_SERVER_IDLE_TIMEOUT` | HTTP server idle timeout | `120s` |
+| **Server** | `A2A_SERVER_DISABLE_HEALTHCHECK_LOG` | Disable logging for health check requests | `true` |
+| **Agent Metadata** | `A2A_AGENT_CARD_FILE_PATH` | Path to agent card JSON file | `.well-known/agent-card.json` |
+| **LLM Client** | `A2A_AGENT_CLIENT_PROVIDER` | LLM provider (`openai`, `anthropic`, `azure`, `ollama`, `deepseek`) | {{- if .ADL.Spec.Agent }}`{{ .ADL.Spec.Agent.Provider }}`{{- else }}`openai`{{- end }} |
+| **LLM Client** | `A2A_AGENT_CLIENT_MODEL` | Model to use | {{- if .ADL.Spec.Agent }}`{{ .ADL.Spec.Agent.Model }}`{{- else }}`gpt-5.5`{{- end }} |
+| **LLM Client** | `A2A_AGENT_CLIENT_API_KEY` | API key for LLM provider | - |
+| **LLM Client** | `A2A_AGENT_CLIENT_BASE_URL` | Custom LLM API endpoint | - |
+| **LLM Client** | `A2A_AGENT_CLIENT_TIMEOUT` | Timeout for LLM requests | `30s` |
+| **LLM Client** | `A2A_AGENT_CLIENT_MAX_RETRIES` | Maximum retries for LLM requests | `3` |
+| **LLM Client** | `A2A_AGENT_CLIENT_MAX_CHAT_COMPLETION_ITERATIONS` | Max chat completion rounds | `10` |
+| **LLM Client** | `A2A_AGENT_CLIENT_MAX_TOKENS` | Maximum tokens for LLM responses | {{- if and .ADL.Spec.Agent .ADL.Spec.Agent.MaxTokens }}`{{ .ADL.Spec.Agent.MaxTokens }}`{{- else }}`4096`{{- end }} |
+| **LLM Client** | `A2A_AGENT_CLIENT_TEMPERATURE` | Controls randomness of LLM output | {{- if and .ADL.Spec.Agent .ADL.Spec.Agent.Temperature }}`{{ .ADL.Spec.Agent.Temperature }}`{{- else }}`0.7`{{- end }} |
+| **Capabilities** | `A2A_CAPABILITIES_STREAMING` | Enable streaming responses | `{{ .ADL.Spec.Capabilities.Streaming | default true }}` |
+| **Capabilities** | `A2A_CAPABILITIES_PUSH_NOTIFICATIONS` | Enable push notifications | `{{ .ADL.Spec.Capabilities.PushNotifications | default false }}` |
+| **Capabilities** | `A2A_CAPABILITIES_STATE_TRANSITION_HISTORY` | Track state transitions | `{{ .ADL.Spec.Capabilities.StateTransitionHistory | default false }}` |
+| **Task Management** | `A2A_TASK_RETENTION_MAX_COMPLETED_TASKS` | Max completed tasks to keep (0 = unlimited) | `100` |
+| **Task Management** | `A2A_TASK_RETENTION_MAX_FAILED_TASKS` | Max failed tasks to keep (0 = unlimited) | `50` |
+| **Task Management** | `A2A_TASK_RETENTION_CLEANUP_INTERVAL` | Cleanup frequency (0 = manual only) | `5m` |
+| **Storage** | `A2A_QUEUE_PROVIDER` | Storage backend (`memory` or `redis`) | `memory` |
+| **Storage** | `A2A_QUEUE_URL` | Redis connection URL (when using Redis) | - |
+| **Storage** | `A2A_QUEUE_MAX_SIZE` | Maximum queue size | `100` |
+| **Storage** | `A2A_QUEUE_CLEANUP_INTERVAL` | Task cleanup interval | `30s` |
+{{- if and .ADL.Spec.Artifacts .ADL.Spec.Artifacts.Enabled }}
+| **Artifacts** | `A2A_ARTIFACTS_ENABLE` | Enable artifacts support | `false` |
+| **Artifacts** | `A2A_ARTIFACTS_SERVER_HOST` | Artifacts server host | `localhost` |
+| **Artifacts** | `A2A_ARTIFACTS_SERVER_PORT` | Artifacts server port | `8081` |
+| **Artifacts** | `A2A_ARTIFACTS_STORAGE_PROVIDER` | Storage backend (`filesystem` or `minio`) | `filesystem` |
+| **Artifacts** | `A2A_ARTIFACTS_STORAGE_BASE_PATH` | Base path for filesystem storage | `./artifacts` |
+| **Artifacts** | `A2A_ARTIFACTS_STORAGE_BASE_URL` | Override base URL for direct downloads | (auto-generated) |
+| **Artifacts** | `A2A_ARTIFACTS_STORAGE_ENDPOINT` | MinIO/S3 endpoint URL | - |
+| **Artifacts** | `A2A_ARTIFACTS_STORAGE_ACCESS_KEY` | MinIO/S3 access key | - |
+| **Artifacts** | `A2A_ARTIFACTS_STORAGE_SECRET_KEY` | MinIO/S3 secret key | - |
+| **Artifacts** | `A2A_ARTIFACTS_STORAGE_BUCKET_NAME` | MinIO/S3 bucket name | `artifacts` |
+| **Artifacts** | `A2A_ARTIFACTS_STORAGE_USE_SSL` | Use SSL for MinIO/S3 connections | `true` |
+| **Artifacts** | `A2A_ARTIFACTS_RETENTION_MAX_ARTIFACTS` | Max artifacts per task (0 = unlimited) | `5` |
+| **Artifacts** | `A2A_ARTIFACTS_RETENTION_MAX_AGE` | Max artifact age (0 = no age limit) | `168h` |
+| **Artifacts** | `A2A_ARTIFACTS_RETENTION_CLEANUP_INTERVAL` | Cleanup frequency (0 = manual only) | `24h` |
+{{- end }}
+{{- if and .ADL.Spec.Server.Auth .ADL.Spec.Server.Auth.Enabled }}
+| **Authentication** | `A2A_AUTH_ENABLE` | Enable OIDC authentication | `true` |
+| **Authentication** | `A2A_AUTH_ISSUER_URL` | OIDC issuer URL | - |
+| **Authentication** | `A2A_AUTH_CLIENT_ID` | OIDC client ID | - |
+| **Authentication** | `A2A_AUTH_CLIENT_SECRET` | OIDC client secret | - |
+{{- else }}
+| **Authentication** | `A2A_AUTH_ENABLE` | Enable OIDC authentication | `false` |
+{{- end }}
+{{- if and .ADL.Spec.Telemetry .ADL.Spec.Telemetry.Enabled }}
+{{- if or (eq .Language "go") (eq .Language "typescript") }}
+| **Telemetry** | `A2A_TELEMETRY_ENABLE` | Enable OpenTelemetry instrumentation | `true` |
+{{- end }}
+{{- range telemetryEnvVars .ADL }}
+| **Telemetry** | `{{ .Key }}` | {{ .Description }} | `{{ .Value }}` |
+{{- end }}
+{{- end }}

--- a/internal/templates/common/docs/README.md.tmpl
+++ b/internal/templates/common/docs/README.md.tmpl
@@ -39,16 +39,12 @@ go run . start
 
 # Or build and invoke the CLI directly
 task build
-./bin/{{ .ADL.Metadata.Name }} --help
-./bin/{{ .ADL.Metadata.Name }} --version
 ./bin/{{ .ADL.Metadata.Name }} start
 {{- else if eq .Language "rust" }}
 cargo run -- start
 
 # Or build and invoke the CLI directly
 task build
-./target/release/{{ .ADL.Spec.Language.Rust.PackageName }} --help
-./target/release/{{ .ADL.Spec.Language.Rust.PackageName }} --version
 ./target/release/{{ .ADL.Spec.Language.Rust.PackageName }} start
 {{- else if eq .Language "typescript" }}
 pnpm install
@@ -99,6 +95,9 @@ infer agents add {{ .ADL.Metadata.Name }} {{ .ADL.Spec.Server.Scheme | default "
 {{- if .ADL.Spec.Capabilities.StateTransitionHistory }}
 - ✅ State transition history
 {{- end }}
+{{- end }}
+{{- if and .ADL.Spec.Telemetry .ADL.Spec.Telemetry.Enabled (ne .Language "rust") }}
+- ✅ OpenTelemetry instrumentation
 {{- end }}
 - ✅ Enterprise-ready
 - ✅ Minimal dependencies
@@ -156,96 +155,9 @@ infer agents add {{ .ADL.Metadata.Name }} {{ .ADL.Spec.Server.Scheme | default "
 
 ## Configuration
 
-Configure the agent via environment variables:
-{{- if .ADL.Spec.Config }}
-
-### Custom Configuration
-
-The following custom configuration variables are available. Defaults are
-derived from `spec.config.*` in `agent.yaml`; the env vars below override
-them at runtime.
-
-| Category | Variable | Default |
-|----------|----------|---------|
-{{- range $category, $configs := .ADL.Spec.Config }}
-{{- range $key, $value := $configs }}
-{{- if kindIs "map" $value }}
-{{- range $leaf, $leafVal := $value }}
-| **{{ $category | title }}** | `{{ $category | toUpperSnakeCase }}_{{ $key | toUpperSnakeCase }}_{{ $leaf | toUpperSnakeCase }}` | `{{ $leafVal }}` |
-{{- end }}
-{{- else }}
-| **{{ $category | title }}** | `{{ $category | toUpperSnakeCase }}_{{ $key | toUpperSnakeCase }}` | `{{ $value }}` |
-{{- end }}
-{{- end }}
-{{- end }}
-{{- end }}
-
-### Environment Variables
-
-| Category | Variable | Description | Default |
-|----------|----------|-------------|---------|
-| **Server** | `A2A_PORT` | Server port | `{{ .ADL.Spec.Server.Port | default 8080 }}` |
-| **Server** | `A2A_DEBUG` | Enable debug mode | `{{ .ADL.Spec.Server.Debug | default false }}` |
-| **Server** | `A2A_AGENT_URL` | Agent URL for internal references | `{{ .ADL.Spec.Server.Scheme | default "http" }}://localhost:{{ .ADL.Spec.Server.Port | default 8080 }}` |
-| **Server** | `A2A_STREAMING_STATUS_UPDATE_INTERVAL` | Streaming status update frequency | `1s` |
-| **Server** | `A2A_SERVER_READ_TIMEOUT` | HTTP server read timeout | `120s` |
-| **Server** | `A2A_SERVER_WRITE_TIMEOUT` | HTTP server write timeout | `120s` |
-| **Server** | `A2A_SERVER_IDLE_TIMEOUT` | HTTP server idle timeout | `120s` |
-| **Server** | `A2A_SERVER_DISABLE_HEALTHCHECK_LOG` | Disable logging for health check requests | `true` |
-| **Agent Metadata** | `A2A_AGENT_CARD_FILE_PATH` | Path to agent card JSON file | `.well-known/agent-card.json` |
-| **LLM Client** | `A2A_AGENT_CLIENT_PROVIDER` | LLM provider (`openai`, `anthropic`, `azure`, `ollama`, `deepseek`) | {{- if .ADL.Spec.Agent }}`{{ .ADL.Spec.Agent.Provider }}`{{- else }}`openai`{{- end }} |
-| **LLM Client** | `A2A_AGENT_CLIENT_MODEL` | Model to use | {{- if .ADL.Spec.Agent }}`{{ .ADL.Spec.Agent.Model }}`{{- else }}`gpt-5.5`{{- end }} |
-| **LLM Client** | `A2A_AGENT_CLIENT_API_KEY` | API key for LLM provider | - |
-| **LLM Client** | `A2A_AGENT_CLIENT_BASE_URL` | Custom LLM API endpoint | - |
-| **LLM Client** | `A2A_AGENT_CLIENT_TIMEOUT` | Timeout for LLM requests | `30s` |
-| **LLM Client** | `A2A_AGENT_CLIENT_MAX_RETRIES` | Maximum retries for LLM requests | `3` |
-| **LLM Client** | `A2A_AGENT_CLIENT_MAX_CHAT_COMPLETION_ITERATIONS` | Max chat completion rounds | `10` |
-| **LLM Client** | `A2A_AGENT_CLIENT_MAX_TOKENS` | Maximum tokens for LLM responses | {{- if and .ADL.Spec.Agent .ADL.Spec.Agent.MaxTokens }}`{{ .ADL.Spec.Agent.MaxTokens }}`{{- else }}`4096`{{- end }} |
-| **LLM Client** | `A2A_AGENT_CLIENT_TEMPERATURE` | Controls randomness of LLM output | {{- if and .ADL.Spec.Agent .ADL.Spec.Agent.Temperature }}`{{ .ADL.Spec.Agent.Temperature }}`{{- else }}`0.7`{{- end }} |
-| **Capabilities** | `A2A_CAPABILITIES_STREAMING` | Enable streaming responses | `{{ .ADL.Spec.Capabilities.Streaming | default true }}` |
-| **Capabilities** | `A2A_CAPABILITIES_PUSH_NOTIFICATIONS` | Enable push notifications | `{{ .ADL.Spec.Capabilities.PushNotifications | default false }}` |
-| **Capabilities** | `A2A_CAPABILITIES_STATE_TRANSITION_HISTORY` | Track state transitions | `{{ .ADL.Spec.Capabilities.StateTransitionHistory | default false }}` |
-| **Task Management** | `A2A_TASK_RETENTION_MAX_COMPLETED_TASKS` | Max completed tasks to keep (0 = unlimited) | `100` |
-| **Task Management** | `A2A_TASK_RETENTION_MAX_FAILED_TASKS` | Max failed tasks to keep (0 = unlimited) | `50` |
-| **Task Management** | `A2A_TASK_RETENTION_CLEANUP_INTERVAL` | Cleanup frequency (0 = manual only) | `5m` |
-| **Storage** | `A2A_QUEUE_PROVIDER` | Storage backend (`memory` or `redis`) | `memory` |
-| **Storage** | `A2A_QUEUE_URL` | Redis connection URL (when using Redis) | - |
-| **Storage** | `A2A_QUEUE_MAX_SIZE` | Maximum queue size | `100` |
-| **Storage** | `A2A_QUEUE_CLEANUP_INTERVAL` | Task cleanup interval | `30s` |
-{{- if and .ADL.Spec.Artifacts .ADL.Spec.Artifacts.Enabled }}
-| **Artifacts** | `A2A_ARTIFACTS_ENABLE` | Enable artifacts support | `false` |
-| **Artifacts** | `A2A_ARTIFACTS_SERVER_HOST` | Artifacts server host | `localhost` |
-| **Artifacts** | `A2A_ARTIFACTS_SERVER_PORT` | Artifacts server port | `8081` |
-| **Artifacts** | `A2A_ARTIFACTS_STORAGE_PROVIDER` | Storage backend (`filesystem` or `minio`) | `filesystem` |
-| **Artifacts** | `A2A_ARTIFACTS_STORAGE_BASE_PATH` | Base path for filesystem storage | `./artifacts` |
-| **Artifacts** | `A2A_ARTIFACTS_STORAGE_BASE_URL` | Override base URL for direct downloads | (auto-generated) |
-| **Artifacts** | `A2A_ARTIFACTS_STORAGE_ENDPOINT` | MinIO/S3 endpoint URL | - |
-| **Artifacts** | `A2A_ARTIFACTS_STORAGE_ACCESS_KEY` | MinIO/S3 access key | - |
-| **Artifacts** | `A2A_ARTIFACTS_STORAGE_SECRET_KEY` | MinIO/S3 secret key | - |
-| **Artifacts** | `A2A_ARTIFACTS_STORAGE_BUCKET_NAME` | MinIO/S3 bucket name | `artifacts` |
-| **Artifacts** | `A2A_ARTIFACTS_STORAGE_USE_SSL` | Use SSL for MinIO/S3 connections | `true` |
-| **Artifacts** | `A2A_ARTIFACTS_RETENTION_MAX_ARTIFACTS` | Max artifacts per task (0 = unlimited) | `5` |
-| **Artifacts** | `A2A_ARTIFACTS_RETENTION_MAX_AGE` | Max artifact age (0 = no age limit) | `168h` |
-| **Artifacts** | `A2A_ARTIFACTS_RETENTION_CLEANUP_INTERVAL` | Cleanup frequency (0 = manual only) | `24h` |
-{{- end }}
-{{- if and .ADL.Spec.Server.Auth .ADL.Spec.Server.Auth.Enabled }}
-| **Authentication** | `A2A_AUTH_ENABLE` | Enable OIDC authentication | `true` |
-| **Authentication** | `A2A_AUTH_ISSUER_URL` | OIDC issuer URL | - |
-| **Authentication** | `A2A_AUTH_CLIENT_ID` | OIDC client ID | - |
-| **Authentication** | `A2A_AUTH_CLIENT_SECRET` | OIDC client secret | - |
-{{- else }}
-| **Authentication** | `A2A_AUTH_ENABLE` | Enable OIDC authentication | `false` |
-{{- end }}
-{{- if and .ADL.Spec.Telemetry .ADL.Spec.Telemetry.Enabled }}
-{{- if eq .Language "go" }}
-| **Telemetry** | `A2A_TELEMETRY_ENABLE` | Enable OpenTelemetry instrumentation | `true` |
-{{- else if eq .Language "typescript" }}
-| **Telemetry** | `TELEMETRY_ENABLE` | Enable OpenTelemetry instrumentation | `true` |
-{{- end }}
-{{- range telemetryEnvVars .ADL }}
-| **Telemetry** | `{{ .Key }}` | {{ .Description }} | `{{ .Value }}` |
-{{- end }}
-{{- end }}
+The agent is configured via environment variables. Defaults are derived
+from `agent.yaml`; see [CONFIGURATIONS.md](CONFIGURATIONS.md) for the
+full reference of custom and `A2A_*` variables.
 
 ## Development
 
@@ -315,10 +227,6 @@ docker run --rm -it --network host ghcr.io/inference-gateway/a2a-debugger:latest
 The Docker image can be built with custom version information using build arguments:
 
 ```bash
-# Build with default values from ADL
-docker build -t {{ .ADL.Metadata.Name }} .
-
-# Build with custom version information
 docker build \
   --build-arg VERSION=1.2.3 \
   --build-arg AGENT_NAME="My Custom Agent" \

--- a/internal/templates/engine_test.go
+++ b/internal/templates/engine_test.go
@@ -470,13 +470,36 @@ func TestREADMETemplate_TitleIsHumanized(t *testing.T) {
 	}
 }
 
-// TestREADMETemplate_TelemetryEnvVars guards the regression from
+// TestREADMETemplate_LinksToConfigurations verifies the README delegates the
+// env-var reference to CONFIGURATIONS.md instead of inlining the A2A_* table.
+func TestREADMETemplate_LinksToConfigurations(t *testing.T) {
+	registry, err := NewRegistry("go")
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	engine := NewWithRegistry("minimal", registry)
+
+	out, err := engine.ExecuteTemplate("docs/README.md", Context{ADL: minimalGoADL(), Language: "go"})
+	if err != nil {
+		t.Fatalf("ExecuteTemplate(README.md): %v", err)
+	}
+
+	if !strings.Contains(out, "[CONFIGURATIONS.md](CONFIGURATIONS.md)") {
+		t.Error("README missing link to CONFIGURATIONS.md")
+	}
+	if strings.Contains(out, "A2A_AGENT_CLIENT_PROVIDER") {
+		t.Error("README still inlines the A2A_* env var table")
+	}
+}
+
+// TestCONFIGURATIONSTemplate_TelemetryEnvVars guards the regression from
 // inference-gateway/mock-agent#64: once telemetry moved from spec.config.telemetry
 // (which the "Custom Configuration" loop documented) to top-level spec.telemetry,
-// the README stopped documenting any telemetry env vars even though .env.example
-// still emits them. The env-var table must carry the language-specific master
-// switch plus every telemetryEnvVars entry, and stay empty when telemetry is off.
-func TestREADMETemplate_TelemetryEnvVars(t *testing.T) {
+// the docs stopped documenting any telemetry env vars even though .env.example
+// still emits them. The env-var table (now in CONFIGURATIONS.md) must carry the
+// language-specific master switch plus every telemetryEnvVars entry, and stay
+// empty when telemetry is off.
+func TestCONFIGURATIONSTemplate_TelemetryEnvVars(t *testing.T) {
 	enabledGo := &schema.TelemetryConfig{
 		Enabled: true,
 		Traces: &schema.TelemetryTracesConfig{
@@ -514,7 +537,7 @@ func TestREADMETemplate_TelemetryEnvVars(t *testing.T) {
 			},
 		},
 		{
-			name: "typescript enabled documents bare vars",
+			name: "typescript enabled documents A2A_-prefixed vars",
 			lang: "typescript",
 			adl: func() *schema.ADL {
 				adl := minimalTypeScriptADL()
@@ -529,10 +552,10 @@ func TestREADMETemplate_TelemetryEnvVars(t *testing.T) {
 				return adl
 			},
 			wantRows: []string{
-				"| **Telemetry** | `TELEMETRY_ENABLE` | Enable OpenTelemetry instrumentation | `true` |",
-				"| **Telemetry** | `OTEL_TRACES_EXPORTER` |",
+				"| **Telemetry** | `A2A_TELEMETRY_ENABLE` | Enable OpenTelemetry instrumentation | `true` |",
+				"| **Telemetry** | `A2A_OTEL_TRACES_EXPORTER` |",
 			},
-			wantAbsent: []string{"A2A_TELEMETRY_ENABLE"},
+			wantAbsent: []string{"| `TELEMETRY_ENABLE`", "| `OTEL_TRACES_EXPORTER`"},
 		},
 		{
 			name: "go disabled documents no telemetry rows",
@@ -554,19 +577,19 @@ func TestREADMETemplate_TelemetryEnvVars(t *testing.T) {
 			}
 			engine := NewWithRegistry("minimal", registry)
 
-			out, err := engine.ExecuteTemplate("docs/README.md", Context{ADL: tt.adl(), Language: tt.lang})
+			out, err := engine.ExecuteTemplate("docs/CONFIGURATIONS.md", Context{ADL: tt.adl(), Language: tt.lang})
 			if err != nil {
-				t.Fatalf("ExecuteTemplate(README.md): %v", err)
+				t.Fatalf("ExecuteTemplate(CONFIGURATIONS.md): %v", err)
 			}
 
 			for _, row := range tt.wantRows {
 				if !strings.Contains(out, row) {
-					t.Errorf("README missing telemetry row %q", row)
+					t.Errorf("CONFIGURATIONS.md missing telemetry row %q", row)
 				}
 			}
 			for _, absent := range tt.wantAbsent {
 				if strings.Contains(out, absent) {
-					t.Errorf("README unexpectedly contains %q", absent)
+					t.Errorf("CONFIGURATIONS.md unexpectedly contains %q", absent)
 				}
 			}
 		})

--- a/internal/templates/languages/typescript/index.ts.tmpl
+++ b/internal/templates/languages/typescript/index.ts.tmpl
@@ -94,11 +94,25 @@ handler.setEnableUsageMetadata(true);
 const storage = new InMemoryTaskStorage();
 {{- if and .ADL.Spec.Telemetry .ADL.Spec.Telemetry.Enabled }}
 
-// OpenTelemetry (spec.telemetry.enabled): start the Node SDK before the server
-// so inbound JSON-RPC requests get an `adk.jsonrpc.request` span and the OTLP
-// exporters are live. The provider is a no-op unless TELEMETRY_ENABLE is truthy
-// (see .env.example), so this is safe to run unconditionally; its lifecycle is
-// owned here - start() before listen(), shutdown() after close().
+// OpenTelemetry (spec.telemetry.enabled): the agent documents all telemetry
+// settings under the A2A_ prefix, but the ADK provider and the OpenTelemetry
+// Node SDK read TELEMETRY_ENABLE and the standard OTEL_* names - mirror each
+// A2A_-prefixed var onto its bare name (without clobbering an explicitly set
+// bare one) before SDK init.
+for (const [key, value] of Object.entries(process.env)) {
+  if (
+    (key.startsWith('A2A_OTEL_') || key === 'A2A_TELEMETRY_ENABLE') &&
+    process.env[key.slice(4)] === undefined
+  ) {
+    process.env[key.slice(4)] = value;
+  }
+}
+
+// Start the Node SDK before the server so inbound JSON-RPC requests get an
+// `adk.jsonrpc.request` span and the OTLP exporters are live. The provider is
+// a no-op unless A2A_TELEMETRY_ENABLE is truthy (see .env.example), so this is
+// safe to run unconditionally; its lifecycle is owned here - start() before
+// listen(), shutdown() after close().
 const telemetry = createTelemetryProvider({
   serviceName: card.name,
   serviceVersion: card.version,

--- a/internal/templates/registry.go
+++ b/internal/templates/registry.go
@@ -152,6 +152,7 @@ func (r *Registry) getGoFiles(adl *schema.ADL) map[string]string {
 		".gitattributes":              "config/gitattributes",
 		".editorconfig":               "config/editorconfig",
 		"README.md":                   "docs/README.md",
+		"CONFIGURATIONS.md":           "docs/CONFIGURATIONS.md",
 		"LICENSE":                     "docs/LICENSE",
 	}
 
@@ -223,6 +224,7 @@ func (r *Registry) getRustFiles(adl *schema.ADL) map[string]string {
 		".gitattributes":              "config/gitattributes",
 		".editorconfig":               "config/editorconfig",
 		"README.md":                   "docs/README.md",
+		"CONFIGURATIONS.md":           "docs/CONFIGURATIONS.md",
 		"LICENSE":                     "docs/LICENSE",
 	}
 
@@ -292,6 +294,7 @@ func (r *Registry) getTypeScriptFiles(adl *schema.ADL) map[string]string {
 		".gitattributes":              "config/gitattributes",
 		".editorconfig":               "config/editorconfig",
 		"README.md":                   "docs/README.md",
+		"CONFIGURATIONS.md":           "docs/CONFIGURATIONS.md",
 		"LICENSE":                     "docs/LICENSE",
 	}
 

--- a/internal/templates/registry_dockerignore_test.go
+++ b/internal/templates/registry_dockerignore_test.go
@@ -68,6 +68,7 @@ func TestDockerignoreTemplate_ContainsExpectedExclusions(t *testing.T) {
 		"target/",
 		"node_modules/",
 		"README.md",
+		"CONFIGURATIONS.md",
 	}
 	for _, line := range wantLines {
 		if !strings.Contains(out, line) {

--- a/internal/templates/telemetry_env.go
+++ b/internal/templates/telemetry_env.go
@@ -17,23 +17,24 @@ type TelemetryEnvVar struct {
 
 // telemetryEnvVars maps a manifest's spec.telemetry exporter blocks to the
 // OpenTelemetry SDK environment variables. It returns only the exporter
-// variables; the master switch (A2A_TELEMETRY_ENABLE / TELEMETRY_ENABLE) is
-// emitted by the template since its name is language-specific.
+// variables; the master switch (A2A_TELEMETRY_ENABLE) is emitted by the
+// template.
 //
-// The key prefix is language-specific:
+// Every variable carries the A2A_ prefix regardless of language, so agents
+// document one consistent surface:
 //   - Go reads the OTel settings through the ADK config, which nests the whole
 //     server config under the A2A_ prefix (config.Config.A2A is
 //     `env:",prefix=A2A_"`) while its OTelConfig carries no prefix of its own -
-//     so every standard OTEL_* name is emitted as A2A_OTEL_*. The Go ADK only
+//     so every standard OTEL_* name is read as A2A_OTEL_*. The Go ADK only
 //     exposes the shared OTEL_EXPORTER_OTLP_{ENDPOINT,PROTOCOL} fields (it has no
 //     per-signal variants), so it always emits that shared pair from whichever
 //     signal pushes over OTLP.
-//   - TypeScript hands the OTLP settings straight to the OpenTelemetry Node SDK,
-//     which reads the bare OTEL_* names from process.env, so they stay
-//     unprefixed. The Node SDK honors the per-signal
-//     OTEL_EXPORTER_OTLP_{TRACES,METRICS}_* names, so when traces and metrics
-//     push to different collectors it emits those and otherwise collapses to the
-//     shared pair.
+//   - TypeScript hands the OTLP settings to the OpenTelemetry Node SDK, which
+//     reads the bare OTEL_* names from process.env - the generated index.ts
+//     mirrors each A2A_OTEL_* var onto its bare name before SDK init. The Node
+//     SDK honors the per-signal OTEL_EXPORTER_OTLP_{TRACES,METRICS}_* names, so
+//     when traces and metrics push to different collectors it emits those and
+//     otherwise collapses to the shared pair.
 //
 // Signal selection follows the schema's declarative-config model: a present
 // traces/metrics exporter sets OTEL_{TRACES,METRICS}_EXPORTER to the chosen key
@@ -53,10 +54,7 @@ func telemetryEnvVars(adl *schema.ADL) []TelemetryEnvVar {
 		return nil
 	}
 
-	prefix := ""
-	if lang == "go" {
-		prefix = "A2A_"
-	}
+	const prefix = "A2A_"
 
 	tel := adl.Spec.Telemetry
 
@@ -130,9 +128,9 @@ func exporterValue(configured bool, key string) string {
 }
 
 // appendOTLPEnv appends the endpoint/protocol vars for one OTLP exporter using
-// the given prefix ("" for TypeScript, "A2A_" for Go) and infix ("" shared, or
-// "TRACES_"/"METRICS_" per-signal). A nil exporter or an omitted field
-// contributes nothing so the SDK default applies.
+// the given prefix and infix ("" shared, or "TRACES_"/"METRICS_" per-signal).
+// A nil exporter or an omitted field contributes nothing so the SDK default
+// applies.
 func appendOTLPEnv(out []TelemetryEnvVar, prefix, infix string, otlp *schema.TelemetryOTLPExporter) []TelemetryEnvVar {
 	if otlp == nil {
 		return out

--- a/internal/templates/telemetry_env_test.go
+++ b/internal/templates/telemetry_env_test.go
@@ -67,10 +67,11 @@ func TestTelemetryEnvVars_GoUsesA2APrefix(t *testing.T) {
 	}
 }
 
-// TestTelemetryEnvVars_TypeScriptStaysBare asserts the TypeScript contract: the
-// OTLP variables stay bare OTEL_* because the OpenTelemetry Node SDK reads them
-// from process.env directly, so prefixing them with A2A_ would disable telemetry.
-func TestTelemetryEnvVars_TypeScriptStaysBare(t *testing.T) {
+// TestTelemetryEnvVars_TypeScriptUsesA2APrefix asserts the TypeScript vars carry
+// the same A2A_ prefix as Go for a consistent surface; the generated index.ts
+// mirrors each A2A_OTEL_* var onto the bare OTEL_* name the OpenTelemetry Node
+// SDK actually reads.
+func TestTelemetryEnvVars_TypeScriptUsesA2APrefix(t *testing.T) {
 	adl := minimalTypeScriptADL()
 	adl.Spec.Telemetry = &schema.TelemetryConfig{
 		Enabled: true,
@@ -89,10 +90,10 @@ func TestTelemetryEnvVars_TypeScriptStaysBare(t *testing.T) {
 	got := envMap(telemetryEnvVars(adl))
 
 	want := map[string]string{
-		"OTEL_TRACES_EXPORTER":        "otlp",
-		"OTEL_METRICS_EXPORTER":       "otlp",
-		"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
-		"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
+		"A2A_OTEL_TRACES_EXPORTER":        "otlp",
+		"A2A_OTEL_METRICS_EXPORTER":       "otlp",
+		"A2A_OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
+		"A2A_OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
 	}
 	for k, v := range want {
 		if got[k] != v {
@@ -100,8 +101,8 @@ func TestTelemetryEnvVars_TypeScriptStaysBare(t *testing.T) {
 		}
 	}
 	for k := range got {
-		if strings.HasPrefix(k, "A2A_") {
-			t.Errorf("TypeScript telemetry var %q must not carry the A2A_ prefix", k)
+		if !strings.HasPrefix(k, "A2A_OTEL_") {
+			t.Errorf("TypeScript telemetry var %q must carry the A2A_ prefix", k)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Generated projects now get a root-level `CONFIGURATIONS.md` holding the Custom Configuration table (from `spec.config`) and the full `A2A_*` environment variable reference. The README Configuration section shrinks to a short paragraph linking to it, so the README stays scannable while both files remain generator-owned and regenerate on every `adl generate`.
- README dedupe: dropped the `--help`/`--version` invocations from Quick Start (covered by the CLI table) and the plain `docker build` repeat from the Deployment section.
- The Features list now includes an OpenTelemetry bullet when `spec.telemetry.enabled` is true (Go and TypeScript).
- Telemetry env vars are now consistently `A2A_`-prefixed across languages: TypeScript docs and `.env.example` use `A2A_TELEMETRY_ENABLE` / `A2A_OTEL_*`, and the generated `index.ts` mirrors each prefixed var onto the bare `OTEL_*` name the OpenTelemetry Node SDK reads. Bare names that are explicitly set still win, so existing agents keep working.
- Follow-through: `CONFIGURATIONS.md` added to the generated `.dockerignore`, `.gitattributes`, and `.releaserc.yaml` assets; CLAUDE.md/GEMINI.md templates now point to CONFIGURATIONS.md for the env var list.

## Testing

- `task ci` passes (fmt, lint, test, build, verify-schema)
- `task examples:generate` regenerates all example manifests; verified telemetry rows appear in `go-agent-telemetry`/`typescript-agent-telemetry` output and are absent otherwise
- Updated regression tests: telemetry table test targets the CONFIGURATIONS.md template, a new test asserts the README links to CONFIGURATIONS.md and no longer inlines the `A2A_*` table

## Cross-repo impact

- Existing generated agents (e.g. inference-gateway/mock-agent) pick up CONFIGURATIONS.md on their next `adl generate`
- No ADK changes required; the TS env mirroring lives in generated code and can be dropped if the TS ADK gains native `A2A_`-prefixed support
- Docs follow-up: inference-gateway/docs generate-command page should mention the new CONFIGURATIONS.md output