### PR TITLE
docs: rewrite AGENTS.md to follow the agents.md open standard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,121 +1,39 @@
-# Repository Guidelines
+# AGENTS.md
 
-This file provides guidance to coding agents (Claude Code, Codex, etc.) when working with code in this repository. `CLAUDE.md` is a symlink to this file.
+`adl` is a Go CLI that scaffolds complete A2A (Agent-to-Agent) projects from YAML Agent Definition Language (ADL) manifests. Three commands: `init` (interactive wizard that writes `agent.yaml`), `generate` (`agent.yaml` → Go/Rust/TypeScript project), `validate` (schema-check a manifest). The canonical schema lives upstream in `inference-gateway/adl`; this repo vendors it.
 
-## What this CLI does
+## Commands
 
-`adl` generates complete A2A (Agent-to-Agent) project scaffolding from YAML Agent Definition Language (ADL) manifests. It is the user-facing scaffolder that complements `inference-gateway/adl` (which owns the canonical schema) and the generated agents themselves.
+All workflows go through Task (`task <name>`); plain `go` works if Task is missing.
 
-Three commands: `init` (interactive wizard that writes `agent.yaml`), `generate` (turns `agent.yaml` into a Go/Rust/TypeScript project), `validate` (schema-checks a manifest).
+| Task | Purpose |
+| --- | --- |
+| `task build` | Build CLI to `bin/adl` with `-X main.Version` |
+| `task test` | `go test -v ./...` |
+| `task fmt` / `task vet` / `task lint` | `go fmt ./...`, `go vet ./...`, `golangci-lint run` |
+| `task lint:md` | `markdownlint '**/*.md' --ignore CHANGELOG.md` |
+| `task ci` | fmt → lint → test → build → verify-schema (what CI runs) |
+| `task examples:test` | Validates every YAML in `examples/` |
+| `task examples:generate` | Generates every example into `test-output/` — the full smoke test |
+| `task fetch-schema` / `verify-schema` / `generate-types` | Sync / drift-check / regenerate the vendored schema + types |
 
-## Common commands
+Single test: `go test -v ./internal/generator -run TestGenerate_Go`.
 
-All workflows go through Taskfile (`task <name>`); falls back to plain `go` if Task isn't available.
+## Architecture (read before editing)
 
-| Task                  | Purpose                                                                                              |
-| --------------------- | ---------------------------------------------------------------------------------------------------- |
-| `task build`          | Build the CLI into `bin/adl` with `-X main.Version`                                                  |
-| `task install`        | Build and install into `$(go env GOPATH)/bin/adl`                                                    |
-| `task test`           | `go test -v ./...`                                                                                   |
-| `task test:coverage`  | Same, with `-cover`                                                                                  |
-| `task fmt`            | `go fmt ./...`                                                                                       |
-| `task vet`            | `go vet ./...`                                                                                       |
-| `task lint`           | `golangci-lint run`                                                                                  |
-| `task lint:md`        | `markdownlint '**/*.md' --ignore CHANGELOG.md`                                                       |
-| `task ci`             | fmt → lint → test → build → verify-schema                                                            |
-| `task examples:test`  | Validates every YAML in `examples/`                                                                  |
-| `task examples:generate` | Generates every example into `test-output/` (rebuilt from scratch each run)                       |
-| `task fetch-schema`   | Refreshes `internal/schema/schema.json` from the pinned upstream `ADL_SCHEMA_VERSION`                |
-| `task verify-schema`  | CI guard — fails if `internal/schema/schema.json` drifts from the pinned upstream                    |
-| `task generate-types` | Re-runs `go-jsonschema` to regenerate `internal/schema/types.go` from `schema.json`                  |
+- **Single binary.** All `.tmpl` files (`internal/templates/`) and the JSON schema are embedded via `go:embed` — editing a template requires a rebuild; there is no runtime file lookup.
+- **Pipeline:** `cmd/generate.go` → `internal/generator` → `internal/templates`. `internal/templates/registry.go` `GetFiles(adl)` maps output path → template key — wire new output files there. `engine.go` executes templates with Sprig + custom case-conversion funcs.
+- **Never hand-edit generated code.** `internal/schema/types.go` (go-jsonschema output, DO NOT EDIT header) and `internal/schema/schema.json` (vendored upstream). `ADL_SCHEMA_VERSION` in `Taskfile.yml` is the single source of truth; `task verify-schema` fails CI on drift. Bump: `task fetch-schema && task generate-types`.
+- **`.adl-ignore` protects user code.** The generator writes gitignore-style globs for TODO-placeholder files (tool implementations, custom services, bare skills); re-generate (even `--overwrite`) skips matched paths. Add new user-owned files to it.
+- **Flag/manifest reconciliation is OR semantics** — a CLI flag (`--ci`, `--cd`, `--deployment`, …) wins over the manifest field.
+- **Tools vs skills.** `spec.tools[]` → one generated file per tool (`tools/<id>.go`); `spec.skills[]` → markdown playbooks resolved from a registry/GitHub (`source:`) or scaffolded locally (`bare: true`). Five reserved tool IDs (`read`/`bash`/`write`/`edit`/`fetch`) render from `languages/<lang>/builtin/`.
+- **Telemetry** (`spec.telemetry.enabled`, manifest-only): Go and TypeScript only; Rust ignores it.
 
