### PR TITLE
fix(templates): install flox in AI workflows when the flox sandbox is enabled

### DIFF
--- a/internal/generator/ai_test.go
+++ b/internal/generator/ai_test.go
@@ -448,6 +448,44 @@ func TestGenerator_AI_InferSandboxInstall(t *testing.T) {
 		assertContains(t, dc, "install.sh | bash -s -- --version v0.154.0", "devcontainer postCreateCommand")
 	})
 
+	t.Run("flox enabled installs flox in AI workflows", func(t *testing.T) {
+		tmp := t.TempDir()
+		manifest := writeManifest(t, tmp, `  development:
+    ai:
+      orchestrators:
+        infer:
+          enabled: true
+        claudecode:
+          enabled: true
+`+sandboxYAML)
+		out := filepath.Join(tmp, "out")
+		mustGenerate(t, manifest, out, Config{Overwrite: true, Version: "test"})
+
+		infer := readGenerated(t, out, ".github/workflows/infer.yml")
+		assertContains(t, infer, "flox/install-flox-action@v2.6.0", "Infer workflow body")
+		assertContains(t, infer, ",^flox( .*)?$", "Infer workflow bash-allow-append")
+
+		claude := readGenerated(t, out, ".github/workflows/claude.yml")
+		assertContains(t, claude, "flox/install-flox-action@v2.6.0", "Claude Code workflow body")
+		assertContains(t, claude, "Bash(flox:*)", "Claude Code workflow allowedTools")
+	})
+
+	t.Run("flox disabled skips flox install in AI workflows", func(t *testing.T) {
+		tmp := t.TempDir()
+		manifest := writeManifest(t, tmp, `  development:
+    ai:
+      orchestrators:
+        infer:
+          enabled: true
+`)
+		out := filepath.Join(tmp, "out")
+		mustGenerate(t, manifest, out, Config{Overwrite: true, Version: "test"})
+
+		infer := readGenerated(t, out, ".github/workflows/infer.yml")
+		assertNotContains(t, infer, "install-flox-action", "Infer workflow body")
+		assertNotContains(t, infer, "^flox", "Infer workflow bash-allow-append")
+	})
+
 	t.Run("infer disabled leaves sandbox untouched", func(t *testing.T) {
 		tmp := t.TempDir()
 		manifest := writeManifest(t, tmp, `  development:

--- a/internal/templates/common/github/workflows/ai-claude-code.yaml.tmpl
+++ b/internal/templates/common/github/workflows/ai-claude-code.yaml.tmpl
@@ -110,6 +110,11 @@ jobs:
           node-version: {{ if and .ADL.Spec.Language.TypeScript .ADL.Spec.Language.TypeScript.NodeVersion }}{{ .ADL.Spec.Language.TypeScript.NodeVersion }}{{ else }}24{{ end }}
           cache: 'npm'
 {{- end }}
+{{- if and .ADL.Spec.Development .ADL.Spec.Development.Sandbox .ADL.Spec.Development.Sandbox.Flox .ADL.Spec.Development.Sandbox.Flox.Enabled }}
+
+      - name: Install flox
+        uses: flox/install-flox-action@{{ pin "action" "flox/install-flox-action" }}
+{{- end }}
 
       - name: Install task
         uses: arduino/setup-task@{{ pin "action" "arduino/setup-task" }}
@@ -176,7 +181,7 @@ jobs:
           claude_args: |
             --effort ${{`{{ inputs.effort || 'medium' }}`}}
             --model ${{`{{ inputs.model || 'claude-opus-5' }}`}}
-            --allowedTools "Bash(task:*),Bash(gh:*),Bash(git:*),Bash(adl:*){{- if eq .Language "go" }},Bash(go:*){{- else if eq .Language "rust" }},Bash(cargo:*){{- else if eq .Language "typescript" }},Bash(npm:*),Bash(node:*){{- end }}"
+            --allowedTools "Bash(task:*),Bash(gh:*),Bash(git:*),Bash(adl:*){{- if and .ADL.Spec.Development .ADL.Spec.Development.Sandbox .ADL.Spec.Development.Sandbox.Flox .ADL.Spec.Development.Sandbox.Flox.Enabled }},Bash(flox:*){{- end }}{{- if eq .Language "go" }},Bash(go:*){{- else if eq .Language "rust" }},Bash(cargo:*){{- else if eq .Language "typescript" }},Bash(npm:*),Bash(node:*){{- end }}"
             --append-system-prompt "After pushing commits to a new branch (issue-triggered runs), open the pull request yourself with 'gh pr create' against main, titled with a conventional commit prefix and linking the triggering issue via 'Closes #<number>' in the body. GH_TOKEN is already set for gh. Do not just post a link to a PR creation page. When working on an existing pull request branch, do not create a new pull request."
           prompt: ${{`{{ steps.set-prompt.outputs.value }}`}}
           track_progress: ${{`{{ github.event_name != 'workflow_dispatch' }}`}}

--- a/internal/templates/common/github/workflows/ai-infer.yaml.tmpl
+++ b/internal/templates/common/github/workflows/ai-infer.yaml.tmpl
@@ -130,6 +130,11 @@ jobs:
             git config "branch.$HEAD_REF.remote" origin
             git config "branch.$HEAD_REF.merge" "refs/heads/$HEAD_REF"
           fi
+{{- if and .ADL.Spec.Development .ADL.Spec.Development.Sandbox .ADL.Spec.Development.Sandbox.Flox .ADL.Spec.Development.Sandbox.Flox.Enabled }}
+
+      - name: Install flox
+        uses: flox/install-flox-action@{{ pin "action" "flox/install-flox-action" }}
+{{- end }}
 
       - name: Install task
         uses: arduino/setup-task@{{ pin "action" "arduino/setup-task" }}
@@ -197,7 +202,7 @@ jobs:
           skills: |
             adl
           bash-allow-append: >-
-            ^adl( .*)?$,^task( .*)?${{- if eq .Language "go" }},^go( .*)?${{- else if eq .Language "rust" }},^cargo( .*)?$,^rustup( .*)?$,^rustc( .*)?${{- else if eq .Language "typescript" }},^bun( .*)?$,^node( .*)?$,^npm( .*)?$,^npx( .*)?${{- end }}
+            ^adl( .*)?$,^task( .*)?${{- if and .ADL.Spec.Development .ADL.Spec.Development.Sandbox .ADL.Spec.Development.Sandbox.Flox .ADL.Spec.Development.Sandbox.Flox.Enabled }},^flox( .*)?${{- end }}{{- if eq .Language "go" }},^go( .*)?${{- else if eq .Language "rust" }},^cargo( .*)?$,^rustup( .*)?$,^rustc( .*)?${{- else if eq .Language "typescript" }},^bun( .*)?$,^node( .*)?$,^npm( .*)?$,^npx( .*)?${{- end }}
           anthropic-api-key: ${{`{{ secrets.ANTHROPIC_API_KEY }}`}}
           openai-api-key: ${{`{{ secrets.OPENAI_API_KEY }}`}}
           google-api-key: ${{`{{ secrets.GOOGLE_API_KEY }}`}}

--- a/internal/vendor/vendor.go
+++ b/internal/vendor/vendor.go
@@ -197,6 +197,7 @@ var Actions = map[string]string{
 	"docker/login-action":                  "v4.6.0",
 	"docker/setup-buildx-action":           "v4.3.0",
 	"docker/setup-qemu-action":             "v4.3.0",
+	"flox/install-flox-action":             "v2.6.0",
 	"golangci/golangci-lint-action":        "v9.3.0",
 	"google-github-actions/auth":           "v2.1.13",
 	"google-github-actions/run-gemini-cli": "v0.1.22",


### PR DESCRIPTION
## Summary

The generated `claude.yml` and `infer.yml` bootstrap Go, golangci-lint, Task and the ADL CLI by hand but never install flox, even when `spec.development.sandbox.flox.enabled` is true. Any agent task that has to refresh `.flox/env/manifest.lock` (for example a Go toolchain bump, see inference-gateway/documentation-agent#111 / #113) dead-ends in CI because `flox` is neither installed nor allowlisted.

## Changes

- Add an `Install flox` step (`flox/install-flox-action`, pinned in `internal/vendor/vendor.go`) to both AI workflow templates, gated on the flox sandbox flag.
- Allow `flox` in the infer `bash-allow-append` regex and the Claude Code `--allowedTools` list under the same gate.
- Add generator tests for the enabled and disabled cases.

## Impact

Consumers regenerate with the next release to pick up the step. No docs ticket: internal-only generator change.