### PR TITLE
fix(schema): keep Spec.Config a free map in generated types

### DIFF
--- a/internal/schema/annotate/main.go
+++ b/internal/schema/annotate/main.go
@@ -41,6 +41,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	restoreFreeConfigMap(doc)
 	walk(doc)
 
 	enc := json.NewEncoder(os.Stdout)
@@ -49,6 +50,27 @@ func main() {
 		fmt.Fprintf(os.Stderr, "encode schema: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+// restoreFreeConfigMap rewrites definitions.Spec.properties.config back to
+// its pre-v0.26.0 free-map shape before code generation. Schema v0.26.0
+// added typed shapes for the reserved spec.config.tools blocks, which is
+// right for validation (it runs against the raw manifest with the
+// unmodified schema.json and now rejects typo'd keys) but wrong for the
+// generated Go types: manifests are parsed with yaml.Unmarshal, which
+// cannot populate a struct's mapstructure ",remain" catch-all, so a
+// struct-typed Config would silently drop user-defined config sections
+// and break templates that range over the map. Typed decoding of the
+// reserved tool blocks stays in builtin_config.go.
+func restoreFreeConfigMap(doc map[string]any) {
+	defs, _ := doc["definitions"].(map[string]any)
+	spec, _ := defs["Spec"].(map[string]any)
+	props, _ := spec["properties"].(map[string]any)
+	cfg, _ := props["config"].(map[string]any)
+	if cfg == nil {
+		return
+	}
+	delete(cfg, "properties")
 }
 
 // walk recursively visits every subschema and applies the annotation to

--- a/internal/schema/types.go
+++ b/internal/schema/types.go
@@ -926,7 +926,7 @@ type Spec struct {
 	Card *Card `json:"card,omitempty,omitzero" yaml:"card,omitempty" mapstructure:"card,omitempty"`
 
 	// Config corresponds to the JSON schema field "config".
-	Config *SpecConfig `json:"config,omitempty,omitzero" yaml:"config,omitempty" mapstructure:"config,omitempty"`
+	Config SpecConfig `json:"config,omitempty,omitzero" yaml:"config,omitempty" mapstructure:"config,omitempty"`
 
 	// Deployment corresponds to the JSON schema field "deployment".
 	Deployment *DeploymentConfig `json:"deployment,omitempty,omitzero" yaml:"deployment,omitempty" mapstructure:"deployment,omitempty"`
@@ -965,12 +965,7 @@ type Spec struct {
 	Tools []Tool `json:"tools,omitempty,omitzero" yaml:"tools,omitempty" mapstructure:"tools,omitempty"`
 }
 
-type SpecConfig struct {
-	// Tools corresponds to the JSON schema field "tools".
-	Tools *ToolsConfig `json:"tools,omitempty,omitzero" yaml:"tools,omitempty" mapstructure:"tools,omitempty"`
-
-	AdditionalProperties map[string]any `mapstructure:",remain"`
-}
+type SpecConfig map[string]map[string]any
 
 type SpecServices map[string]Service
 


### PR DESCRIPTION
Fixes the CI failure on main after the v0.26.0 schema sync (#374): https://github.com/inference-gateway/adl-cli/actions/runs/32916992127/job/98022658696

## Summary

Schema v0.26.0 (inference-gateway/adl#166) added typed shapes for the reserved `spec.config.tools` blocks. That is right for validation but wrong for the generated Go types: go-jsonschema emitted a `SpecConfig` struct, which

1. broke compilation everywhere `Spec.Config` is indexed/ranged (`builtin_config.go`, `validator.go`, `generator.go`), and
2. would have silently dropped user-defined config sections even if compilation were patched - manifests are parsed with `yaml.Unmarshal`, which cannot populate the struct's `mapstructure ",remain"` catch-all, and `config.go.tmpl` ranges over the map.

## Fix

One rule in the `annotate` preprocessor (the sanctioned in-flight rewrite layer): strip `properties` from `definitions.Spec.properties.config` before code generation, restoring `type SpecConfig map[string]map[string]any`. Typed decoding of reserved tool blocks stays in `builtin_config.go` as before.

The committed `schema.json` remains byte-identical to upstream v0.26.0, so:

- `task verify-schema` passes
- raw-manifest validation still enforces the new shapes: `adl validate` rejects `max_liness` under `spec.config.tools.read` with "Additional property max_liness is not allowed", while all `examples/` manifests stay valid

## Verification

- `task ci` green (fmt, lint, test, build, verify-schema)
- `task examples:generate` succeeds; generated `tools/read.go` renders builtin config correctly