-### Running a single test
+## Conventions & gotchas
 
-```bash
-go test -v ./internal/generator -run TestGenerate_Go
-go test -v ./internal/templates -run TestRegistry_GetFiles
-```
-
-### Trying a local build end-to-end
-
-```bash
-task build
-./bin/adl generate --file examples/go-agent.yaml --output test-output/go-agent --overwrite
-```
-
-`task examples:generate` is the canonical full smoke test — it exercises every example manifest across Go, Rust, CloudRun, GHCR, Kubernetes, Redis, and AI variants.
-
-## Architecture
-
-### Single binary, embedded templates
-
-Everything ships in one Go binary. Templates and the ADL JSON schema are embedded at compile time via `//go:embed` — there is no runtime file lookup for templates or schema. Editing a template requires a rebuild.
-
-### Schema is vendored, types are generated
-
-`internal/schema/types.go` is generated by `go-jsonschema` from `internal/schema/schema.json`. Both are committed.
-
-- **Never hand-edit `internal/schema/types.go`** — it has a `Code generated by ... DO NOT EDIT.` header. The schema itself is owned upstream in `inference-gateway/adl`; do not hand-edit `internal/schema/schema.json` either, except as the output of a version bump.
-- The pinned `ADL_SCHEMA_VERSION` in `Taskfile.yml` (a git tag or commit SHA of `inference-gateway/adl`) is the single source of truth. `task verify-schema` runs in CI and fails the build on drift.
-- `internal/schema/annotate/` is a small preprocessor that runs over the schema before code generation (adjusts capitalization, etc.) — see the `generate-types` task in `Taskfile.yml`.
-
-#### Syncing a new schema version
-
-The schema is kept in sync with upstream `inference-gateway/adl` two ways:
-
-- **Automated (preferred).** A maintainer runs the **Sync adl-cli** workflow in `inference-gateway/adl`. That sends a `repository_dispatch` (`event_type: schema-sync`) here, which triggers `.github/workflows/sync-schema.yml`: it bumps `ADL_SCHEMA_VERSION`, runs `task fetch-schema` + `task generate-types`, and opens a PR. Review and merge it. The same workflow can be run directly here via `workflow_dispatch` with a `ref` input.
-- **Manual.** Bump `ADL_SCHEMA_VERSION` in `Taskfile.yml`, then run `task fetch-schema && task generate-types` and commit the result.
-
-### Three-layer generation pipeline
-
-`cmd/generate.go` → `internal/generator/generator.go` → `internal/templates/`.
-
-1. **`internal/generator`** parses + validates the ADL, reconciles CLI flags with manifest fields (the CLI flag is OR'd on top of the manifest value — passing `--ci`/`--cd` always wins), resolves skills/vendor/sandbox deps, builds the template context, then walks the registry's file map.
-2. **`internal/templates/registry.go`** owns the **file mapping** per language: `GetFiles(adl) map[outputPath]templateKey`. This is where you wire a new output file (e.g. `main.go` → `main.go` template, `tools/{toolname}.go` → `tool.go` template). The output filename is what becomes the on-disk path; the value is the lookup key for the embedded template.
-3. **`internal/templates/engine.go`** loads embedded `.tmpl` files (`languages/<lang>/`, `common/`, `sandbox/`), wires up Sprig + custom funcs (PascalCase/snake\_case conversion with configurable acronyms — see `getDefaultAcronyms`), and executes per file.
-
-Template files live as `.tmpl` under three roots that map to embed globs in `registry.go`:
-- `languages/{go,rust,typescript}/` — per-language code (`main.go.tmpl`, `tool.go.tmpl`, `service.go.tmpl`, plus `builtin/` for reserved tools)
-- `common/` — language-agnostic files (`docker/`, `taskfile/`, `github/`, `ai/`, `kubernetes/`, `skills/`, `config/`, `docs/`)
-- `sandbox/{flox,devcontainer}/` — sandbox environment files
-
-### Tools vs Skills (key ADL concept)
-
-- **Tools** (`spec.tools[]`) — function-call entrypoints with JSON schemas, generated as one file per tool (`tools/<id>.go` / `src/tools/<id>.rs`).
-- **Skills** (`spec.skills[]`) — markdown playbooks (`skills/<id>/SKILL.md` + bundled assets) fetched from a registry or GitHub repo (`source:`), or scaffolded as `bare: true`. Resolved in `internal/registry/resolver.go`.
-
-There are also five **reserved tool IDs** (`read`/`bash`/`write`/`edit`/`fetch`) — see `internal/schema/builtin_config.go`. They render from `languages/<lang>/builtin/*.tmpl` and are configured under the reserved `spec.config.tools.<id>` namespace, which is intentionally skipped when generating the `Config` struct.
-
-### Telemetry (`spec.telemetry.enabled`)
-
-A manifest-only boolean (no CLI flag) that turns on OpenTelemetry instrumentation. Go gets a generated `tools/telemetry.go` (from `languages/go/telemetry.go.tmpl`, per-tool-call spans, OTel deps added to `go.mod`, `A2A_TELEMETRY_*` vars in `.env.example`); TypeScript gets `createTelemetryProvider` wiring in `index.ts.tmpl` (`TELEMETRY_ENABLED` + `OTEL_*` vars). Rust is not supported — the toggle is ignored there. Regression coverage: `examples/{go,typescript}-agent-telemetry.yaml`.
-
-### `.adl-ignore` protects user code on re-generate
-
-The generator creates a `.adl-ignore` (gitignore-style globs) listing files containing TODO placeholders — tool implementations, custom services, bare skill directories. On subsequent `adl generate` runs (even with `--overwrite`), matched paths are skipped. `internal/generator/ignore.go` handles matching. When adding new "user-owned" files, decide whether they should be in `.adl-ignore` by default.
-
-### Flag/manifest reconciliation
-
-`--ci`, `--cd`, `--deployment`, `--flox`, `--devcontainer` are mirrored by declarative fields under `spec.scm`, `spec.deployment.type`, `spec.development.sandbox`. The reconciliation in `Generator.Generate` is **OR semantics**: CLI flag wins if set, manifest fills in otherwise. After reconciliation, both `g.config.*` and `adl.Spec.*` reflect the same effective state so templates can read either source.
-
-AI assistant generation (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, plus matching `.github/workflows/*.yml`) is **manifest-only** via `spec.development.ai.orchestrators.<agent>.enabled` toggles — there is no CLI flag for individual agents. `init`'s `--ai` flag writes `orchestrators.claudecode.enabled: true` into the ADL; everything downstream reads from the manifest. Each agent toggle is independent and defaults to `false`.
-
-### Legacy manifest detection
-
-`internal/schema/validator.go::checkLegacySpecFields` explicitly rejects pre-v0.6.0 (`spec.sandbox`/`spec.ai` at the root), pre-v0.8.0 (`spec.development.ai.enabled` single flag), and pre-orchestrators (flat `spec.development.ai.<agent>` toggles, now nested under `spec.development.ai.orchestrators`) shapes with a migration hint. JSON Schema's `additionalProperties:true` would otherwise silently drop these fields — keep this guard updated whenever schema shape changes.
-
-### Skills registry resolver (`internal/registry/`)
-
-Skills are resolved in three modes:
-1. `bare: true` → scaffold `skills/<id>/SKILL.md` locally from the manifest's frontmatter; the directory is added to `.adl-ignore` so bundled scripts survive regeneration.
-2. `source:` set → fetch the full GitHub directory (shorthand or URL) into `skills/<id>/`.
-3. Otherwise → fetch `registry.inference-gateway.com/skills/<id>[/<version>].md` (overridable via `ADL_SKILLS_REGISTRY`), cached under `~/.adl/skills-cache/<id>@<ref>/`.
-
-`--offline` skips network access entirely; every non-bare skill must already be in the cache.
-
-## Project conventions
-
-- Go version is **1.26.4**; the Flox sandbox at `.flox/env/manifest.toml` pins `go`, `golangci-lint`, `goreleaser`, `go-task`, `prettier`, `markdownlint-cli`. Run `flox activate` to enter it.
-- Indentation: tabs in Go, 2-space in YAML/JSON/Markdown (see `.editorconfig`).
-- Commit messages follow conventional commits (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `ci:`, `build:`) — semantic-release in `.releaserc.yaml` derives version bumps from them.
-- Examples in `examples/` are **the regression suite**: `task examples:test` + `task examples:generate` is what catches template breakage. When adding a new ADL feature, add or update an example and wire it into both lists in `Taskfile.yml`.
+- Go 1.26.x; Flox sandbox (`.flox/env/manifest.toml`) pins `go`, `golangci-lint`, `go-task`, `prettier`, `markdownlint-cli` — `flox activate` to enter.
+- Tabs in Go, 2-space in YAML/JSON/Markdown.
+- Conventional commits (`feat:`, `fix:`, …) — semantic-release derives versions from them.
+- **`examples/` is the regression suite.** When adding a feature, add/update an example and wire it into both lists (`examples:test` + `examples:generate`) in `Taskfile.yml`.
+- Skills resolution hits the network (registry/GitHub, cached under `~/.adl/skills-cache`); `--offline` skips all network access.
+- `internal/schema/validator.go::checkLegacySpecFields` rejects pre-orchestrators manifest shapes with migration hints — keep it in sync whenever the schema shape changes (JSON Schema `additionalProperties:true` would otherwise silently drop legacy fields).


### PR DESCRIPTION
Rewrite `AGENTS.md` to follow the agents.md open standard, condensing the repository guidance into a tighter, more scannable format.

- Condensed the command reference into a single table
- Consolidated architecture notes into bullet points
- Removed redundant prose while preserving all key gotchas (schema vendoring, `.adl-ignore`, flag/manifest OR semantics, tools vs skills, telemetry, legacy manifest detection)